### PR TITLE
Faster streaming, Navidrome-mode discovery, self-configuring setup, and rich downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,26 @@
-# ===== OCTO-RADIOSTARR CONFIGURATION =====
+# ===== OCTO CONFIGURATION =====
 # Environment variables for deployment (Docker Compose, systemd, etc.)
 # These override the values in appsettings.json.
 #
+# How Octo fits in: your Subsonic client talks to OCTO, and Octo talks to your
+# existing Navidrome. So there are two things to do:
+#   1. Set SUBSONIC_URL below to your Navidrome server.
+#   2. Point your Subsonic app at Octo (port 5274) instead of Navidrome.
+#
+# The ONLY required setting is SUBSONIC_URL. Everything else has a working
+# default; Soulseek (downloads) and Last.fm (radio) are optional add-ons.
+#
 # NOTE: Use double-underscore (__) for nested properties in raw env keys.
 # Example: Subsonic__Url maps to { "Subsonic": { "Url": "..." } }
-# The keys below (UPPER_SNAKE) are the ones docker-compose.yml reads;
-# they get translated into the proper Subsonic__ / Soulseek__ etc. forms.
+# The keys below (UPPER_SNAKE) are the ones docker-compose.yml reads.
 
-# ===== SUBSONIC / NAVIDROME UPSTREAM =====
-SUBSONIC_URL=http://localhost:4533
+# ===== REQUIRED: your Navidrome server =====
+# Must be reachable from the Octo container: use a LAN IP or a docker service
+# name, NOT localhost (inside the container localhost is Octo itself).
+#   e.g. SUBSONIC_URL=http://192.168.1.10:4533
+SUBSONIC_URL=
+
+# ===== OPTIONAL: playback / download behavior (safe defaults below) =====
 # Stream | Permanent | Cache
 STORAGE_MODE=Stream
 # Track | Album

--- a/.env.example
+++ b/.env.example
@@ -3,22 +3,38 @@
 # These override the values in appsettings.json.
 #
 # How Octo fits in: your Subsonic client talks to OCTO, and Octo talks to your
-# existing Navidrome. So there are two things to do:
-#   1. Set SUBSONIC_URL below to your Navidrome server.
-#   2. Point your Subsonic app at Octo (port 5274) instead of Navidrome.
+# existing Navidrome. So the one thing you MUST do:
+#   >>> Point your music app at Octo (port 5274), NOT at Navidrome. <<<
+# That is the only way any of this works. If an app points straight at Navidrome
+# it bypasses Octo and you get plain Navidrome with no discovery or downloads.
 #
-# The ONLY required setting is SUBSONIC_URL. Everything else has a working
-# default; Soulseek (downloads) and Last.fm (radio) are optional add-ons.
+# SUBSONIC_URL (your Navidrome) can be left blank: on first run Octo scans the
+# local network and configures it automatically if it finds exactly one server.
+# Set it explicitly to skip the scan or when auto-detect can't see your LAN
+# (e.g. a Docker bridge network). Everything else has a working default;
+# Soulseek (downloads) and Last.fm (discovery/radio) are optional add-ons.
 #
 # NOTE: Use double-underscore (__) for nested properties in raw env keys.
 # Example: Subsonic__Url maps to { "Subsonic": { "Url": "..." } }
 # The keys below (UPPER_SNAKE) are the ones docker-compose.yml reads.
 
-# ===== REQUIRED: your Navidrome server =====
+# ===== Your Navidrome server (auto-detected if left blank) =====
 # Must be reachable from the Octo container: use a LAN IP or a docker service
 # name, NOT localhost (inside the container localhost is Octo itself).
 #   e.g. SUBSONIC_URL=http://192.168.1.10:4533
+# Leave blank to let Octo find it on the network at first run.
 SUBSONIC_URL=
+
+# Optional Navidrome admin login. Lets Octo detect the music folder and run
+# authenticated library rescans on its own. If blank, Octo instead learns an
+# admin token the first time an admin signs in through it.
+SUBSONIC_ADMIN_USERNAME=
+SUBSONIC_ADMIN_PASSWORD=
+
+# Auto-detect the download folder from Navidrome so downloads always land where
+# Navidrome scans. Only adopts a path Octo can actually see; otherwise it uses
+# DOWNLOAD_PATH below. Set false to always use DOWNLOAD_PATH verbatim.
+AUTO_DETECT_DOWNLOAD_PATH=true
 
 # ===== OPTIONAL: playback / download behavior (safe defaults below) =====
 # Stream | Permanent | Cache

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ obj/
 
 # Downloaded music files
 octo/downloads/
+
+# local build artifacts
+*.tgz

--- a/README.md
+++ b/README.md
@@ -42,12 +42,26 @@ Plug Octo in front of your Navidrome. Point your Subsonic apps (Feishin, Arpeggi
 
 ## Get started
 
-You need:
+Octo sits **in front of** your existing Navidrome. Your Subsonic app talks to Octo; Octo adds discovery and previews, then proxies everything else through to Navidrome:
+
+```
+   Subsonic app          Octo               Navidrome
+  (Feishin, Arpeggi) ──▶  :5274  ──────────▶  (your library)
+                           ├─▶ yt-dlp shim   (instant previews)
+                           └─▶ slskd         (downloads on star)
+```
+
+So setup is two steps: **tell Octo where Navidrome is**, and **point your app at Octo**.
+
+**Required**
 
 - A box with [Docker](https://docs.docker.com/engine/install/) installed.
-- An existing [Navidrome](https://www.navidrome.org/) server.
-- A free [Last.fm API key](https://www.last.fm/api/account/create).
-- A free [Soulseek account](https://www.slsknet.org/news/node/1).
+- An existing [Navidrome](https://www.navidrome.org/) server, reachable from the Octo host by LAN IP or service name (not `localhost`).
+
+**Optional** — Octo runs fine without these:
+
+- A free [Last.fm API key](https://www.last.fm/api/account/create) — enables radio / discovery.
+- A free [Soulseek account](https://www.slsknet.org/news/node/1) — enables lossless FLAC downloads when you star a song.
 
 Then:
 
@@ -57,12 +71,13 @@ cd octo
 ./install.sh
 ```
 
-The installer asks for those four things, brings the stack up, and prints the address.
+The installer asks for your Navidrome URL (and, optionally, Last.fm and Soulseek), brings the stack up, and prints the address.
 
 **When it's done:**
 
-- Point your Subsonic apps at `http://<your-host>:5274`.
+- Point your Subsonic apps at `http://<your-host>:5274` — **not** Navidrome's own address.
 - Open the admin dashboard at **`http://<your-host>:5274/admin`** to manage every setting from the browser — no editing config files by hand.
+- If a client reports the server is unreachable, that is Octo telling you setup is not finished: its ping response spells out exactly what to fix (usually the Navidrome URL).
 
 ## Compatible apps
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,11 @@ services:
       URL_CACHE_TTL: ${YTDLP_URL_CACHE_TTL:-3600}
     expose:
       - "8080"
+    volumes:
+      # Persist yt-dlp's player/nsig cache so base.js + signature solving is not
+      # repeated on every fork, and survives container recreate. Named volume so
+      # ownership is correct and `docker compose down` does not touch host paths.
+      - ytdlp-cache:/root/.cache/yt-dlp
 
   # Soulseek client (slskd). Web UI on 5030, peer port 50300.
   # State (config, db, downloads-in-progress) persisted to ./slskd-state so the
@@ -82,3 +87,6 @@ services:
     volumes:
       - ./slskd-state:/app
       - ${DOWNLOAD_PATH:-./downloads}:/music
+
+volumes:
+  ytdlp-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,15 @@ services:
       # or service name, not localhost). Left blank on purpose so a missing value
       # is detected and reported clearly instead of silently failing.
       Subsonic__Url: ${SUBSONIC_URL:-}
+      # Optional Navidrome admin login. Lets Octo detect the music folder and run
+      # authenticated rescans on its own. Leave blank to have Octo learn an admin
+      # token from a client sign-in instead.
+      Subsonic__AdminUsername: ${SUBSONIC_ADMIN_USERNAME:-}
+      Subsonic__AdminPassword: ${SUBSONIC_ADMIN_PASSWORD:-}
+      # Auto-detect the download folder from Navidrome so downloads land where it
+      # scans. Only adopts a path Octo can actually see; otherwise falls back to
+      # Library__DownloadPath below. Set false to always use that path verbatim.
+      Subsonic__AutoDetectDownloadPath: ${AUTO_DETECT_DOWNLOAD_PATH:-true}
       Subsonic__StorageMode: ${STORAGE_MODE:-Stream}
       Subsonic__DownloadMode: ${DOWNLOAD_MODE:-Track}
       Subsonic__DownloadOnStar: ${DOWNLOAD_ON_STAR:-true}
@@ -66,6 +75,9 @@ services:
       URL_CACHE_TTL: ${YTDLP_URL_CACHE_TTL:-3600}
       # Root the /download endpoint may write under (matches the /music mount).
       DOWNLOAD_ROOT: /music
+      # Persistent duration cache (SQLite). On the named volume below so resolved
+      # "artist - title -> {video_id, duration}" mappings survive container recreate.
+      META_DB_PATH: /var/lib/ytshim/meta.db
     expose:
       - "8080"
     volumes:
@@ -73,6 +85,8 @@ services:
       # repeated on every fork, and survives container recreate. Named volume so
       # ownership is correct and `docker compose down` does not touch host paths.
       - ytdlp-cache:/root/.cache/yt-dlp
+      # Persistent duration cache DB (see META_DB_PATH above).
+      - ytshim-cache:/var/lib/ytshim
       # Shared music root so YouTube-MP3 downloads (DownloadSource=YouTube) land
       # where Navidrome scans; same host dir Octo and slskd mount, so dest paths
       # line up across containers.
@@ -100,3 +114,4 @@ services:
 
 volumes:
   ytdlp-cache:
+  ytshim-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       Subsonic__DownloadMode: ${DOWNLOAD_MODE:-Track}
       Subsonic__DownloadOnStar: ${DOWNLOAD_ON_STAR:-true}
       Subsonic__FolderStructure: ${FOLDER_STRUCTURE:-Flat}
+      Subsonic__DownloadSource: ${DOWNLOAD_SOURCE:-Soulseek}
       Subsonic__UseLocalStaging: ${USE_LOCAL_STAGING:-false}
       Subsonic__ExplicitFilter: ${EXPLICIT_FILTER:-All}
       Subsonic__CacheDurationHours: ${CACHE_DURATION_HOURS:-1}
@@ -63,6 +64,8 @@ services:
       SEARCH_CACHE_MAX: ${YTDLP_SEARCH_CACHE_MAX:-1024}
       URL_CACHE_MAX: ${YTDLP_URL_CACHE_MAX:-512}
       URL_CACHE_TTL: ${YTDLP_URL_CACHE_TTL:-3600}
+      # Root the /download endpoint may write under (matches the /music mount).
+      DOWNLOAD_ROOT: /music
     expose:
       - "8080"
     volumes:
@@ -70,6 +73,10 @@ services:
       # repeated on every fork, and survives container recreate. Named volume so
       # ownership is correct and `docker compose down` does not touch host paths.
       - ytdlp-cache:/root/.cache/yt-dlp
+      # Shared music root so YouTube-MP3 downloads (DownloadSource=YouTube) land
+      # where Navidrome scans; same host dir Octo and slskd mount, so dest paths
+      # line up across containers.
+      - ${DOWNLOAD_PATH:-./downloads}:/music
 
   # Soulseek client (slskd). Web UI on 5030, peer port 50300.
   # State (config, db, downloads-in-progress) persisted to ./slskd-state so the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
 
       # ----- Subsonic / Navidrome upstream -----
-      Subsonic__Url: ${SUBSONIC_URL:-http://localhost:4533}
+      # Required. Your Navidrome server, reachable from THIS container (a LAN IP
+      # or service name, not localhost). Left blank on purpose so a missing value
+      # is detected and reported clearly instead of silently failing.
+      Subsonic__Url: ${SUBSONIC_URL:-}
       Subsonic__StorageMode: ${STORAGE_MODE:-Stream}
       Subsonic__DownloadMode: ${DOWNLOAD_MODE:-Track}
       Subsonic__DownloadOnStar: ${DOWNLOAD_ON_STAR:-true}

--- a/octo.Tests/LocalLibraryServiceTests.cs
+++ b/octo.Tests/LocalLibraryServiceTests.cs
@@ -50,7 +50,10 @@ public class LocalLibraryServiceTests : IDisposable
         var mockLogger = new Mock<ILogger<LocalLibraryService>>();
 
         var idRegistry = new Octo.Services.Soulseek.ExternalIdRegistry();
-        _service = new LocalLibraryService(configuration, _mockHttpClientFactory.Object, subsonicSettings, idRegistry, mockLogger.Object);
+        var navIdentity = new Octo.Services.Subsonic.NavidromeIdentityService(
+            subsonicSettings, _mockHttpClientFactory.Object,
+            new Mock<ILogger<Octo.Services.Subsonic.NavidromeIdentityService>>().Object);
+        _service = new LocalLibraryService(configuration, _mockHttpClientFactory.Object, subsonicSettings, idRegistry, navIdentity, mockLogger.Object);
     }
 
     public void Dispose()

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -32,6 +32,8 @@ public class AdminController : ControllerBase
     private readonly IConfiguration _config;
     private readonly SoulseekClient _slskd;
     private readonly SubsonicProxyService _proxy;
+    private readonly SubsonicDiscoveryService _discovery;
+    private readonly Octo.Services.Local.DownloadHistoryService _history;
     private readonly IHttpClientFactory _httpFactory;
     private readonly IHostApplicationLifetime _lifetime;
     private readonly ILogger<AdminController> _logger;
@@ -44,6 +46,8 @@ public class AdminController : ControllerBase
         IConfiguration config,
         SoulseekClient slskd,
         SubsonicProxyService proxy,
+        SubsonicDiscoveryService discovery,
+        Octo.Services.Local.DownloadHistoryService history,
         IHttpClientFactory httpFactory,
         IHostApplicationLifetime lifetime,
         ILogger<AdminController> logger)
@@ -55,9 +59,31 @@ public class AdminController : ControllerBase
         _config = config;
         _slskd = slskd;
         _proxy = proxy;
+        _discovery = discovery;
+        _history = history;
         _httpFactory = httpFactory;
         _lifetime = lifetime;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Scans the local network for Subsonic/Navidrome servers so the setup UI can
+    /// offer a detected upstream URL instead of requiring it typed by hand. Returns
+    /// the found servers with their type/version. Empty when Octo can't see the LAN
+    /// (e.g. a Docker bridge network).
+    /// </summary>
+    [HttpGet("discover-servers")]
+    public async Task<IActionResult> DiscoverServers(CancellationToken ct)
+    {
+        var servers = await _discovery.ScanAsync(ct);
+        return Ok(new { servers });
+    }
+
+    /// <summary>The running log of songs Octo has fetched, newest first.</summary>
+    [HttpGet("downloads")]
+    public IActionResult Downloads()
+    {
+        return Ok(new { downloads = _history.GetRecent(200) });
     }
 
     /// <summary>

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1698,14 +1698,13 @@ public class SubsonicController : ControllerBase
         {
             var album = await _metadataService.GetAlbumAsync(provider!, externalId!);
             var url = album?.CoverArtUrl ?? "";
-            if (format == "json")
-                return _responseBuilder.CreateJsonResponse(new Dictionary<string, object>
-                {
-                    ["status"] = "ok",
-                    ["version"] = "1.16.1",
-                    ["albumInfo"] = new { notes = "", smallImageUrl = url, mediumImageUrl = url, largeImageUrl = url },
-                });
-            return _responseBuilder.CreateResponse(format, "albumInfo", new { });
+            return _responseBuilder.CreateInfoResponse(format, "albumInfo", new Dictionary<string, string>
+            {
+                ["notes"] = "",
+                ["smallImageUrl"] = url,
+                ["mediumImageUrl"] = url,
+                ["largeImageUrl"] = url,
+            });
         }
 
         var relay = await _proxyService.RelaySafeAsync("rest/getAlbumInfo2", parameters);
@@ -1730,14 +1729,13 @@ public class SubsonicController : ControllerBase
         {
             var artist = await _metadataService.GetArtistAsync(provider!, externalId!);
             var url = artist?.ImageUrl ?? "";
-            if (format == "json")
-                return _responseBuilder.CreateJsonResponse(new Dictionary<string, object>
-                {
-                    ["status"] = "ok",
-                    ["version"] = "1.16.1",
-                    ["artistInfo2"] = new { biography = "", smallImageUrl = url, mediumImageUrl = url, largeImageUrl = url },
-                });
-            return _responseBuilder.CreateResponse(format, "artistInfo2", new { });
+            return _responseBuilder.CreateInfoResponse(format, "artistInfo2", new Dictionary<string, string>
+            {
+                ["biography"] = "",
+                ["smallImageUrl"] = url,
+                ["mediumImageUrl"] = url,
+                ["largeImageUrl"] = url,
+            });
         }
 
         var relay = await _proxyService.RelaySafeAsync("rest/getArtistInfo2", parameters);
@@ -1757,17 +1755,53 @@ public class SubsonicController : ControllerBase
         var parameters = await ExtractAllParameters();
         var format = parameters.GetValueOrDefault("f", "xml");
 
+        // Safety net (client-agnostic): any endpoint we don't explicitly handle,
+        // called with one of our external ids, would relay to Navidrome and come
+        // back "data not found" — Navidrome has no such id. Degrade to a graceful
+        // ok so a client we haven't specifically tested never errors on external
+        // tracks. Endpoints that need real external data have their own handlers.
+        if (HasExternalId(parameters))
+        {
+            return _responseBuilder.CreateResponse(format, ElementFor(endpoint), new { });
+        }
+
         try
         {
-            var result = await _proxyService.RelayAsync(endpoint, parameters);
-            var contentType = result.ContentType ?? $"application/{format}";
-            return File(result.Body, contentType);
+            // Faithful relay: forward the caller's method + body + status so native
+            // Navidrome endpoints (e.g. the POST /auth/login some clients use) work,
+            // not just GET-shaped Subsonic calls.
+            var raw = await _proxyService.RelayRawAsync(endpoint, parameters);
+            Response.StatusCode = raw.Status;
+            Response.ContentType = raw.ContentType ?? $"application/{format}";
+            await Response.Body.WriteAsync(raw.Body);
+            return new EmptyResult();
         }
-        catch (HttpRequestException ex)
+        catch (Exception ex)
         {
-            // Return Subsonic-compatible error response
             return _responseBuilder.CreateError(format, 0, $"Error connecting to Subsonic server: {ex.Message}");
         }
+    }
+
+    /// <summary>True if any id-shaped parameter is one of Octo's external ids.</summary>
+    private bool HasExternalId(Dictionary<string, string> parameters)
+    {
+        foreach (var key in new[] { "id", "mediaId", "albumId", "artistId" })
+        {
+            if (parameters.TryGetValue(key, out var v) && !string.IsNullOrEmpty(v)
+                && _localLibraryService.ParseSongId(v).isExternal)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>rest/getSomething -> "something"; best-effort element name for an
+    /// empty-ok response (JSON ignores it; XML just needs a well-formed element).</summary>
+    private static string ElementFor(string endpoint)
+    {
+        var name = (endpoint.Split('/').LastOrDefault() ?? "response").Replace(".view", "");
+        if (name.StartsWith("get", StringComparison.OrdinalIgnoreCase) && name.Length > 3)
+            name = char.ToLowerInvariant(name[3]) + name[4..];
+        return string.IsNullOrEmpty(name) ? "response" : name;
     }
 
     private static bool IsOctoOwnedPath(string endpoint)

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -97,7 +97,7 @@ public class SubsonicController : ControllerBase
             || !Uri.TryCreate(_subsonicSettings.Url, UriKind.Absolute, out _))
         {
             return _responseBuilder.CreateError(format, 0,
-                $"Octo isn't configured yet. Open {Request.Scheme}://{Request.Host}/admin/ and set " +
+                $"Octo isn't configured yet. Open {Request.Scheme}://{Request.Host}/admin and set " +
                 "your Navidrome URL (SUBSONIC_URL), then point this client at Octo instead of Navidrome.");
         }
 

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1778,6 +1778,8 @@ public class SubsonicController : ControllerBase
             // not just GET-shaped Subsonic calls.
             var raw = await _proxyService.RelayRawAsync(endpoint, parameters);
             Response.StatusCode = raw.Status;
+            foreach (var h in raw.ResponseHeaders)
+                Response.Headers[h.Key] = h.Value;
             Response.ContentType = raw.ContentType ?? $"application/{format}";
             await Response.Body.WriteAsync(raw.Body);
             return new EmptyResult();
@@ -1814,8 +1816,11 @@ public class SubsonicController : ControllerBase
     {
         if (string.IsNullOrEmpty(endpoint)) return false;
         var lower = endpoint.ToLowerInvariant();
+        // Only Octo's OWN paths. Navidrome's native API also lives under /api/*
+        // (api/album, api/song, ...), so we must NOT claim all of /api/ — only
+        // api/admin — or Navidrome-mode clients can't reach the native API.
         return lower.StartsWith("admin", StringComparison.Ordinal)
-            || lower.StartsWith("api/", StringComparison.Ordinal)
+            || lower.StartsWith("api/admin", StringComparison.Ordinal)
             || lower.StartsWith("assets/", StringComparison.Ordinal)
             || lower == "favicon.ico";
     }

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -336,6 +336,10 @@ public class SubsonicController : ControllerBase
         // song via SoulseekMetadataService — no yt-dlp call until /rest/stream.
         var externalSongs = await BuildExternalSearchResultsAsync(cleanQuery, externalTarget);
 
+        // Fill real duration/album/year so the list stops showing every track at
+        // 3:00 (the placeholder). Bounded + cached; a provider miss keeps 180s.
+        await _metadataService.EnrichExternalSongsAsync(externalSongs);
+
         // Local pass-through. Albums/artists always get the full requested counts;
         // song-side gets the local target.
         var localProxyEndpoint = (Request.Path.Value ?? "").Contains("search2", StringComparison.OrdinalIgnoreCase)

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1610,6 +1610,74 @@ public class SubsonicController : ControllerBase
     // .NET 9 + Static Web Assets configurations), we don't accidentally turn
     // /admin/admin.css into a Navidrome HTML response.
     [HttpGet, HttpPost]
+    // Album/artist "info" panels. For external tracks these used to fall through
+    // to Navidrome (which has no such id) and return "data not found" — the error
+    // spam a client logs per row. Now they return a valid response with real
+    // Deezer art for external ids, and only relay for genuine local ids.
+    [HttpGet, HttpPost]
+    [Route("rest/getAlbumInfo2")]
+    [Route("rest/getAlbumInfo2.view")]
+    [Route("rest/getAlbumInfo")]
+    [Route("rest/getAlbumInfo.view")]
+    public async Task<IActionResult> GetAlbumInfo2()
+    {
+        var parameters = await ExtractAllParameters();
+        var id = parameters.GetValueOrDefault("id", "");
+        var format = parameters.GetValueOrDefault("f", "xml");
+        var (isExternal, provider, externalId) = _localLibraryService.ParseSongId(id);
+
+        if (isExternal)
+        {
+            var album = await _metadataService.GetAlbumAsync(provider!, externalId!);
+            var url = album?.CoverArtUrl ?? "";
+            if (format == "json")
+                return _responseBuilder.CreateJsonResponse(new Dictionary<string, object>
+                {
+                    ["status"] = "ok",
+                    ["version"] = "1.16.1",
+                    ["albumInfo"] = new { notes = "", smallImageUrl = url, mediumImageUrl = url, largeImageUrl = url },
+                });
+            return _responseBuilder.CreateResponse(format, "albumInfo", new { });
+        }
+
+        var relay = await _proxyService.RelaySafeAsync("rest/getAlbumInfo2", parameters);
+        if (relay.Success && relay.Body != null)
+            return File(relay.Body, relay.ContentType ?? $"application/{format}");
+        return _responseBuilder.CreateResponse(format, "albumInfo", new { });
+    }
+
+    [HttpGet, HttpPost]
+    [Route("rest/getArtistInfo2")]
+    [Route("rest/getArtistInfo2.view")]
+    [Route("rest/getArtistInfo")]
+    [Route("rest/getArtistInfo.view")]
+    public async Task<IActionResult> GetArtistInfo2()
+    {
+        var parameters = await ExtractAllParameters();
+        var id = parameters.GetValueOrDefault("id", "");
+        var format = parameters.GetValueOrDefault("f", "xml");
+        var (isExternal, provider, externalId) = _localLibraryService.ParseSongId(id);
+
+        if (isExternal)
+        {
+            var artist = await _metadataService.GetArtistAsync(provider!, externalId!);
+            var url = artist?.ImageUrl ?? "";
+            if (format == "json")
+                return _responseBuilder.CreateJsonResponse(new Dictionary<string, object>
+                {
+                    ["status"] = "ok",
+                    ["version"] = "1.16.1",
+                    ["artistInfo2"] = new { biography = "", smallImageUrl = url, mediumImageUrl = url, largeImageUrl = url },
+                });
+            return _responseBuilder.CreateResponse(format, "artistInfo2", new { });
+        }
+
+        var relay = await _proxyService.RelaySafeAsync("rest/getArtistInfo2", parameters);
+        if (relay.Success && relay.Body != null)
+            return File(relay.Body, relay.ContentType ?? $"application/{format}");
+        return _responseBuilder.CreateResponse(format, "artistInfo2", new { });
+    }
+
     [Route("{**endpoint}")]
     public async Task<IActionResult> GenericEndpoint(string endpoint)
     {

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1646,6 +1646,38 @@ public class SubsonicController : ControllerBase
         return _responseBuilder.CreateError(format, 0, "Jukebox is not supported");
     }
 
+    // OpenSubsonic getLyricsBySongId — Feishin fetches this every time a song
+    // plays. External tracks have no lyrics in Navidrome, so it returned code 70
+    // "data not found" per play; return an empty-but-ok lyrics list instead.
+    // (Real synced lyrics from an open source like lrclib are a future add.)
+    [HttpGet, HttpPost]
+    [Route("rest/getLyricsBySongId")]
+    [Route("rest/getLyricsBySongId.view")]
+    public async Task<IActionResult> GetLyricsBySongId()
+    {
+        var parameters = await ExtractAllParameters();
+        var id = parameters.GetValueOrDefault("id", "");
+        var format = parameters.GetValueOrDefault("f", "xml");
+        var (isExternal, _, _) = _localLibraryService.ParseSongId(id);
+
+        if (isExternal)
+        {
+            if (format == "json")
+                return _responseBuilder.CreateJsonResponse(new Dictionary<string, object>
+                {
+                    ["status"] = "ok",
+                    ["version"] = "1.16.1",
+                    ["lyricsList"] = new { structuredLyrics = Array.Empty<object>() },
+                });
+            return _responseBuilder.CreateResponse(format, "lyricsList", new { });
+        }
+
+        var relay = await _proxyService.RelaySafeAsync("rest/getLyricsBySongId", parameters);
+        if (relay.Success && relay.Body != null)
+            return File(relay.Body, relay.ContentType ?? $"application/{format}");
+        return _responseBuilder.CreateResponse(format, "lyricsList", new { });
+    }
+
     // Album/artist "info" panels. For external tracks these used to fall through
     // to Navidrome (which has no such id) and return "data not found" — the error
     // spam a client logs per row. Now they return a valid response with real

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1610,6 +1610,42 @@ public class SubsonicController : ControllerBase
     // .NET 9 + Static Web Assets configurations), we don't accidentally turn
     // /admin/admin.css into a Navidrome HTML response.
     [HttpGet, HttpPost]
+    // OpenSubsonic reportPlayback: Feishin pings this on play-start and during
+    // playback (176 hits in one session). For external ids Navidrome has no such
+    // media and returns an error, so we ack with ok; local ids relay through so
+    // Navidrome's now-playing stays accurate.
+    [HttpGet, HttpPost]
+    [Route("rest/reportPlayback")]
+    [Route("rest/reportPlayback.view")]
+    public async Task<IActionResult> ReportPlayback()
+    {
+        var parameters = await ExtractAllParameters();
+        var format = parameters.GetValueOrDefault("f", "xml");
+        var mediaId = parameters.GetValueOrDefault("mediaId", parameters.GetValueOrDefault("id", ""));
+        var (isExternal, _, _) = _localLibraryService.ParseSongId(mediaId);
+
+        if (!isExternal && !string.IsNullOrEmpty(mediaId))
+        {
+            var relay = await _proxyService.RelaySafeAsync("rest/reportPlayback", parameters);
+            if (relay.Success && relay.Body != null)
+                return File(relay.Body, relay.ContentType ?? $"application/{format}");
+        }
+        return _responseBuilder.CreateResponse(format, "reportPlayback", new { });
+    }
+
+    // Octo has no jukebox device. Relaying surfaced a misleading "Error
+    // connecting to Subsonic server"; return a clean, plain "not supported" so
+    // the client just disables jukebox mode instead of logging a scary error.
+    [HttpGet, HttpPost]
+    [Route("rest/jukeboxControl")]
+    [Route("rest/jukeboxControl.view")]
+    public async Task<IActionResult> JukeboxControl()
+    {
+        var parameters = await ExtractAllParameters();
+        var format = parameters.GetValueOrDefault("f", "xml");
+        return _responseBuilder.CreateError(format, 0, "Jukebox is not supported");
+    }
+
     // Album/artist "info" panels. For external tracks these used to fall through
     // to Navidrome (which has no such id) and return "data not found" — the error
     // spam a client logs per row. Now they return a valid response with real

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Xml.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Options;
 using Octo.Models.Domain;
 using Octo.Models.Settings;
@@ -37,6 +38,7 @@ public class SubsonicController : ControllerBase
     private readonly CoverArtAggregator? _coverArtAggregator;
     private readonly ExternalIdRegistry _idRegistry;
     private readonly RadioQueueStore _radioQueueStore;
+    private readonly NavidromeIdentityService _navIdentity;
     private readonly ILogger<SubsonicController> _logger;
 
     public SubsonicController(
@@ -50,6 +52,7 @@ public class SubsonicController : ControllerBase
         SubsonicProxyService proxyService,
         ExternalIdRegistry idRegistry,
         RadioQueueStore radioQueueStore,
+        NavidromeIdentityService navIdentity,
         ILogger<SubsonicController> logger,
         IOptions<LastFmSettings> lastFmSettings,
         PlaylistSyncService? playlistSyncService = null,
@@ -67,6 +70,7 @@ public class SubsonicController : ControllerBase
         _proxyService = proxyService;
         _idRegistry = idRegistry;
         _radioQueueStore = radioQueueStore;
+        _navIdentity = navIdentity;
         _playlistSyncService = playlistSyncService;
         _lastFmService = lastFmService;
         _lastFmSettings = lastFmSettings.Value;
@@ -1771,12 +1775,34 @@ public class SubsonicController : ControllerBase
             return _responseBuilder.CreateResponse(format, ElementFor(endpoint), new { });
         }
 
+        // Navidrome-native single-song detail for an external id. Native clients
+        // load the now-playing view via GET /api/song/{id}; the id lives in the
+        // path, not the query, so HasExternalId above (query-only) misses it and a
+        // relay would 500. Serve the synthetic native object instead.
+        var nativeSong = await TryServeNativeExternalSongAsync(endpoint);
+        if (nativeSong != null) return nativeSong;
+
+        // Navidrome-native discovery. Navidrome-mode clients (e.g. Feishin) search
+        // songs via GET /api/song?title=..., which otherwise relays straight through
+        // and only ever surfaces the local library. This mirrors the Subsonic
+        // search3 hijack onto the native API using the same discovery core, so
+        // discovery is a property of the request shape, not the client's mode.
+        var nativeSearch = await TryInjectNativeSongSearchAsync(endpoint, parameters);
+        if (nativeSearch != null) return nativeSearch;
+
         try
         {
             // Faithful relay: forward the caller's method + body + status so native
             // Navidrome endpoints (e.g. the POST /auth/login some clients use) work,
             // not just GET-shaped Subsonic calls.
             var raw = await _proxyService.RelayRawAsync(endpoint, parameters);
+
+            // Learn Octo's own Navidrome identity from a client's native sign-in as
+            // it passes through, so background work (music-folder detection, an
+            // authenticated rescan) has an admin token without any extra config.
+            if (raw.Status == 200 && endpoint.Equals("auth/login", StringComparison.OrdinalIgnoreCase))
+                _navIdentity.CaptureLogin(raw.Body);
+
             Response.StatusCode = raw.Status;
             foreach (var h in raw.ResponseHeaders)
                 Response.Headers[h.Key] = h.Value;
@@ -1811,6 +1837,167 @@ public class SubsonicController : ControllerBase
             name = char.ToLowerInvariant(name[3]) + name[4..];
         return string.IsNullOrEmpty(name) ? "response" : name;
     }
+
+    /// <summary>
+    /// Native single-song fetch for one of Octo's external ids. Navidrome-mode
+    /// clients load the now-playing detail via GET /api/song/{id}; relaying an
+    /// external id to Navidrome 500s (it has no such song). Rebuild the song from
+    /// the id via the same metadata core getSong uses and return it in native shape.
+    /// Returns null (fall through to relay) for anything but a leaf external-id fetch.
+    /// </summary>
+    private async Task<IActionResult?> TryServeNativeExternalSongAsync(string endpoint)
+    {
+        const string prefix = "api/song/";
+        if (!endpoint.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return null;
+        var id = endpoint[prefix.Length..].Trim('/');
+        if (string.IsNullOrEmpty(id) || id.Contains('/')) return null; // leaf id only
+
+        var (isExternal, provider, externalId) = _localLibraryService.ParseSongId(id);
+        if (!isExternal) return null;
+
+        var song = await _metadataService.GetSongAsync(provider!, externalId!);
+        if (song == null) return null;
+
+        // Enrich (Deezer album/year/art) so the detail matches the search-list row
+        // exactly; without this a client that refreshes now-playing from the detail
+        // would blank the album. Cached, so this is cheap after the initial search.
+        var one = new List<Song> { song };
+        await _metadataService.EnrichExternalSongsAsync(one);
+
+        // Lazy-resolve the accurate YouTube duration at play. Navidrome-mode clients
+        // re-fetch this endpoint when a track starts, so this is where the scrub bar
+        // gets the real length for results past the search's top-N (which are already
+        // resolved). Backed by the shim's persistent cache, so it is a disk hit for
+        // anything seen before and resolved-once-then-instant otherwise.
+        await _metadataService.ResolveTopDurationsAsync(one);
+
+        var bytes = Encoding.UTF8.GetBytes(BuildNativeSongObject(song).ToJsonString());
+        Response.StatusCode = 200;
+        Response.ContentType = "application/json";
+        await Response.Body.WriteAsync(bytes);
+        return new EmptyResult();
+    }
+
+    /// <summary>
+    /// Native-API twin of the Subsonic search3 hijack. When a Navidrome-mode client
+    /// searches songs (GET /api/song?title=...), relay the real query, then append
+    /// external discovery results serialized in Navidrome's native song shape. Play
+    /// and cover art need no special handling: native clients stream via /rest/stream
+    /// and fetch art via /rest/getCoverArt using the salt+token from login, and our
+    /// existing handlers already resolve Octo's external ids there.
+    ///
+    /// Returns null to fall through to the normal faithful relay whenever this is not
+    /// a first-page native song search we should touch, so library browsing, paging,
+    /// and every other native endpoint stay pure passthrough.
+    /// </summary>
+    private async Task<IActionResult?> TryInjectNativeSongSearchAsync(
+        string endpoint, Dictionary<string, string> parameters)
+    {
+        if (!string.Equals(endpoint, "api/song", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // Only a text search carries discovery intent. No title filter = library
+        // browse; a non-zero _start = a later page. Both stay passthrough so we
+        // never duplicate injected rows across pages or disturb navigation.
+        var term = parameters.GetValueOrDefault("title", "").Trim();
+        if (string.IsNullOrWhiteSpace(term)) return null;
+        if (parameters.TryGetValue("_start", out var startStr)
+            && int.TryParse(startStr, out var start) && start > 0)
+            return null;
+
+        // Relay the real query first; we append to whatever the library returned.
+        RawRelayResult raw;
+        try { raw = await _proxyService.RelayRawAsync(endpoint, parameters); }
+        catch { return null; } // upstream trouble -> let the normal path surface it
+
+        if (raw.Status != 200) return null;
+
+        // Native list endpoints answer with a bare JSON array + X-Total-Count. If the
+        // body is any other shape (error object, unexpected version), don't touch it.
+        JsonArray? realArr;
+        try { realArr = JsonNode.Parse(raw.Body) as JsonArray; }
+        catch { return null; }
+        if (realArr == null) return null;
+
+        // Stay inside the page window the client asked for so a single page holds
+        // everything and the client never pages into a duplicated injection.
+        var end = parameters.TryGetValue("_end", out var endStr) && int.TryParse(endStr, out var e)
+            ? e : realArr.Count + 60;
+        const int MaxExternalNative = 60;
+        var target = Math.Min(Math.Max(0, end - realArr.Count), MaxExternalNative);
+        if (target <= 0) return null;
+
+        // Same discovery core as Subsonic search3: Last.fm fan-out, Deezer enrich,
+        // accurate YouTube durations for the top of the list.
+        var externalSongs = await BuildExternalSearchResultsAsync(term, target);
+        if (externalSongs.Count == 0) return null;
+        await _metadataService.EnrichExternalSongsAsync(externalSongs);
+        await _metadataService.ResolveTopDurationsAsync(externalSongs);
+
+        foreach (var s in externalSongs)
+            realArr.Add(BuildNativeSongObject(s));
+
+        // Register for the scrobble-driven prewarm, same as search3.
+        _radioQueueStore.Register(externalSongs.Select(s => s.Id));
+
+        var bytes = Encoding.UTF8.GetBytes(realArr.ToJsonString());
+        Response.StatusCode = 200;
+        foreach (var h in raw.ResponseHeaders)
+        {
+            if (string.Equals(h.Key, "X-Total-Count", StringComparison.OrdinalIgnoreCase)) continue;
+            Response.Headers[h.Key] = h.Value;
+        }
+        Response.Headers["X-Total-Count"] = realArr.Count.ToString();
+        Response.ContentType = raw.ContentType ?? "application/json";
+        await Response.Body.WriteAsync(bytes);
+        return new EmptyResult();
+    }
+
+    /// <summary>
+    /// Serializes one external Song into Navidrome's native song JSON shape. Only the
+    /// fields a Navidrome-mode client reads to render and play a row are populated.
+    /// The id is Octo's external id, which /rest/stream and /rest/getCoverArt resolve.
+    /// </summary>
+    private static JsonObject BuildNativeSongObject(Song s)
+    {
+        var artistId = string.IsNullOrEmpty(s.ArtistId) ? s.Id + "-ar" : s.ArtistId!;
+        var albumId = string.IsNullOrEmpty(s.AlbumId) ? s.Id + "-al" : s.AlbumId!;
+        var duration = s.Duration ?? 0;
+        const string suffix = "m4a";
+        const int bitRate = 128; // format 140 AAC ~128 kbps
+        long size = duration > 0 ? (long)duration * bitRate * 1000L / 8 : 0;
+
+        var o = new JsonObject
+        {
+            ["id"] = s.Id,
+            ["path"] = $"{Sanitize(s.Artist)}/{Sanitize(s.Album)}/{Sanitize(s.Title)}.{suffix}",
+            ["title"] = s.Title,
+            ["album"] = s.Album ?? "",
+            ["artist"] = s.Artist ?? "",
+            ["artistId"] = artistId,
+            ["albumArtist"] = string.IsNullOrEmpty(s.AlbumArtist) ? s.Artist : s.AlbumArtist,
+            ["albumArtistId"] = artistId,
+            ["albumId"] = albumId,
+            ["hasCoverArt"] = true,
+            ["trackNumber"] = s.Track ?? 0,
+            ["discNumber"] = s.DiscNumber ?? 1,
+            ["size"] = size,
+            ["suffix"] = suffix,
+            ["duration"] = duration,
+            ["bitRate"] = bitRate,
+            ["playCount"] = 0,
+            // Fixed old timestamp: injected tracks are not "recently added" library
+            // items, so they should never crowd a client's recently-added view.
+            ["createdAt"] = "2020-01-01T00:00:00Z",
+            ["updatedAt"] = "2020-01-01T00:00:00Z",
+        };
+        if (s.Year is int y && y > 0) o["year"] = y;
+        if (!string.IsNullOrEmpty(s.Genre)) o["genre"] = s.Genre;
+        return o;
+    }
+
+    private static string Sanitize(string? s) =>
+        string.IsNullOrEmpty(s) ? "Unknown" : s.Replace('/', '_').Replace('\\', '_');
 
     private static bool IsOctoOwnedPath(string endpoint)
     {

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -73,11 +73,46 @@ public class SubsonicController : ControllerBase
         _coverArtService = coverArtService;
         _coverArtAggregator = coverArtAggregator;
         _logger = logger;
+        // No hard throw on a missing/blank Subsonic URL: that made every request
+        // fail opaquely. Misconfiguration is now reported per-request with an
+        // actionable message (see Ping and OctoNotConfiguredException), and the
+        // admin panel stays reachable so the user can fix it.
+    }
 
-        if (string.IsNullOrWhiteSpace(_subsonicSettings.Url))
+    // -------------------------------------------------------------------------
+    // ping — the first call every Subsonic client makes. We make it the moment a
+    // broken setup explains itself, instead of relaying blindly and returning an
+    // opaque error when the Navidrome URL is missing or unreachable.
+    // -------------------------------------------------------------------------
+    [HttpGet]
+    [HttpPost]
+    [Route("rest/ping")]
+    [Route("rest/ping.view")]
+    public async Task<IActionResult> Ping()
+    {
+        var parameters = await ExtractAllParameters();
+        var format = parameters.GetValueOrDefault("f", "xml");
+
+        if (string.IsNullOrWhiteSpace(_subsonicSettings.Url)
+            || !Uri.TryCreate(_subsonicSettings.Url, UriKind.Absolute, out _))
         {
-            throw new Exception("Error: Environment variable SUBSONIC_URL is not set.");
+            return _responseBuilder.CreateError(format, 0,
+                $"Octo isn't configured yet. Open {Request.Scheme}://{Request.Host}/admin/ and set " +
+                "your Navidrome URL (SUBSONIC_URL), then point this client at Octo instead of Navidrome.");
         }
+
+        // Relay to Navidrome so real credentials are validated there. A connection
+        // failure means Octo can't reach the configured URL; pass a successful
+        // (or auth-failed) Navidrome envelope straight through otherwise.
+        var relay = await _proxyService.RelaySafeAsync("rest/ping.view", parameters);
+        if (!relay.Success || relay.Body is null)
+        {
+            return _responseBuilder.CreateError(format, 0,
+                $"Octo can't reach Navidrome at {_subsonicSettings.Url}. Check the URL is correct and " +
+                "reachable from the Octo container (use a LAN IP or service name, not localhost).");
+        }
+
+        return File(relay.Body, relay.ContentType ?? $"application/{format}");
     }
 
     // ---------------------------------------------------------------------

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -336,9 +336,11 @@ public class SubsonicController : ControllerBase
         // song via SoulseekMetadataService — no yt-dlp call until /rest/stream.
         var externalSongs = await BuildExternalSearchResultsAsync(cleanQuery, externalTarget);
 
-        // Fill real duration/album/year so the list stops showing every track at
-        // 3:00 (the placeholder). Bounded + cached; a provider miss keeps 180s.
+        // Album/art/year from Deezer (fast), then the ACCURATE duration for the top
+        // of the list from the real YouTube video (so the scrub bar matches the
+        // audio and the client advances correctly). Bounded + cached.
         await _metadataService.EnrichExternalSongsAsync(externalSongs);
+        await _metadataService.ResolveTopDurationsAsync(externalSongs);
 
         // Local pass-through. Albums/artists always get the full requested counts;
         // song-side gets the local target.

--- a/octo/Middleware/GlobalExceptionHandler.cs
+++ b/octo/Middleware/GlobalExceptionHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Diagnostics;
+using Octo.Services.Subsonic;
 
 namespace Octo.Middleware;
 
@@ -39,6 +40,10 @@ public class GlobalExceptionHandler : IExceptionHandler
     {
         return exception switch
         {
+            // Configuration errors (503) — surface the actionable message verbatim
+            // so a misconfigured upstream URL tells the user exactly what to fix.
+            OctoNotConfiguredException => (503, 0, exception.Message),
+
             // Not Found errors (404)
             FileNotFoundException => (404, 70, "Resource not found"),
             DirectoryNotFoundException => (404, 70, "Directory not found"),

--- a/octo/Models/Download/DownloadHistoryEntry.cs
+++ b/octo/Models/Download/DownloadHistoryEntry.cs
@@ -1,0 +1,29 @@
+namespace Octo.Models.Download;
+
+/// <summary>
+/// One entry in the running log of songs Octo has fetched (via download-on-star or
+/// permanent-mode playback). Surfaced in the admin dashboard's "Fetched songs" view.
+/// </summary>
+public class DownloadHistoryEntry
+{
+    public string Artist { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string? Album { get; set; }
+
+    /// <summary>Absolute path the file was saved to.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>File format, upper-cased from the extension (FLAC, MP3, M4A).</summary>
+    public string Format { get; set; } = string.Empty;
+
+    /// <summary>Where it came from — "Soulseek" (FLAC) or "YouTube" (MP3).</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Cover art URL (Deezer), for the thumbnail in the log.</summary>
+    public string? CoverArtUrl { get; set; }
+
+    public long SizeBytes { get; set; }
+
+    /// <summary>When it was saved (ISO 8601, UTC).</summary>
+    public string DownloadedAt { get; set; } = string.Empty;
+}

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -99,7 +99,33 @@ public enum DownloadSource
 public class SubsonicSettings
 {
     public string? Url { get; set; }
-    
+
+    /// <summary>
+    /// Optional Navidrome admin username. When set (with AdminPassword), Octo can
+    /// authenticate to Navidrome for background work it does as a proxy: detecting
+    /// the music folder and triggering an authenticated rescan. If left empty, Octo
+    /// falls back to an admin token captured from a client's relayed native login.
+    /// Environment variable: SUBSONIC__ADMINUSERNAME
+    /// </summary>
+    public string? AdminUsername { get; set; }
+
+    /// <summary>
+    /// Optional Navidrome admin password paired with AdminUsername. See AdminUsername.
+    /// Environment variable: SUBSONIC__ADMINPASSWORD
+    /// </summary>
+    public string? AdminPassword { get; set; }
+
+    /// <summary>
+    /// Auto-detect the download destination from Navidrome's own music folder
+    /// (default: true). Octo is a proxy in front of Navidrome, so downloads should
+    /// land where Navidrome scans. When on, the effective download path is the
+    /// folder reported by Navidrome's /api/library; the Library:DownloadPath value
+    /// becomes a fallback used only until detection succeeds (or if it never does).
+    /// Turn off to always use Library:DownloadPath verbatim.
+    /// Environment variable: SUBSONIC__AUTODETECTDOWNLOADPATH
+    /// </summary>
+    public bool AutoDetectDownloadPath { get; set; } = true;
+
     /// <summary>
     /// Explicit content filter mode (default: All)
     /// Environment variable: EXPLICIT_FILTER

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -81,6 +81,21 @@ public enum FolderStructure
     Flat
 }
 
+/// <summary>
+/// Where a starred track's permanent copy comes from.
+/// </summary>
+public enum DownloadSource
+{
+    /// <summary>Lossless FLAC via Soulseek/slskd (default).</summary>
+    Soulseek,
+
+    /// <summary>Lossy MP3 via the yt-dlp shim.</summary>
+    YouTube,
+
+    /// <summary>Try Soulseek FLAC first; fall back to YouTube MP3 if it fails.</summary>
+    SoulseekThenYouTube
+}
+
 public class SubsonicSettings
 {
     public string? Url { get; set; }
@@ -144,6 +159,13 @@ public class SubsonicSettings
     /// Values: "Organized" (Artist/Album/Track.flac), "Flat" (Artist - Title.flac)
     /// </summary>
     public FolderStructure FolderStructure { get; set; } = FolderStructure.Flat;
+
+    /// <summary>
+    /// Source for permanent downloads (default: Soulseek).
+    /// Environment variable: DOWNLOAD_SOURCE
+    /// Values: "Soulseek" (FLAC), "YouTube" (MP3), "SoulseekThenYouTube" (FLAC with MP3 fallback)
+    /// </summary>
+    public DownloadSource DownloadSource { get; set; } = DownloadSource.Soulseek;
     
     /// <summary>
     /// Use local staging for cloud storage mounts (default: false)

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -70,6 +70,7 @@ builder.Services.AddHttpClient(YouTubeResolver.StreamClientName, c =>
 });
 builder.Services.AddSingleton<ExternalIdRegistry>();
 builder.Services.AddSingleton<RadioQueueStore>();
+builder.Services.AddSingleton<Octo.Services.Metadata.DeezerMetadataService>();
 builder.Services.AddSingleton<IMusicMetadataService, SoulseekMetadataService>();
 builder.Services.AddSingleton<IDownloadService, SoulseekDownloadService>();
 

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -107,6 +107,23 @@ var app = builder.Build();
 
 app.UseExceptionHandler(_ => { });
 
+// Capture the raw request body for body-carrying methods so the proxy can
+// faithfully forward it after parameter extraction has consumed/closed the
+// stream (needed for relayed native endpoints like POST /auth/login).
+app.Use(async (ctx, next) =>
+{
+    var m = ctx.Request.Method;
+    if (HttpMethods.IsPost(m) || HttpMethods.IsPut(m) || HttpMethods.IsPatch(m))
+    {
+        ctx.Request.EnableBuffering();
+        using var ms = new MemoryStream();
+        await ctx.Request.Body.CopyToAsync(ms);
+        ctx.Items["Octo.RawBody"] = ms.ToArray();
+        ctx.Request.Body.Position = 0; // rewind so form/model reading still works
+    }
+    await next(ctx);
+});
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -27,6 +27,11 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<Octo.Services.Admin.SettingsFileWriter>(
     sp => new Octo.Services.Admin.SettingsFileWriter(SettingsFilePath));
+// Running log of fetched songs, stored next to the settings file (same
+// bind-mounted config dir, so it survives restarts).
+builder.Services.AddSingleton(sp => new Octo.Services.Local.DownloadHistoryService(
+    System.IO.Path.Combine(System.IO.Path.GetDirectoryName(SettingsFilePath)!, "downloads-history.json"),
+    sp.GetRequiredService<ILogger<Octo.Services.Local.DownloadHistoryService>>()));
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
@@ -70,6 +75,8 @@ builder.Services.AddHttpClient(YouTubeResolver.StreamClientName, c =>
 });
 builder.Services.AddSingleton<ExternalIdRegistry>();
 builder.Services.AddSingleton<RadioQueueStore>();
+builder.Services.AddSingleton<Octo.Services.Subsonic.NavidromeIdentityService>();
+builder.Services.AddSingleton<Octo.Services.Subsonic.SubsonicDiscoveryService>();
 builder.Services.AddSingleton<Octo.Services.Metadata.DeezerMetadataService>();
 builder.Services.AddSingleton<IMusicMetadataService, SoulseekMetadataService>();
 builder.Services.AddSingleton<IDownloadService, SoulseekDownloadService>();
@@ -104,6 +111,50 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+// First-run automation (best-effort, background). Octo is an accessory to an
+// existing Navidrome, so it self-configures what it can: if no upstream URL is
+// set, scan the LAN and adopt the server when exactly one is found; then detect
+// the music folder from it. Anything ambiguous (several servers, none found) is
+// left for the dashboard so we never silently point at the wrong server.
+_ = Task.Run(async () =>
+{
+    var sp = app.Services;
+    var log = sp.GetRequiredService<ILogger<Program>>();
+    try
+    {
+        var subOpts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<Octo.Models.Settings.SubsonicSettings>>();
+        if (string.IsNullOrWhiteSpace(subOpts.CurrentValue.Url))
+        {
+            var servers = await sp.GetRequiredService<Octo.Services.Subsonic.SubsonicDiscoveryService>().ScanAsync();
+            if (servers.Count == 1)
+            {
+                sp.GetRequiredService<Octo.Services.Admin.SettingsFileWriter>().Merge(
+                    new System.Text.Json.Nodes.JsonObject
+                    {
+                        ["Subsonic"] = new System.Text.Json.Nodes.JsonObject { ["Url"] = servers[0].Url }
+                    });
+                // The URL is a restart-required setting (services bind it via IOptions
+                // at startup), so restart cleanly to apply it. A supervised deploy
+                // (compose restart policy / systemd) brings Octo straight back, now
+                // with the URL loaded; on next boot the URL is set so this is skipped.
+                log.LogInformation("First-run: auto-configured Navidrome URL -> {Url} ({Type} {Ver}). Restarting to apply.",
+                    servers[0].Url, servers[0].Type, servers[0].ServerVersion);
+                sp.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+                return;
+            }
+            else if (servers.Count > 1)
+                log.LogInformation("First-run: {N} servers found; pick one in the dashboard.", servers.Count);
+            else
+                log.LogInformation("First-run: no Navidrome auto-detected; set the URL in the dashboard.");
+        }
+    }
+    catch (Exception ex) { log.LogWarning("First-run server auto-detect failed: {Msg}", ex.Message); }
+
+    // Detect the music folder from whatever URL we now have (configured or adopted).
+    await sp.GetRequiredService<Octo.Services.Subsonic.NavidromeIdentityService>()
+        .DetectMusicFolderAsync(force: true);
+});
 
 app.UseExceptionHandler(_ => { });
 

--- a/octo/Services/Common/BaseDownloadService.cs
+++ b/octo/Services/Common/BaseDownloadService.cs
@@ -23,8 +23,18 @@ public abstract class BaseDownloadService : IDownloadService
     protected readonly SubsonicSettings SubsonicSettings;
     protected readonly ILogger Logger;
     private readonly IServiceProvider _serviceProvider;
-    
-    protected readonly string DownloadPath;
+    private readonly NavidromeIdentityService _navIdentity;
+    private readonly DownloadHistoryService _history;
+
+    // The configured Library:DownloadPath. With auto-detect on this is only a
+    // fallback used until Navidrome's real music folder is detected.
+    private readonly string _configuredDownloadPath;
+
+    /// <summary>
+    /// Effective download destination. Resolves fresh each access so that once
+    /// Navidrome's music folder is detected, downloads follow it without a restart.
+    /// </summary>
+    protected string DownloadPath => _navIdentity.EffectiveDownloadPath(_configuredDownloadPath);
     protected readonly string CachePath;
     
     protected readonly Dictionary<string, DownloadInfo> ActiveDownloads = new();
@@ -56,6 +66,8 @@ public abstract class BaseDownloadService : IDownloadService
         ILocalLibraryService localLibraryService,
         IMusicMetadataService metadataService,
         SubsonicSettings subsonicSettings,
+        NavidromeIdentityService navIdentity,
+        DownloadHistoryService history,
         IServiceProvider serviceProvider,
         ILogger logger)
     {
@@ -63,12 +75,14 @@ public abstract class BaseDownloadService : IDownloadService
         LocalLibraryService = localLibraryService;
         MetadataService = metadataService;
         SubsonicSettings = subsonicSettings;
+        _navIdentity = navIdentity;
+        _history = history;
         _serviceProvider = serviceProvider;
         Logger = logger;
-        
-        DownloadPath = configuration["Library:DownloadPath"] ?? "./downloads";
+
+        _configuredDownloadPath = configuration["Library:DownloadPath"] ?? "./downloads";
         CachePath = PathHelper.GetCachePath();
-        
+
         if (!Directory.Exists(DownloadPath))
         {
             Directory.CreateDirectory(DownloadPath);
@@ -168,7 +182,60 @@ public abstract class BaseDownloadService : IDownloadService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Local file path where the track was saved</returns>
     protected abstract Task<string> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken);
-    
+
+    /// <summary>Record a completed download in the fetched-songs log. Best-effort:
+    /// format + source are derived from the file extension (flac -> Soulseek/lossless,
+    /// otherwise -> YouTube/lossy), which matches Octo's two download sources.</summary>
+    private async Task RecordHistoryAsync(Song song, string localPath)
+    {
+        try
+        {
+            string? cover = song.CoverArtUrlLarge ?? song.CoverArtUrl;
+            string? album = string.IsNullOrEmpty(song.Album) ? null : song.Album;
+
+            // The star path rebuilds the song from its id, so it has no artwork or
+            // album. Pull the cover + album straight from Deezer for the log entry
+            // (cached, so this is cheap). Best-effort — never fails a download.
+            if (string.IsNullOrEmpty(cover) || album is null)
+            {
+                try
+                {
+                    var deezer = _serviceProvider.GetService<Octo.Services.Metadata.DeezerMetadataService>();
+                    if (deezer != null)
+                    {
+                        var meta = await deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: false);
+                        if (meta != null)
+                        {
+                            cover ??= meta.AlbumCoverUrl;
+                            album ??= meta.AlbumTitle;
+                        }
+                    }
+                }
+                catch { /* enrichment is best-effort */ }
+            }
+
+            var ext = System.IO.Path.GetExtension(localPath).TrimStart('.').ToUpperInvariant();
+            long size = 0;
+            try { size = new FileInfo(localPath).Length; } catch { /* best-effort */ }
+            _history.Record(new DownloadHistoryEntry
+            {
+                Artist = song.Artist,
+                Title = song.Title,
+                Album = album ?? string.Empty,
+                Path = localPath,
+                Format = string.IsNullOrEmpty(ext) ? "?" : ext,
+                Source = ext == "FLAC" ? "Soulseek" : "YouTube",
+                CoverArtUrl = cover,
+                SizeBytes = size,
+                DownloadedAt = DateTime.UtcNow.ToString("o"),
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to record download history for {Path}", localPath);
+        }
+    }
+
     /// <summary>
     /// Extracts the external album ID from the internal album ID format.
     /// Example: "ext-deezer-album-123456" -> "123456"
@@ -292,7 +359,13 @@ public abstract class BaseDownloadService : IDownloadService
             downloadInfo.CompletedAt = DateTime.UtcNow;
             
             song.LocalPath = localPath;
-            
+
+            // Enrich from Deezer and write rich tags + real album art onto the file.
+            // Downloads otherwise arrive bare (YouTube: artist/title + a video
+            // thumbnail; Soulseek: whatever the peer tagged), so this is what makes
+            // every fetched song a properly-tagged library citizen.
+            await EnrichAndTagAsync(song, localPath, cancellationToken);
+
             // Check if this track belongs to a playlist and update M3U
             if (PlaylistSyncService != null)
             {
@@ -315,7 +388,8 @@ public abstract class BaseDownloadService : IDownloadService
             if (!isCache)
             {
                 await LocalLibraryService.RegisterDownloadedSongAsync(song, localPath);
-                
+                await RecordHistoryAsync(song, localPath);
+
                 // Trigger a Subsonic library rescan (with debounce)
                 _ = Task.Run(async () =>
                 {
@@ -430,6 +504,69 @@ public abstract class BaseDownloadService : IDownloadService
     /// <summary>
     /// Writes ID3/Vorbis metadata and cover art to the audio file
     /// </summary>
+    /// <summary>
+    /// Fills any missing metadata on <paramref name="song"/> from Deezer, then writes
+    /// full tags + real album art onto the downloaded file. Existing values win (a
+    /// well-tagged Soulseek FLAC is enriched, not overwritten); Deezer fills the gaps
+    /// and supplies the cover. Best-effort — a miss or write failure never breaks the
+    /// download, the file just keeps whatever tags it already had.
+    /// </summary>
+    protected async Task EnrichAndTagAsync(Song song, string filePath, CancellationToken cancellationToken)
+    {
+        // Last.fm/YouTube titles often carry a redundant "Artist - " prefix (e.g.
+        // "Radiohead - No Surprises") which both mislabels the file and breaks the
+        // Deezer lookup. Strip it for the written title; strip bracketed junk too for
+        // the lookup query so the match lands and we get real album art + tags.
+        song.Title = StripArtistPrefix(song.Artist, song.Title);
+        var queryTitle = StripBracketedJunk(song.Title);
+
+        try
+        {
+            var deezer = _serviceProvider.GetService<Octo.Services.Metadata.DeezerMetadataService>();
+            if (deezer != null)
+            {
+                var m = await deezer.EnrichTrackFullAsync(song.Artist, queryTitle, cancellationToken);
+                if (m != null)
+                {
+                    if (string.IsNullOrEmpty(song.Album) && !string.IsNullOrEmpty(m.AlbumTitle)) song.Album = m.AlbumTitle;
+                    if (string.IsNullOrEmpty(song.AlbumArtist) && !string.IsNullOrEmpty(m.ArtistName)) song.AlbumArtist = m.ArtistName;
+                    if (string.IsNullOrEmpty(song.CoverArtUrlLarge)) song.CoverArtUrlLarge = m.AlbumCoverUrl;
+                    if (!song.Year.HasValue) song.Year = m.Year;
+                    if (!song.Track.HasValue) song.Track = m.TrackNumber;
+                    if (!song.DiscNumber.HasValue) song.DiscNumber = m.DiscNumber;
+                    if (!song.TotalTracks.HasValue) song.TotalTracks = m.TotalTracks;
+                    if (!song.Duration.HasValue) song.Duration = m.Duration;
+                    if (string.IsNullOrEmpty(song.Genre)) song.Genre = m.Genre;
+                    if (string.IsNullOrEmpty(song.Isrc)) song.Isrc = m.Isrc;
+                    if (string.IsNullOrEmpty(song.Label)) song.Label = m.Label;
+                    if (string.IsNullOrEmpty(song.ReleaseDate)) song.ReleaseDate = m.ReleaseDate;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Deezer enrichment for tagging failed for '{Artist} - {Title}'", song.Artist, song.Title);
+        }
+
+        await WriteMetadataAsync(filePath, song, cancellationToken);
+    }
+
+    /// <summary>Drop a redundant leading "Artist - " from a track title.</summary>
+    private static string StripArtistPrefix(string? artist, string? title)
+    {
+        var t = (title ?? string.Empty).Trim();
+        var a = (artist ?? string.Empty).Trim();
+        if (a.Length > 0 && t.StartsWith(a + " - ", StringComparison.OrdinalIgnoreCase))
+            t = t[(a.Length + 3)..].Trim();
+        return t;
+    }
+
+    /// <summary>Strip [bracketed] / (parenthesized) annotations for a cleaner Deezer
+    /// query (e.g. "No Surprises (Official Video)" -> "No Surprises"). Only used for
+    /// the lookup, not the written title, so real "(feat. …)" tags are preserved.</summary>
+    private static string StripBracketedJunk(string title)
+        => System.Text.RegularExpressions.Regex.Replace(title ?? string.Empty, @"\s*[\[\(][^\]\)]*[\]\)]", "").Trim();
+
     protected async Task WriteMetadataAsync(string filePath, Song song, CancellationToken cancellationToken)
     {
         try
@@ -438,17 +575,26 @@ public abstract class BaseDownloadService : IDownloadService
             
             using var tagFile = TagLib.File.Create(filePath);
             
-            // Basic metadata
-            tagFile.Tag.Title = song.Title;
-            tagFile.Tag.Performers = new[] { song.Artist };
-            tagFile.Tag.Album = song.Album;
-            tagFile.Tag.AlbumArtists = new[] { !string.IsNullOrEmpty(song.AlbumArtist) ? song.AlbumArtist : song.Artist };
+            // Basic metadata. Title/artist we always have; only overwrite album +
+            // album-artist when we actually resolved them, so a well-tagged Soulseek
+            // FLAC keeps its own album if Deezer had no match.
+            if (!string.IsNullOrEmpty(song.Title)) tagFile.Tag.Title = song.Title;
+            if (!string.IsNullOrEmpty(song.Artist)) tagFile.Tag.Performers = new[] { song.Artist };
+            if (!string.IsNullOrEmpty(song.Album)) tagFile.Tag.Album = song.Album;
+            if (!string.IsNullOrEmpty(song.AlbumArtist))
+                tagFile.Tag.AlbumArtists = new[] { song.AlbumArtist };
+            else if (!string.IsNullOrEmpty(song.Artist))
+                tagFile.Tag.AlbumArtists = new[] { song.Artist };
             
-            if (song.Track.HasValue)
+            // Only write the track number when we actually have one, and only pair
+            // the total with it — avoids a bogus "0/11" when Deezer's search result
+            // carried the album total but not this track's position.
+            if (song.Track is > 0)
+            {
                 tagFile.Tag.Track = (uint)song.Track.Value;
-            
-            if (song.TotalTracks.HasValue)
-                tagFile.Tag.TrackCount = (uint)song.TotalTracks.Value;
+                if (song.TotalTracks.HasValue)
+                    tagFile.Tag.TrackCount = (uint)song.TotalTracks.Value;
+            }
             
             if (song.DiscNumber.HasValue)
                 tagFile.Tag.Disc = (uint)song.DiscNumber.Value;

--- a/octo/Services/IMusicMetadataService.cs
+++ b/octo/Services/IMusicMetadataService.cs
@@ -39,6 +39,14 @@ public interface IMusicMetadataService
         => Task.CompletedTask;
 
     /// <summary>
+    /// Resolves the real YouTube video (and its duration) for the top of a search
+    /// result so the shown length matches the audio that plays. Bounded + cached;
+    /// also stores the videoId so playback reuses the same video.
+    /// </summary>
+    Task ResolveTopDurationsAsync(List<Song> songs, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    /// <summary>
     /// Best-effort pre-resolve of upstream identifiers (e.g. YouTube videoIds) for
     /// the first N songs of a freshly-built search result. Called fire-and-forget
     /// so search3 still returns instantly. Provider-specific (a Deezer/Qobuz

--- a/octo/Services/IMusicMetadataService.cs
+++ b/octo/Services/IMusicMetadataService.cs
@@ -31,6 +31,14 @@ public interface IMusicMetadataService
     Task<List<Song>> SearchSongsByArtistTitleAsync(string artist, string title, int limit = 1, int? durationSeconds = null);
 
     /// <summary>
+    /// Fills in real duration/album/year on external placeholder songs (which
+    /// otherwise show a 3:00 fallback) from a metadata provider. Bounded, cached,
+    /// best-effort; does not block or fail the search if the provider is down.
+    /// </summary>
+    Task EnrichExternalSongsAsync(List<Song> songs, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    /// <summary>
     /// Best-effort pre-resolve of upstream identifiers (e.g. YouTube videoIds) for
     /// the first N songs of a freshly-built search result. Called fire-and-forget
     /// so search3 still returns instantly. Provider-specific (a Deezer/Qobuz

--- a/octo/Services/Local/DownloadHistoryService.cs
+++ b/octo/Services/Local/DownloadHistoryService.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Octo.Models.Download;
+
+namespace Octo.Services.Local;
+
+/// <summary>
+/// Persistent, bounded log of songs Octo has fetched. Written to a JSON file next
+/// to the settings file so it survives restarts and container recreation (the
+/// config dir is a host bind-mount). Newest entries first; capped so it can't grow
+/// without limit. Best-effort — a write failure never breaks a download.
+/// </summary>
+public class DownloadHistoryService
+{
+    private const int MaxEntries = 500;
+
+    private readonly string _path;
+    private readonly ILogger<DownloadHistoryService> _logger;
+    private readonly object _lock = new();
+    private List<DownloadHistoryEntry>? _cache;
+
+    public DownloadHistoryService(string path, ILogger<DownloadHistoryService> logger)
+    {
+        _path = path;
+        _logger = logger;
+    }
+
+    /// <summary>Append a fetched-song entry (newest first) and persist.</summary>
+    public void Record(DownloadHistoryEntry entry)
+    {
+        lock (_lock)
+        {
+            var list = LoadLocked();
+            list.Insert(0, entry);
+            while (list.Count > MaxEntries) list.RemoveAt(list.Count - 1);
+            SaveLocked(list);
+        }
+    }
+
+    /// <summary>The most recent entries, newest first.</summary>
+    public IReadOnlyList<DownloadHistoryEntry> GetRecent(int limit = 200)
+    {
+        lock (_lock)
+        {
+            return LoadLocked().Take(Math.Max(0, limit)).ToList();
+        }
+    }
+
+    private List<DownloadHistoryEntry> LoadLocked()
+    {
+        if (_cache != null) return _cache;
+        try
+        {
+            if (File.Exists(_path))
+            {
+                var json = File.ReadAllText(_path);
+                _cache = string.IsNullOrWhiteSpace(json)
+                    ? new List<DownloadHistoryEntry>()
+                    : JsonSerializer.Deserialize<List<DownloadHistoryEntry>>(json) ?? new List<DownloadHistoryEntry>();
+            }
+            else
+            {
+                _cache = new List<DownloadHistoryEntry>();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Download history load failed ({Msg}); starting fresh", ex.Message);
+            _cache = new List<DownloadHistoryEntry>();
+        }
+        return _cache;
+    }
+
+    private void SaveLocked(List<DownloadHistoryEntry> list)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_path) ?? ".");
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, JsonSerializer.Serialize(list));
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Download history save failed: {Msg}", ex.Message);
+        }
+    }
+}

--- a/octo/Services/Local/LocalLibraryService.cs
+++ b/octo/Services/Local/LocalLibraryService.cs
@@ -7,6 +7,7 @@ using Octo.Models.Search;
 using Octo.Models.Subsonic;
 using Octo.Services;
 using Octo.Services.Soulseek;
+using Octo.Services.Subsonic;
 
 namespace Octo.Services.Local;
 
@@ -21,6 +22,7 @@ public class LocalLibraryService : ILocalLibraryService
     private readonly HttpClient _httpClient;
     private readonly SubsonicSettings _subsonicSettings;
     private readonly ExternalIdRegistry _idRegistry;
+    private readonly NavidromeIdentityService _navIdentity;
     private readonly ILogger<LocalLibraryService> _logger;
     private Dictionary<string, LocalSongMapping>? _mappings;
     private readonly SemaphoreSlim _lock = new(1, 1);
@@ -34,6 +36,7 @@ public class LocalLibraryService : ILocalLibraryService
         IHttpClientFactory httpClientFactory,
         IOptions<SubsonicSettings> subsonicSettings,
         ExternalIdRegistry idRegistry,
+        NavidromeIdentityService navIdentity,
         ILogger<LocalLibraryService> logger)
     {
         _downloadDirectory = configuration["Library:DownloadPath"] ?? Path.Combine(Directory.GetCurrentDirectory(), "downloads");
@@ -41,6 +44,7 @@ public class LocalLibraryService : ILocalLibraryService
         _httpClient = httpClientFactory.CreateClient();
         _subsonicSettings = subsonicSettings.Value;
         _idRegistry = idRegistry;
+        _navIdentity = navIdentity;
         _logger = logger;
         
         if (!Directory.Exists(_downloadDirectory))
@@ -207,14 +211,20 @@ public class LocalLibraryService : ILocalLibraryService
         
         try
         {
-            // Call Subsonic API to trigger a scan
-            // Note: This endpoint works without authentication on most Subsonic/Navidrome servers
-            // when called from localhost. For remote servers requiring auth, this would need
-            // to be refactored to accept credentials from the controller layer.
-            var url = $"{_subsonicSettings.Url}/rest/startScan?f=json";
-            
-            _logger.LogInformation("Triggering Subsonic library scan...");
-            
+            // Navidrome's startScan requires an admin identity. Octo, as a proxy,
+            // gets one from the NavidromeIdentityService (captured from a client's
+            // relayed login or configured admin creds). When available we send the
+            // Subsonic u/t/s triplet; otherwise we fall back to the bare call, which
+            // only works on servers that allow unauthenticated localhost scans.
+            var auth = _navIdentity.GetScanAuth();
+            var url = auth is { } a
+                ? $"{_subsonicSettings.Url}/rest/startScan?f=json&c=octo&v=1.16.1" +
+                  $"&u={Uri.EscapeDataString(a.user)}&t={a.token}&s={a.salt}"
+                : $"{_subsonicSettings.Url}/rest/startScan?f=json";
+
+            _logger.LogInformation("Triggering Subsonic library scan ({Auth})...",
+                auth is null ? "unauthenticated" : "authenticated");
+
             var response = await _httpClient.GetAsync(url);
             
             if (response.IsSuccessStatusCode)

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -26,6 +26,9 @@ public class DeezerMetadataService
     private readonly ConcurrentDictionary<string, TrackMeta?> _trackCache = new();
     private readonly ConcurrentDictionary<string, ArtistMeta?> _artistCache = new();
     private readonly ConcurrentDictionary<long, int?> _albumYearCache = new();
+    // Single-flight the album-year fetch: many tracks in one search share an album
+    // (a whole album's tracks), so concurrent lookups collapse onto one HTTP call.
+    private readonly ConcurrentDictionary<long, Lazy<Task<int?>>> _albumYearTasks = new();
 
     public DeezerMetadataService(IHttpClientFactory httpFactory, ILogger<DeezerMetadataService> logger)
     {
@@ -109,19 +112,27 @@ public class DeezerMetadataService
         return meta;
     }
 
-    private async Task<int?> AlbumYearAsync(long albumId, CancellationToken ct)
+    private Task<int?> AlbumYearAsync(long albumId, CancellationToken ct)
     {
-        if (_albumYearCache.TryGetValue(albumId, out var y)) return y;
+        if (_albumYearCache.TryGetValue(albumId, out var y)) return Task.FromResult(y);
+        // Shared across concurrent callers for the same album id (single-flight).
+        return _albumYearTasks.GetOrAdd(albumId,
+            id => new Lazy<Task<int?>>(() => FetchAlbumYearAsync(id))).Value;
+    }
+
+    private async Task<int?> FetchAlbumYearAsync(long albumId)
+    {
         int? year = null;
         try
         {
-            using var doc = await GetJsonAsync($"{Base}/album/{albumId}", ct);
+            using var doc = await GetJsonAsync($"{Base}/album/{albumId}", CancellationToken.None);
             var rd = doc is null ? null : Str(doc.RootElement, "release_date");
             if (!string.IsNullOrEmpty(rd) && rd.Length >= 4 && int.TryParse(rd[..4], out var yr))
                 year = yr;
         }
         catch { /* best-effort */ }
         _albumYearCache[albumId] = year;
+        _albumYearTasks.TryRemove(albumId, out _);
         return year;
     }
 

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -18,12 +18,19 @@ public class DeezerMetadataService
         string? ArtistName, string? ArtistImageUrl);
     public record ArtistMeta(string? Name, string? ImageUrl);
 
+    /// <summary>Everything Deezer knows about a track, for writing rich file tags.</summary>
+    public record FullTrackMeta(
+        string? AlbumTitle, string? AlbumCoverUrl, int? Year, int? Duration, string? ArtistName,
+        int? TrackNumber, int? DiscNumber, string? Isrc, int? TotalTracks, string? Genre,
+        string? Label, string? ReleaseDate);
+
     private const string Base = "https://api.deezer.com";
     private const int MaxCache = 4096;
 
     private readonly IHttpClientFactory _httpFactory;
     private readonly ILogger<DeezerMetadataService> _logger;
     private readonly ConcurrentDictionary<string, TrackMeta?> _trackCache = new();
+    private readonly ConcurrentDictionary<string, FullTrackMeta?> _fullCache = new();
     private readonly ConcurrentDictionary<string, ArtistMeta?> _artistCache = new();
     private readonly ConcurrentDictionary<long, int?> _albumYearCache = new();
     // Single-flight the album-year fetch: many tracks in one search share an album
@@ -85,6 +92,68 @@ public class DeezerMetadataService
         }
 
         Cache(_trackCache, key, meta);
+        return meta;
+    }
+
+    /// <summary>
+    /// Full track metadata for tagging a downloaded file: one track search (album,
+    /// cover_xl, artist, duration, track_position, disk_number, isrc) plus one album
+    /// detail call (release year, genre, total tracks, label). Cached; best-effort.
+    /// </summary>
+    public async Task<FullTrackMeta?> EnrichTrackFullAsync(string? artist, string? title, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(artist) && string.IsNullOrWhiteSpace(title)) return null;
+        var key = $"full|{artist}|{title}".ToLowerInvariant();
+        if (_fullCache.TryGetValue(key, out var cached)) return cached;
+
+        FullTrackMeta? meta = null;
+        try
+        {
+            var q = Uri.EscapeDataString($"artist:\"{artist}\" track:\"{title}\"");
+            using var doc = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct);
+            if (FirstData(doc) is JsonElement t)
+            {
+                string? albTitle = null, cover = null, artName = null;
+                var isrc = Str(t, "isrc");
+                long albId = 0;
+                if (t.TryGetProperty("album", out var alb))
+                {
+                    albTitle = Str(alb, "title");
+                    cover = Str(alb, "cover_xl") ?? Str(alb, "cover_big") ?? Str(alb, "cover_medium");
+                    if (alb.TryGetProperty("id", out var aid) && aid.ValueKind == JsonValueKind.Number)
+                        albId = aid.GetInt64();
+                }
+                if (t.TryGetProperty("artist", out var art)) artName = Str(art, "name");
+
+                int? year = null, totalTracks = null;
+                string? genre = null, label = null, releaseDate = null;
+                if (albId > 0)
+                {
+                    using var adoc = await GetJsonAsync($"{Base}/album/{albId}", ct);
+                    if (adoc != null)
+                    {
+                        var root = adoc.RootElement;
+                        releaseDate = Str(root, "release_date");
+                        if (!string.IsNullOrEmpty(releaseDate) && releaseDate.Length >= 4 && int.TryParse(releaseDate[..4], out var yr))
+                            year = yr;
+                        totalTracks = Int(root, "nb_tracks");
+                        label = Str(root, "label");
+                        if (root.TryGetProperty("genres", out var g) && g.TryGetProperty("data", out var gd)
+                            && gd.ValueKind == JsonValueKind.Array && gd.GetArrayLength() > 0)
+                            genre = Str(gd[0], "name");
+                    }
+                }
+
+                meta = new FullTrackMeta(albTitle, cover, year, Int(t, "duration"), artName,
+                    Int(t, "track_position"), Int(t, "disk_number"), isrc, totalTracks, genre, label, releaseDate);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug("deezer full enrich '{A} - {T}' failed: {M}", artist, title, ex.Message);
+        }
+
+        Cache(_fullCache, key, meta);
         return meta;
     }
 
@@ -154,6 +223,9 @@ public class DeezerMetadataService
 
     private static string? Str(JsonElement e, string name)
         => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static int? Int(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt32() : (int?)null;
 
     private static void Cache<TK, TV>(ConcurrentDictionary<TK, TV> cache, TK key, TV val) where TK : notnull
     {

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -14,7 +14,7 @@ namespace Octo.Services.Metadata;
 /// </summary>
 public class DeezerMetadataService
 {
-    public record TrackMeta(string? AlbumTitle, string? AlbumCoverUrl, int? Year,
+    public record TrackMeta(string? AlbumTitle, string? AlbumCoverUrl, int? Year, int? Duration,
         string? ArtistName, string? ArtistImageUrl);
     public record ArtistMeta(string? Name, string? ImageUrl);
 
@@ -40,8 +40,10 @@ public class DeezerMetadataService
         return c;
     }
 
-    /// <summary>Resolve "artist + title" to the real album + artist (name, art, year).</summary>
-    public async Task<TrackMeta?> EnrichTrackAsync(string? artist, string? title, CancellationToken ct = default)
+    /// <summary>Resolve "artist + title" to the real album + artist (name, art, year).
+    /// Pass includeYear=false to skip the extra album-detail call (bulk enrichment
+    /// wants duration + album fast; the year is fetched lazily by the album view).</summary>
+    public async Task<TrackMeta?> EnrichTrackAsync(string? artist, string? title, bool includeYear = true, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(artist) && string.IsNullOrWhiteSpace(title)) return null;
         var key = $"{artist}|{title}".ToLowerInvariant();
@@ -68,8 +70,10 @@ public class DeezerMetadataService
                     artName = Str(art, "name");
                     artImg = Str(art, "picture_xl") ?? Str(art, "picture_medium");
                 }
-                var year = albId > 0 ? await AlbumYearAsync(albId, ct) : null;
-                meta = new TrackMeta(albTitle, cover, year, artName, artImg);
+                int? duration = t.TryGetProperty("duration", out var du) && du.ValueKind == JsonValueKind.Number
+                    ? du.GetInt32() : null;
+                var year = includeYear && albId > 0 ? await AlbumYearAsync(albId, ct) : null;
+                meta = new TrackMeta(albTitle, cover, year, duration, artName, artImg);
             }
         }
         catch (Exception ex)

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace Octo.Services.Metadata;
+
+/// <summary>
+/// Enriches external (YouTube-resolved) tracks with real album/artist metadata
+/// from Deezer's public API. Keyless and no ARL — the ARL that expires on the
+/// music bot is only for Deezer AUDIO; metadata endpoints are open.
+///
+/// Everything here is best-effort and cached: a Deezer outage, throttle, or miss
+/// returns null, and callers fall back to a synthetic entity. Nothing on this
+/// path ever blocks or fails playback.
+/// </summary>
+public class DeezerMetadataService
+{
+    public record TrackMeta(string? AlbumTitle, string? AlbumCoverUrl, int? Year,
+        string? ArtistName, string? ArtistImageUrl);
+    public record ArtistMeta(string? Name, string? ImageUrl);
+
+    private const string Base = "https://api.deezer.com";
+    private const int MaxCache = 4096;
+
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<DeezerMetadataService> _logger;
+    private readonly ConcurrentDictionary<string, TrackMeta?> _trackCache = new();
+    private readonly ConcurrentDictionary<string, ArtistMeta?> _artistCache = new();
+    private readonly ConcurrentDictionary<long, int?> _albumYearCache = new();
+
+    public DeezerMetadataService(IHttpClientFactory httpFactory, ILogger<DeezerMetadataService> logger)
+    {
+        _httpFactory = httpFactory;
+        _logger = logger;
+    }
+
+    private HttpClient Client()
+    {
+        var c = _httpFactory.CreateClient();
+        c.Timeout = TimeSpan.FromSeconds(8);
+        return c;
+    }
+
+    /// <summary>Resolve "artist + title" to the real album + artist (name, art, year).</summary>
+    public async Task<TrackMeta?> EnrichTrackAsync(string? artist, string? title, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(artist) && string.IsNullOrWhiteSpace(title)) return null;
+        var key = $"{artist}|{title}".ToLowerInvariant();
+        if (_trackCache.TryGetValue(key, out var cached)) return cached;
+
+        TrackMeta? meta = null;
+        try
+        {
+            var q = Uri.EscapeDataString($"artist:\"{artist}\" track:\"{title}\"");
+            using var doc = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct);
+            if (FirstData(doc) is JsonElement t)
+            {
+                string? albTitle = null, cover = null, artName = null, artImg = null;
+                long albId = 0;
+                if (t.TryGetProperty("album", out var alb))
+                {
+                    albTitle = Str(alb, "title");
+                    cover = Str(alb, "cover_xl") ?? Str(alb, "cover_medium");
+                    if (alb.TryGetProperty("id", out var aid) && aid.ValueKind == JsonValueKind.Number)
+                        albId = aid.GetInt64();
+                }
+                if (t.TryGetProperty("artist", out var art))
+                {
+                    artName = Str(art, "name");
+                    artImg = Str(art, "picture_xl") ?? Str(art, "picture_medium");
+                }
+                var year = albId > 0 ? await AlbumYearAsync(albId, ct) : null;
+                meta = new TrackMeta(albTitle, cover, year, artName, artImg);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug("deezer enrich track '{A} - {T}' failed: {M}", artist, title, ex.Message);
+        }
+
+        Cache(_trackCache, key, meta);
+        return meta;
+    }
+
+    /// <summary>Resolve an artist name to its Deezer name + image.</summary>
+    public async Task<ArtistMeta?> EnrichArtistAsync(string? artist, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(artist)) return null;
+        var key = artist.ToLowerInvariant();
+        if (_artistCache.TryGetValue(key, out var cached)) return cached;
+
+        ArtistMeta? meta = null;
+        try
+        {
+            var q = Uri.EscapeDataString(artist);
+            using var doc = await GetJsonAsync($"{Base}/search/artist?q={q}&limit=1", ct);
+            if (FirstData(doc) is JsonElement a)
+                meta = new ArtistMeta(Str(a, "name"), Str(a, "picture_xl") ?? Str(a, "picture_medium"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug("deezer enrich artist '{A}' failed: {M}", artist, ex.Message);
+        }
+
+        Cache(_artistCache, key, meta);
+        return meta;
+    }
+
+    private async Task<int?> AlbumYearAsync(long albumId, CancellationToken ct)
+    {
+        if (_albumYearCache.TryGetValue(albumId, out var y)) return y;
+        int? year = null;
+        try
+        {
+            using var doc = await GetJsonAsync($"{Base}/album/{albumId}", ct);
+            var rd = doc is null ? null : Str(doc.RootElement, "release_date");
+            if (!string.IsNullOrEmpty(rd) && rd.Length >= 4 && int.TryParse(rd[..4], out var yr))
+                year = yr;
+        }
+        catch { /* best-effort */ }
+        _albumYearCache[albumId] = year;
+        return year;
+    }
+
+    private async Task<JsonDocument?> GetJsonAsync(string url, CancellationToken ct)
+    {
+        using var resp = await Client().GetAsync(url, ct);
+        if (!resp.IsSuccessStatusCode) return null;
+        var s = await resp.Content.ReadAsStringAsync(ct);
+        return JsonDocument.Parse(s);
+    }
+
+    private static JsonElement? FirstData(JsonDocument? doc)
+    {
+        if (doc is null) return null;
+        if (doc.RootElement.TryGetProperty("data", out var d) && d.ValueKind == JsonValueKind.Array && d.GetArrayLength() > 0)
+            return d[0];
+        return null;
+    }
+
+    private static string? Str(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static void Cache<TK, TV>(ConcurrentDictionary<TK, TV> cache, TK key, TV val) where TK : notnull
+    {
+        cache[key] = val;
+        if (cache.Count > MaxCache) cache.Clear();  // crude bound; simple and safe
+    }
+}

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -122,6 +122,60 @@ public class SoulseekDownloadService : BaseDownloadService
             throw new InvalidOperationException(
                 $"Cannot download '{song.Artist} - {song.Title}': missing artist/title in external id");
 
+        // DownloadOnStar decides WHETHER to download; DownloadSource decides FROM WHERE.
+        switch (SubsonicSettings.DownloadSource)
+        {
+            case DownloadSource.YouTube:
+                return await DownloadViaYouTubeAsync(routing, cancellationToken);
+            case DownloadSource.SoulseekThenYouTube:
+                try { return await DownloadViaSoulseekAsync(routing, cancellationToken); }
+                catch (Exception ex)
+                {
+                    Logger.LogWarning("Soulseek download failed ({Msg}); falling back to YouTube MP3", ex.Message);
+                    return await DownloadViaYouTubeAsync(routing, cancellationToken);
+                }
+            default:
+                return await DownloadViaSoulseekAsync(routing, cancellationToken);
+        }
+    }
+
+    // Lossy MP3 via the yt-dlp shim's /download. The shim writes <dest>.mp3 in
+    // the final layout with clean tags + cover, so there is no post-move.
+    private async Task<string> DownloadViaYouTubeAsync(SoulseekRouting routing, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(DownloadPath))
+            throw new InvalidOperationException("DownloadPath is not configured");
+
+        var videoId = routing.YouTubeId;
+        if (string.IsNullOrEmpty(videoId))
+        {
+            var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, cancellationToken);
+            videoId = hit?.VideoId;
+            if (!string.IsNullOrEmpty(videoId)) routing.YouTubeId = videoId;
+        }
+        if (string.IsNullOrEmpty(videoId))
+            throw new FileNotFoundException($"No YouTube match for '{routing.Artist} - {routing.Title}'");
+
+        var ytArtist = SanitizeForFs(routing.Artist) ?? "Unknown Artist";
+        var ytTitle  = SanitizeForFs(routing.Title)  ?? "Unknown Title";
+        var destWithoutExt = SubsonicSettings.FolderStructure switch
+        {
+            Models.Settings.FolderStructure.Organized => Path.Combine(DownloadPath, ytArtist, ytTitle, $"{ytArtist} - {ytTitle}"),
+            _ => Path.Combine(DownloadPath, $"{ytArtist} - {ytTitle}"),
+        };
+
+        var path = await _youtube.DownloadAsync(videoId, destWithoutExt, routing.Artist, routing.Title, cancellationToken);
+        if (string.IsNullOrEmpty(path) || !IOFile.Exists(path))
+            throw new FileNotFoundException($"YouTube MP3 download failed for '{routing.Artist} - {routing.Title}'");
+
+        Logger.LogInformation("YouTube MP3 download complete: {Path}", path);
+        return path;
+    }
+
+    // Lossless FLAC via Soulseek/slskd: walk the top-N peers in quality order,
+    // first successful transfer wins.
+    private async Task<string> DownloadViaSoulseekAsync(SoulseekRouting routing, CancellationToken cancellationToken)
+    {
         // Clean the title before searching Soulseek. Last.fm's track.search
         // sometimes returns `title="Adele - Hello"` with the artist redundantly
         // prefixed, or YouTube-flavored titles like `"Long Season [LIVE][4K]"`.

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -66,7 +66,7 @@ public class SoulseekDownloadService : BaseDownloadService
         var videoId = routing.YouTubeId;
         if (string.IsNullOrEmpty(videoId) && routing.HasArtistTitle)
         {
-            var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", cancellationToken);
+            var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, cancellationToken);
             videoId = hit?.VideoId;
             // Cache back on the routing so a second click on the same placeholder
             // skips the yt-dlp ytsearch1: round trip — that 3-8s saving is the

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -3,6 +3,7 @@ using Octo.Models.Domain;
 using Octo.Models.Settings;
 using Octo.Services.Common;
 using Octo.Services.Local;
+using Octo.Services.Subsonic;
 using Octo.Services.YouTube;
 using IOFile = System.IO.File;
 
@@ -35,9 +36,11 @@ public class SoulseekDownloadService : BaseDownloadService
         YouTubeResolver youtube,
         ExternalIdRegistry idRegistry,
         IHttpClientFactory httpClientFactory,
+        NavidromeIdentityService navIdentity,
+        DownloadHistoryService history,
         IServiceProvider serviceProvider,
         ILogger<SoulseekDownloadService> logger)
-        : base(configuration, localLibraryService, metadataService, subsonicSettings.Value, serviceProvider, logger)
+        : base(configuration, localLibraryService, metadataService, subsonicSettings.Value, navIdentity, history, serviceProvider, logger)
     {
         _slskd = slskd;
         _settings = soulseekSettings.Value;
@@ -157,7 +160,10 @@ public class SoulseekDownloadService : BaseDownloadService
             throw new FileNotFoundException($"No YouTube match for '{routing.Artist} - {routing.Title}'");
 
         var ytArtist = SanitizeForFs(routing.Artist) ?? "Unknown Artist";
-        var ytTitle  = SanitizeForFs(routing.Title)  ?? "Unknown Title";
+        // Strip a redundant "Artist - " prefix from the title before naming the file,
+        // so a Last.fm title like "Massive Attack - Teardrop" doesn't produce
+        // "Massive Attack - Massive Attack - Teardrop.mp3".
+        var ytTitle  = SanitizeForFs(NormalizeTitle(routing.Title ?? "", routing.Artist ?? "")) ?? "Unknown Title";
         var destWithoutExt = SubsonicSettings.FolderStructure switch
         {
             Models.Settings.FolderStructure.Organized => Path.Combine(DownloadPath, ytArtist, ytTitle, $"{ytArtist} - {ytTitle}"),
@@ -273,7 +279,9 @@ public class SoulseekDownloadService : BaseDownloadService
             if (string.IsNullOrEmpty(DownloadPath) || !IOFile.Exists(currentPath)) return null;
 
             var artist = SanitizeForFs(routing.Artist) ?? "Unknown Artist";
-            var title  = SanitizeForFs(routing.Title)  ?? "Unknown Title";
+            // Same prefix cleanup as the YouTube path, so FLAC files don't double the
+            // artist ("Massive Attack - Massive Attack - Teardrop.flac").
+            var title  = SanitizeForFs(NormalizeTitle(routing.Title ?? "", routing.Artist ?? "")) ?? "Unknown Title";
             var ext    = Path.GetExtension(currentPath);
 
             string targetPath = SubsonicSettings.FolderStructure switch

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -123,6 +123,43 @@ public class SoulseekMetadataService : IMusicMetadataService
         await Task.WhenAll(tasks);
     }
 
+    // Resolve the ACTUAL YouTube video for the top of the list at search time and
+    // use its duration. Deezer's duration is a different recording (e.g. "Fade"
+    // is 3:13 on Deezer but the YouTube upload that plays is 3:45), so the scrub
+    // bar overran and the client's advance logic broke. Storing the videoId also
+    // means playback reuses this exact video (durations match) and it is prewarmed.
+    private const int TopDurationResolveLimit = 8;
+
+    public async Task ResolveTopDurationsAsync(List<Song> songs, CancellationToken ct = default)
+    {
+        var sem = new SemaphoreSlim(6);
+        var tasks = songs.Where(s => !s.IsLocal).Take(TopDurationResolveLimit).Select(async song =>
+        {
+            await sem.WaitAsync(ct);
+            try
+            {
+                // Fast metadata-only lookup (flat search, no URL solve). Pass the
+                // Deezer duration as a hint so it picks the closest-length canonical
+                // video (not a long-form/compilation upload); playback reuses the
+                // stored videoId, so the shown length matches the audio.
+                var hit = await _youtube.MetaAsync($"{song.Artist} {song.Title}", song.Duration, ct);
+                if (hit is { VideoId.Length: > 0 } && hit.Duration is int d && d > 0)
+                {
+                    song.Duration = d;
+                    var routing = _idRegistry.Lookup(song.Id);
+                    if (routing != null)
+                    {
+                        routing.YouTubeId = hit.VideoId; // playback reuses this exact video
+                        routing.Duration = d;
+                    }
+                }
+            }
+            catch { /* best-effort; keeps the existing duration on a miss */ }
+            finally { sem.Release(); }
+        });
+        await Task.WhenAll(tasks);
+    }
+
     /// <summary>
     /// Fire-and-forget background prewarm: resolve the YouTube videoId (and via
     /// shim's automatic prefetch, the stream URL) for the first <paramref name="topN"/>

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Octo.Models.Domain;
 using Octo.Models.Search;
 using Octo.Models.Subsonic;
+using Octo.Services.Metadata;
 using Octo.Services.YouTube;
 
 namespace Octo.Services.Soulseek;
@@ -24,15 +25,18 @@ public class SoulseekMetadataService : IMusicMetadataService
 
     private readonly YouTubeResolver _youtube;
     private readonly ExternalIdRegistry _idRegistry;
+    private readonly DeezerMetadataService _deezer;
     private readonly ILogger<SoulseekMetadataService> _logger;
 
     public SoulseekMetadataService(
         YouTubeResolver youtube,
         ExternalIdRegistry idRegistry,
+        DeezerMetadataService deezer,
         ILogger<SoulseekMetadataService> logger)
     {
         _youtube = youtube;
         _idRegistry = idRegistry;
+        _deezer = deezer;
         _logger = logger;
     }
 
@@ -178,11 +182,50 @@ public class SoulseekMetadataService : IMusicMetadataService
         });
     }
 
-    public Task<Album?> GetAlbumAsync(string externalProvider, string externalId)
-        => Task.FromResult<Album?>(null);
+    public async Task<Album?> GetAlbumAsync(string externalProvider, string externalId)
+    {
+        if (!string.Equals(externalProvider, ProviderName, StringComparison.OrdinalIgnoreCase)) return null;
+        var routing = _idRegistry.Lookup(externalId);
+        if (routing is null) return null;
 
-    public Task<Artist?> GetArtistAsync(string externalProvider, string externalId)
-        => Task.FromResult<Artist?>(null);
+        var placeholder = routing.Album ?? routing.Title ?? "";
+        // Enrich by the track title (the placeholder "album" is the song title) so
+        // Deezer returns the REAL album (e.g. "Creep" -> "Pablo Honey"). Degrades
+        // to the placeholder name if Deezer misses or is unreachable.
+        var meta = await _deezer.EnrichTrackAsync(routing.Artist, routing.Album ?? routing.Title);
+        var artistId = _idRegistry.Register(new SoulseekRouting { Kind = RoutingKind.Artist, Artist = routing.Artist });
+
+        return new Album
+        {
+            Id = externalId,
+            Title = meta?.AlbumTitle ?? placeholder,
+            Artist = routing.Artist ?? "",
+            ArtistId = artistId,
+            Year = meta?.Year,
+            CoverArtUrl = meta?.AlbumCoverUrl,
+            IsLocal = false,
+            ExternalProvider = ProviderName,
+            ExternalId = externalId,
+        };
+    }
+
+    public async Task<Artist?> GetArtistAsync(string externalProvider, string externalId)
+    {
+        if (!string.Equals(externalProvider, ProviderName, StringComparison.OrdinalIgnoreCase)) return null;
+        var routing = _idRegistry.Lookup(externalId);
+        if (routing is null) return null;
+
+        var meta = await _deezer.EnrichArtistAsync(routing.Artist);
+        return new Artist
+        {
+            Id = externalId,
+            Name = meta?.Name ?? routing.Artist ?? "",
+            ImageUrl = meta?.ImageUrl,
+            IsLocal = false,
+            ExternalProvider = ProviderName,
+            ExternalId = externalId,
+        };
+    }
 
     public Task<List<Album>> GetArtistAlbumsAsync(string externalProvider, string externalId)
         => Task.FromResult(new List<Album>());

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -103,7 +103,7 @@ public class SoulseekMetadataService : IMusicMetadataService
             await sem.WaitAsync(ct);
             try
             {
-                var meta = await _deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: false, ct: ct);
+                var meta = await _deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: true, ct: ct);
                 if (meta is null) return;
                 if (meta.Duration is int d && d > 0) song.Duration = d;
                 if (!string.IsNullOrWhiteSpace(meta.AlbumTitle)) song.Album = meta.AlbumTitle;

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -132,7 +132,7 @@ public class SoulseekMetadataService : IMusicMetadataService
             {
                 var routing = t.routing!;
                 if (!string.IsNullOrEmpty(routing.YouTubeId)) return;
-                var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", ct);
+                var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, ct);
                 if (hit is { VideoId: { Length: > 0 } })
                 {
                     routing.YouTubeId = hit.VideoId;

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -89,6 +89,40 @@ public class SoulseekMetadataService : IMusicMetadataService
         });
     }
 
+    // Cap Deezer calls per search so a big result set (Feishin requests up to 200)
+    // does not add seconds of latency or trip Deezer's rate limit. The visible top
+    // of the list gets real data; the rest keep the 180s fallback. Cached, so a
+    // repeat search fills in more instantly.
+    private const int SearchEnrichLimit = 60;
+
+    public async Task EnrichExternalSongsAsync(List<Song> songs, CancellationToken ct = default)
+    {
+        var sem = new SemaphoreSlim(8);
+        var tasks = songs.Where(s => !s.IsLocal).Take(SearchEnrichLimit).Select(async song =>
+        {
+            await sem.WaitAsync(ct);
+            try
+            {
+                var meta = await _deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: false, ct: ct);
+                if (meta is null) return;
+                if (meta.Duration is int d && d > 0) song.Duration = d;
+                if (!string.IsNullOrWhiteSpace(meta.AlbumTitle)) song.Album = meta.AlbumTitle;
+                if (meta.Year is int y) song.Year = y;
+
+                // Reflect onto the shared routing so getSong stays consistent.
+                var routing = _idRegistry.Lookup(song.Id);
+                if (routing != null)
+                {
+                    if (meta.Duration is int rd && rd > 0) routing.Duration = rd;
+                    if (!string.IsNullOrWhiteSpace(meta.AlbumTitle)) routing.Album = meta.AlbumTitle;
+                }
+            }
+            catch { /* best-effort; a miss just leaves the 180s fallback */ }
+            finally { sem.Release(); }
+        });
+        await Task.WhenAll(tasks);
+    }
+
     /// <summary>
     /// Fire-and-forget background prewarm: resolve the YouTube videoId (and via
     /// shim's automatic prefetch, the stream URL) for the first <paramref name="topN"/>

--- a/octo/Services/Subsonic/NavidromeIdentityService.cs
+++ b/octo/Services/Subsonic/NavidromeIdentityService.cs
@@ -1,0 +1,218 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
+
+namespace Octo.Services.Subsonic;
+
+/// <summary>
+/// Octo's own standing identity toward the upstream Navidrome. Octo is a proxy, so
+/// most requests carry the client's credentials. But background work has no client
+/// in flight: detecting where Navidrome keeps its music, and triggering a rescan
+/// after a download. This service supplies that identity two ways, in priority
+/// order:
+///   1. Configured admin creds (Subsonic:AdminUsername / AdminPassword), if set.
+///   2. Captured from traffic: when a client signs in through the relayed native
+///      POST /auth/login, we cache the returned admin JWT + subsonic salt/token.
+///
+/// From that identity it auto-detects the music folder from Navidrome's native
+/// GET /api/library, so downloads land where Navidrome actually scans no matter
+/// how the two are configured, instead of relying on a hand-kept DownloadPath that
+/// can silently drift from the server's real music directory.
+/// </summary>
+public class NavidromeIdentityService
+{
+    private readonly SubsonicSettings _settings;
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<NavidromeIdentityService> _logger;
+
+    private readonly object _lock = new();
+    private string? _jwt;
+    private string? _subsonicToken;
+    private string? _subsonicSalt;
+    private string? _username;
+
+    private string? _detectedFolder;
+    private DateTime _detectedAt;
+    private static readonly TimeSpan DetectTtl = TimeSpan.FromMinutes(30);
+    private readonly SemaphoreSlim _detectGate = new(1, 1);
+
+    public NavidromeIdentityService(
+        IOptions<SubsonicSettings> settings,
+        IHttpClientFactory httpFactory,
+        ILogger<NavidromeIdentityService> logger)
+    {
+        _settings = settings.Value;
+        _httpFactory = httpFactory;
+        _logger = logger;
+    }
+
+    /// <summary>The Navidrome music folder detected from /api/library, or null.</summary>
+    public string? DetectedMusicFolder { get { lock (_lock) return _detectedFolder; } }
+
+    /// <summary>
+    /// Effective download path: an explicit override wins, else the Navidrome-detected
+    /// music folder, else the caller's configured fallback. Auto-detect can be turned
+    /// off, in which case the configured value is always used.
+    /// </summary>
+    public string EffectiveDownloadPath(string configuredFallback)
+    {
+        if (!_settings.AutoDetectDownloadPath) return configuredFallback;
+        var d = DetectedMusicFolder;
+        return string.IsNullOrEmpty(d) ? configuredFallback : d;
+    }
+
+    /// <summary>Subsonic auth triplet (u/t/s) for authenticated Subsonic calls such
+    /// as startScan, or null if no admin identity has been captured/configured yet.</summary>
+    public (string user, string token, string salt)? GetScanAuth()
+    {
+        lock (_lock)
+        {
+            if (!string.IsNullOrEmpty(_username) && !string.IsNullOrEmpty(_subsonicToken)
+                && !string.IsNullOrEmpty(_subsonicSalt))
+                return (_username!, _subsonicToken!, _subsonicSalt!);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Cache the identity from a native login response body. Only admin logins are
+    /// kept: /api/library and startScan need admin, and a later non-admin sign-in
+    /// must not overwrite a good admin identity.
+    /// </summary>
+    public void CaptureLogin(byte[] body)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return;
+            var token = root.TryGetProperty("token", out var t) ? t.GetString() : null;
+            var isAdmin = root.TryGetProperty("isAdmin", out var a) && a.ValueKind == JsonValueKind.True;
+            if (string.IsNullOrEmpty(token) || !isAdmin) return;
+
+            lock (_lock)
+            {
+                _jwt = token;
+                _subsonicToken = root.TryGetProperty("subsonicToken", out var st) ? st.GetString() : _subsonicToken;
+                _subsonicSalt = root.TryGetProperty("subsonicSalt", out var ss) ? ss.GetString() : _subsonicSalt;
+                _username = root.TryGetProperty("username", out var u) ? u.GetString() : _username;
+            }
+            _logger.LogInformation("Captured Navidrome admin identity from login (user={User})", _username);
+            // Refresh the detected music folder in the background off the new token.
+            _ = Task.Run(() => DetectMusicFolderAsync(force: true));
+        }
+        catch { /* not a login response we understand; ignore */ }
+    }
+
+    /// <summary>
+    /// Detects Navidrome's music folder via GET /api/library. Prefers remotePath
+    /// (the path as other services see the same library) then falls back to path.
+    /// Cached with a TTL; pass force to bypass the cache.
+    /// </summary>
+    public async Task<string?> DetectMusicFolderAsync(bool force = false, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            if (!force && !string.IsNullOrEmpty(_detectedFolder) && DateTime.UtcNow - _detectedAt < DetectTtl)
+                return _detectedFolder;
+        }
+        if (string.IsNullOrEmpty(_settings.Url) || !_settings.AutoDetectDownloadPath) return null;
+
+        await _detectGate.WaitAsync(ct);
+        try
+        {
+            lock (_lock)
+            {
+                if (!force && !string.IsNullOrEmpty(_detectedFolder) && DateTime.UtcNow - _detectedAt < DetectTtl)
+                    return _detectedFolder;
+            }
+
+            var jwt = await EnsureJwtAsync(ct);
+            if (string.IsNullOrEmpty(jwt)) return null;
+
+            var http = _httpFactory.CreateClient();
+            using var req = new HttpRequestMessage(HttpMethod.Get, $"{_settings.Url!.TrimEnd('/')}/api/library");
+            req.Headers.TryAddWithoutValidation("X-Nd-Authorization", $"Bearer {jwt}");
+            using var resp = await http.SendAsync(req, ct);
+            if (resp.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                lock (_lock) _jwt = null; // captured token expired; force a fresh login next time
+                return null;
+            }
+            if (!resp.IsSuccessStatusCode) return null;
+
+            var json = await resp.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0)
+                return null;
+
+            var lib = doc.RootElement[0];
+            var remote = lib.TryGetProperty("remotePath", out var rp) ? rp.GetString() : null;
+            var path = lib.TryGetProperty("path", out var p) ? p.GetString() : null;
+            var folder = !string.IsNullOrEmpty(remote) ? remote : path;
+            if (string.IsNullOrEmpty(folder)) return null;
+
+            // Safety gate: only ADOPT the detected path if it actually exists inside
+            // Octo's own container. Navidrome reports the path as IT sees it, which is
+            // only useful to Octo when the same directory is mounted at the same path
+            // here. If it isn't (different mount, or Octo can't see it), keep the
+            // configured DownloadPath instead of silently redirecting downloads to a
+            // folder Navidrome can't read. This is what makes auto-detect safe to have
+            // on by default, including for existing installs on update.
+            if (!Directory.Exists(folder))
+            {
+                _logger.LogWarning(
+                    "Navidrome reports its music folder as '{Folder}', but that path is not " +
+                    "mounted in Octo's container — keeping the configured download path. " +
+                    "Mount '{Folder}' into Octo (or set Navidrome's remotePath) to enable auto-detect.",
+                    folder, folder);
+                return null;
+            }
+
+            lock (_lock) { _detectedFolder = folder; _detectedAt = DateTime.UtcNow; }
+            _logger.LogInformation("Detected Navidrome music folder: {Folder}", folder);
+            return folder;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Navidrome music-folder detection failed: {Msg}", ex.Message);
+            return null;
+        }
+        finally
+        {
+            _detectGate.Release();
+        }
+    }
+
+    /// <summary>Ensure a usable admin JWT: a captured one, else a fresh login with
+    /// configured admin creds. Returns the token or null when neither is available.</summary>
+    private async Task<string?> EnsureJwtAsync(CancellationToken ct)
+    {
+        lock (_lock) { if (!string.IsNullOrEmpty(_jwt)) return _jwt; }
+
+        if (string.IsNullOrEmpty(_settings.AdminUsername) || string.IsNullOrEmpty(_settings.AdminPassword)
+            || string.IsNullOrEmpty(_settings.Url))
+            return null;
+
+        try
+        {
+            var http = _httpFactory.CreateClient();
+            var payload = JsonSerializer.Serialize(new { username = _settings.AdminUsername, password = _settings.AdminPassword });
+            using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+            using var resp = await http.PostAsync($"{_settings.Url!.TrimEnd('/')}/auth/login", content, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Navidrome admin login failed: HTTP {Code}", (int)resp.StatusCode);
+                return null;
+            }
+            CaptureLogin(await resp.Content.ReadAsByteArrayAsync(ct));
+            lock (_lock) return _jwt;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Navidrome admin login error: {Msg}", ex.Message);
+            return null;
+        }
+    }
+}

--- a/octo/Services/Subsonic/SubsonicDiscoveryService.cs
+++ b/octo/Services/Subsonic/SubsonicDiscoveryService.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text.Json;
+
+namespace Octo.Services.Subsonic;
+
+/// <summary>One Subsonic-compatible server found on the local network.</summary>
+public record DiscoveredServer(string Url, string? Type, string? ServerVersion, bool RequiresAuth);
+
+/// <summary>
+/// Finds Subsonic/Navidrome servers on the local network so Octo, which is an
+/// accessory to an existing server, can auto-configure its upstream URL instead of
+/// making the user hand-type it. The probe is credential-free: a Subsonic ping to a
+/// real server returns a `{"subsonic-response":...}` envelope (even with no/bad
+/// auth, as a `code 40` failure), while a non-Subsonic host returns 404/HTML. The
+/// envelope also carries the server `type` and `serverVersion` for display.
+///
+/// Scope is the host's own /24 on a small set of well-known ports, run concurrently
+/// with short timeouts, so a full sweep takes a few seconds. Only works where Octo
+/// can see the real LAN (host networking or an LXC); in a Docker bridge network it
+/// only sees the internal subnet and will typically find nothing.
+/// </summary>
+public class SubsonicDiscoveryService
+{
+    private readonly ILogger<SubsonicDiscoveryService> _logger;
+
+    // Navidrome default is 4533; 4040 is Airsonic-Advanced; 4747/8080 are common
+    // reverse-proxy/self-host choices. Kept short so the sweep stays fast.
+    private static readonly int[] CandidatePorts = { 4533, 4040, 4747, 8080 };
+    private const int ProbeTimeoutMs = 800;
+    private const int MaxConcurrency = 96;
+
+    public SubsonicDiscoveryService(ILogger<SubsonicDiscoveryService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<List<DiscoveredServer>> ScanAsync(CancellationToken ct = default)
+    {
+        var targets = BuildTargets();
+        if (targets.Count == 0)
+        {
+            _logger.LogInformation("Server discovery: no scannable local /24 found (bridge network?).");
+            return new List<DiscoveredServer>();
+        }
+
+        _logger.LogInformation("Server discovery: probing {Hosts} hosts x {Ports} ports...",
+            targets.Count, CandidatePorts.Length);
+
+        var found = new List<DiscoveredServer>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var gate = new SemaphoreSlim(MaxConcurrency);
+        using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(ProbeTimeoutMs) };
+
+        var tasks = new List<Task>();
+        foreach (var ip in targets)
+        {
+            foreach (var port in CandidatePorts)
+            {
+                await gate.WaitAsync(ct);
+                tasks.Add(Task.Run(async () =>
+                {
+                    try
+                    {
+                        var server = await ProbeAsync(http, ip, port, ct);
+                        if (server != null)
+                        {
+                            lock (found)
+                            {
+                                if (seen.Add(server.Url)) found.Add(server);
+                            }
+                        }
+                    }
+                    catch { /* unreachable host/port; ignore */ }
+                    finally { gate.Release(); }
+                }, ct));
+            }
+        }
+
+        await Task.WhenAll(tasks);
+        _logger.LogInformation("Server discovery: found {N} Subsonic server(s).", found.Count);
+        return found.OrderBy(s => s.Url, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    /// <summary>Ping-probe one host:port. Returns a server only if it answers with a
+    /// Subsonic envelope.</summary>
+    private static async Task<DiscoveredServer?> ProbeAsync(HttpClient http, string ip, int port, CancellationToken ct)
+    {
+        var baseUrl = $"http://{ip}:{port}";
+        var url = $"{baseUrl}/rest/ping.view?c=octo&v=1.16.1&f=json";
+        using var resp = await http.GetAsync(url, ct);
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        if (!body.Contains("subsonic-response", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        string? type = null, version = null;
+        var requiresAuth = false;
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("subsonic-response", out var r))
+            {
+                if (r.TryGetProperty("type", out var t)) type = t.GetString();
+                if (r.TryGetProperty("serverVersion", out var v)) version = v.GetString();
+                // A "failed / code 40" ping is still a positive server hit — it just
+                // means it wants credentials, which the user supplies later.
+                if (r.TryGetProperty("status", out var s) && s.GetString() == "failed")
+                    requiresAuth = true;
+            }
+        }
+        catch { /* non-JSON but contained the marker; still count it */ }
+
+        return new DiscoveredServer(baseUrl, type, version, requiresAuth);
+    }
+
+    /// <summary>The host's own /24 address list (network+1 .. network+254), across
+    /// every up, non-loopback IPv4 interface. Capped at /24 so the sweep is bounded
+    /// even when the real subnet is larger.</summary>
+    private static List<string> BuildTargets()
+    {
+        var ips = new List<string>();
+        foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (nic.OperationalStatus != OperationalStatus.Up) continue;
+            if (nic.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
+
+            foreach (var ua in nic.GetIPProperties().UnicastAddresses)
+            {
+                if (ua.Address.AddressFamily != AddressFamily.InterNetwork) continue;
+                var addr = ua.Address.GetAddressBytes();
+                // Skip link-local 169.254.x.x and anything that isn't a normal LAN.
+                if (addr[0] == 169 && addr[1] == 254) continue;
+
+                // Enumerate the /24 containing this address (addr[0..2].x, 1..254).
+                for (var host = 1; host <= 254; host++)
+                {
+                    ips.Add($"{addr[0]}.{addr[1]}.{addr[2]}.{host}");
+                }
+            }
+        }
+        return ips.Distinct().ToList();
+    }
+}

--- a/octo/Services/Subsonic/SubsonicProxyService.cs
+++ b/octo/Services/Subsonic/SubsonicProxyService.cs
@@ -29,10 +29,19 @@ public class SubsonicProxyService
         string endpoint, 
         Dictionary<string, string> parameters)
     {
-        var query = string.Join("&", parameters.Select(kv => 
+        if (string.IsNullOrWhiteSpace(_subsonicSettings.Url)
+            || !Uri.TryCreate(_subsonicSettings.Url, UriKind.Absolute, out _))
+        {
+            throw new OctoNotConfiguredException(
+                "Octo has no valid Navidrome URL. Set SUBSONIC_URL (Subsonic__Url) to your " +
+                "Navidrome server, e.g. http://192.168.1.10:4533 — an absolute URL reachable " +
+                "from the Octo container, not localhost.");
+        }
+
+        var query = string.Join("&", parameters.Select(kv =>
             $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
-        var url = $"{_subsonicSettings.Url}/{endpoint}?{query}";
-        
+        var url = $"{_subsonicSettings.Url.TrimEnd('/')}/{endpoint}?{query}";
+
         HttpResponseMessage response = await _httpClient.GetAsync(url);
         response.EnsureSuccessStatusCode();
         
@@ -147,4 +156,14 @@ public class SubsonicProxyService
             };
         }
     }
+}
+
+/// <summary>
+/// Thrown when Octo's upstream Navidrome URL is missing or not an absolute URL.
+/// The global handler surfaces its message to the client as an actionable
+/// Subsonic error instead of an opaque "Invalid request".
+/// </summary>
+public class OctoNotConfiguredException : Exception
+{
+    public OctoNotConfiguredException(string message) : base(message) { }
 }

--- a/octo/Services/Subsonic/SubsonicProxyService.cs
+++ b/octo/Services/Subsonic/SubsonicProxyService.cs
@@ -52,6 +52,50 @@ public class SubsonicProxyService
     }
 
     /// <summary>
+    /// Faithful relay: forwards the caller's HTTP method + body + content-type and
+    /// returns the upstream status verbatim (no EnsureSuccessStatusCode). This is
+    /// what makes non-GET / body-carrying endpoints work through Octo — e.g.
+    /// Navidrome's native POST /auth/login that some clients use to sign in.
+    /// Requires request buffering (enabled in Program.cs) so the body is re-readable.
+    /// </summary>
+    public async Task<(int Status, byte[] Body, string? ContentType)> RelayRawAsync(
+        string endpoint,
+        Dictionary<string, string> parameters)
+    {
+        if (string.IsNullOrWhiteSpace(_subsonicSettings.Url)
+            || !Uri.TryCreate(_subsonicSettings.Url, UriKind.Absolute, out _))
+        {
+            throw new OctoNotConfiguredException(
+                "Octo has no valid Navidrome URL. Set SUBSONIC_URL (Subsonic__Url) to your " +
+                "Navidrome server, e.g. http://192.168.1.10:4533 — an absolute URL reachable " +
+                "from the Octo container, not localhost.");
+        }
+
+        var query = string.Join("&", parameters.Select(kv =>
+            $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
+        var url = $"{_subsonicSettings.Url.TrimEnd('/')}/{endpoint}?{query}";
+
+        var ctx = _httpContextAccessor.HttpContext;
+        var incoming = ctx?.Request;
+        var method = incoming?.Method ?? "GET";
+        using var req = new HttpRequestMessage(new HttpMethod(method), url);
+
+        // Forward the raw request body captured by the middleware (the live body
+        // stream is already closed by parameter extraction at this point).
+        if (ctx?.Items.TryGetValue("Octo.RawBody", out var rb) == true
+            && rb is byte[] bytes && bytes.Length > 0)
+        {
+            req.Content = new ByteArrayContent(bytes);
+            if (!string.IsNullOrEmpty(incoming?.ContentType))
+                req.Content.Headers.TryAddWithoutValidation("Content-Type", incoming.ContentType);
+        }
+
+        using var response = await _httpClient.SendAsync(req);
+        var body = await response.Content.ReadAsByteArrayAsync();
+        return ((int)response.StatusCode, body, response.Content.Headers.ContentType?.ToString());
+    }
+
+    /// <summary>
     /// Safely relays a request to the Subsonic server, returning null on failure.
     /// </summary>
     public async Task<(byte[]? Body, string? ContentType, bool Success)> RelaySafeAsync(

--- a/octo/Services/Subsonic/SubsonicProxyService.cs
+++ b/octo/Services/Subsonic/SubsonicProxyService.cs
@@ -58,7 +58,21 @@ public class SubsonicProxyService
     /// Navidrome's native POST /auth/login that some clients use to sign in.
     /// Requires request buffering (enabled in Program.cs) so the body is re-readable.
     /// </summary>
-    public async Task<(int Status, byte[] Body, string? ContentType)> RelayRawAsync(
+    // Headers forwarded to Navidrome so its native /api/* endpoints (used by
+    // Navidrome-mode clients like Feishin) authenticate and behave correctly.
+    private static readonly string[] ForwardRequestHeaders =
+    {
+        "Authorization", "X-Nd-Client-Unique-Id", "X-Nd-Authorization",
+        "Accept", "User-Agent", "If-None-Match", "If-Modified-Since", "Range",
+    };
+    // Response headers passed back to the client (notably the rotated ND token).
+    private static readonly string[] ForwardResponseHeaders =
+    {
+        "X-Nd-Authorization", "ETag", "Last-Modified", "Cache-Control",
+        "Content-Range", "Accept-Ranges", "Vary",
+    };
+
+    public async Task<RawRelayResult> RelayRawAsync(
         string endpoint,
         Dictionary<string, string> parameters)
     {
@@ -90,9 +104,27 @@ public class SubsonicProxyService
                 req.Content.Headers.TryAddWithoutValidation("Content-Type", incoming.ContentType);
         }
 
+        // Forward auth + conditional headers so native Navidrome endpoints work.
+        if (incoming != null)
+        {
+            foreach (var h in ForwardRequestHeaders)
+                if (incoming.Headers.TryGetValue(h, out var vals))
+                    req.Headers.TryAddWithoutValidation(h, vals.ToArray());
+        }
+
         using var response = await _httpClient.SendAsync(req);
         var body = await response.Content.ReadAsByteArrayAsync();
-        return ((int)response.StatusCode, body, response.Content.Headers.ContentType?.ToString());
+
+        var respHeaders = new List<KeyValuePair<string, string>>();
+        foreach (var h in ForwardResponseHeaders)
+        {
+            if (response.Headers.TryGetValues(h, out var v) ||
+                response.Content.Headers.TryGetValues(h, out v))
+                foreach (var val in v) respHeaders.Add(new(h, val));
+        }
+
+        return new RawRelayResult((int)response.StatusCode, body,
+            response.Content.Headers.ContentType?.ToString(), respHeaders);
     }
 
     /// <summary>
@@ -211,3 +243,7 @@ public class OctoNotConfiguredException : Exception
 {
     public OctoNotConfiguredException(string message) : base(message) { }
 }
+
+/// <summary>Result of a faithful (method/body/status/header-preserving) relay.</summary>
+public record RawRelayResult(
+    int Status, byte[] Body, string? ContentType, List<KeyValuePair<string, string>> ResponseHeaders);

--- a/octo/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -44,6 +44,35 @@ public class SubsonicResponseBuilder
     }
 
     /// <summary>
+    /// Creates an ok response with a single element carrying string child fields,
+    /// in BOTH json and xml (unlike CreateResponse, which emits an empty element).
+    /// Used for albumInfo/artistInfo2 so the data survives regardless of format.
+    /// </summary>
+    public IActionResult CreateInfoResponse(string format, string elementName, Dictionary<string, string> fields)
+    {
+        if (format == "json")
+        {
+            return CreateJsonResponse(new Dictionary<string, object>
+            {
+                ["status"] = "ok",
+                ["version"] = SubsonicVersion,
+                [elementName] = fields.ToDictionary(kv => kv.Key, kv => (object)kv.Value),
+            });
+        }
+
+        var ns = XNamespace.Get(SubsonicNamespace);
+        var el = new XElement(ns + elementName);
+        foreach (var f in fields)
+            el.Add(new XElement(ns + f.Key, f.Value));
+        var doc = new XDocument(
+            new XElement(ns + "subsonic-response",
+                new XAttribute("status", "ok"),
+                new XAttribute("version", SubsonicVersion),
+                el));
+        return new ContentResult { Content = doc.ToString(), ContentType = "application/xml" };
+    }
+
+    /// <summary>
     /// Creates a Subsonic error response.
     /// </summary>
     public IActionResult CreateError(string format, int code, string message)

--- a/octo/Services/YouTube/YouTubeResolver.cs
+++ b/octo/Services/YouTube/YouTubeResolver.cs
@@ -64,6 +64,39 @@ public class YouTubeResolver
     }
 
     /// <summary>
+    /// Fast metadata-only lookup via the shim's /meta (flat search, no URL
+    /// resolution). Returns the top video's id + duration for showing an accurate
+    /// length without paying the full /search extraction.
+    /// </summary>
+    public async Task<YouTubeHit?> MetaAsync(string query, int? durationHint = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return null;
+        var url = $"{_baseUrl}/meta?q={Uri.EscapeDataString(query)}"
+            + (durationHint is int dh && dh > 0 ? $"&duration={dh}" : "");
+        try
+        {
+            var http = _httpClientFactory.CreateClient(SearchClientName);
+            using var resp = await http.GetAsync(url, ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            var json = await resp.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var vid = root.TryGetProperty("video_id", out var v) ? v.GetString() : null;
+            if (string.IsNullOrEmpty(vid)) return null;
+            return new YouTubeHit
+            {
+                VideoId = vid,
+                Title = root.TryGetProperty("title", out var t) ? t.GetString() : null,
+                Duration = root.TryGetProperty("duration", out var d) && d.ValueKind == JsonValueKind.Number ? d.GetInt32() : null,
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Opens a streaming connection to the shim's /stream endpoint. The shim
     /// proxies bytes from YouTube's CDN to us; we hand the resulting stream
     /// off to ASP.NET which forwards it to the Subsonic client.

--- a/octo/Services/YouTube/YouTubeResolver.cs
+++ b/octo/Services/YouTube/YouTubeResolver.cs
@@ -119,6 +119,39 @@ public class YouTubeResolver
             return null;
         }
     }
+
+    /// <summary>
+    /// Downloads a YouTube video as MP3 to {destWithoutExt}.mp3 via the shim's
+    /// /download endpoint, passing clean artist/title so the file is tagged for
+    /// the library. Returns the saved path, or null on failure. Uses the
+    /// infinite-timeout stream client because a download can take a while.
+    /// </summary>
+    public async Task<string?> DownloadAsync(string videoId, string destWithoutExt,
+        string? artist = null, string? title = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(videoId) || string.IsNullOrWhiteSpace(destWithoutExt)) return null;
+        var url = $"{_baseUrl}/download?id={Uri.EscapeDataString(videoId)}&dest={Uri.EscapeDataString(destWithoutExt)}"
+            + (string.IsNullOrEmpty(artist) ? "" : $"&artist={Uri.EscapeDataString(artist)}")
+            + (string.IsNullOrEmpty(title) ? "" : $"&title={Uri.EscapeDataString(title)}");
+        try
+        {
+            var http = _httpClientFactory.CreateClient(StreamClientName);
+            using var resp = await http.GetAsync(url, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("shim /download HTTP {Code} for vid={Vid}", (int)resp.StatusCode, videoId);
+                return null;
+            }
+            var json = await resp.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.TryGetProperty("path", out var p) ? p.GetString() : null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("shim /download failed for {Vid}: {Msg}", videoId, ex.Message);
+            return null;
+        }
+    }
 }
 
 public class YouTubeHit

--- a/octo/Services/YouTube/YouTubeResolver.cs
+++ b/octo/Services/YouTube/YouTubeResolver.cs
@@ -29,10 +29,11 @@ public class YouTubeResolver
     /// <summary>
     /// Resolves "Artist - Title" to a single best YouTube hit via the shim.
     /// </summary>
-    public async Task<YouTubeHit?> SearchAsync(string query, CancellationToken ct = default)
+    public async Task<YouTubeHit?> SearchAsync(string query, int? durationHint = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query)) return null;
-        var url = $"{_baseUrl}/search?q={Uri.EscapeDataString(query)}";
+        var url = $"{_baseUrl}/search?q={Uri.EscapeDataString(query)}"
+            + (durationHint is int dh && dh > 0 ? $"&duration={dh}" : "");
         try
         {
             var http = _httpClientFactory.CreateClient(SearchClientName);

--- a/octo/wwwroot/admin/admin.css
+++ b/octo/wwwroot/admin/admin.css
@@ -11,33 +11,33 @@
  */
 
 :root {
-  /* Surfaces */
-  --bg-0: #0b0d10;        /* page */
-  --bg-1: #111418;        /* sidebar */
-  --bg-2: #161a20;        /* card */
-  --bg-3: #1c2128;        /* card-hover, input bg */
-  --bg-4: #242a33;        /* input focus, hovered chip */
+  /* Surfaces — near-black base with a faint blue-gray (Winters' Glass) cast */
+  --bg-0: #0c0c0d;        /* page */
+  --bg-1: #0e1012;        /* sidebar */
+  --bg-2: #14181a;        /* card */
+  --bg-3: #191f22;        /* card-hover, input bg */
+  --bg-4: #222a2e;        /* input focus, hovered chip */
 
-  /* Borders */
-  --border:        rgba(255, 255, 255, 0.07);
-  --border-strong: rgba(255, 255, 255, 0.12);
+  /* Borders — the accent, held at low alpha (translucent, not hard lines) */
+  --border:        rgba(151, 177, 185, 0.12);
+  --border-strong: rgba(151, 177, 185, 0.22);
 
-  /* Text */
-  --fg:       #e6e8eb;
-  --fg-soft:  #b8bdc7;
-  --fg-mute:  #8a909a;
-  --fg-faint: #5a606b;
+  /* Text — the signature blue-gray carries secondary/muted */
+  --fg:       #f2f5f6;
+  --fg-soft:  #97b1b9;
+  --fg-mute:  rgba(151, 177, 185, 0.62);
+  --fg-faint: rgba(151, 177, 185, 0.40);
 
-  /* Accents */
-  --accent:        #6366f1;
-  --accent-hover:  #7c7fea;
-  --accent-soft:   rgba(99, 102, 241, 0.15);
-  --accent-ring:   rgba(99, 102, 241, 0.45);
+  /* Accent — Winters' blue-gray */
+  --accent:        #97b1b9;
+  --accent-hover:  #adc4cc;
+  --accent-soft:   rgba(151, 177, 185, 0.14);
+  --accent-ring:   rgba(151, 177, 185, 0.30);
 
   /* Status */
-  --good: #34d399;  --good-glow: rgba(52, 211, 153, 0.18);
-  --bad:  #f87171;  --bad-glow:  rgba(248, 113, 113, 0.18);
-  --warn: #fbbf24;  --warn-glow: rgba(251, 191, 36, 0.18);
+  --good: #22c55e;  --good-glow: rgba(34, 197, 94, 0.16);
+  --bad:  #ef4444;  --bad-glow:  rgba(239, 68, 68, 0.16);
+  --warn: #eab308;  --warn-glow: rgba(234, 179, 8, 0.16);
 
   /* Radii / motion */
   --r-1: 6px; --r-2: 8px; --r-3: 12px;
@@ -130,7 +130,7 @@ img { display: block; }
   /* If the logo's a transparent PNG, sit it on a subtle gradient so it
      doesn't disappear into the sidebar background on lighter palettes. */
   background:
-    radial-gradient(circle at 30% 30%, rgba(99,102,241,0.22), transparent 70%),
+    radial-gradient(circle at 30% 30%, rgba(151,177,185,0.22), transparent 70%),
     var(--bg-3);
   padding: 2px;
 }
@@ -206,7 +206,7 @@ img { display: block; }
   display: none;
 }
 .sidebar-nav-badge.bad   { display: inline; background: var(--bad-glow);  color: var(--bad); }
-.sidebar-nav-badge.good  { display: inline; background: rgba(52,211,153,0.15); color: var(--good); }
+.sidebar-nav-badge.good  { display: inline; background: rgba(34,197,94,0.15); color: var(--good); }
 
 .sidebar-footer {
   padding: 12px;
@@ -216,9 +216,9 @@ img { display: block; }
 /* ─── Content ────────────────────────────────────────────────── */
 .content {
   padding: 56px 64px 96px;
-  max-width: 960px;
+  max-width: 920px;
   width: 100%;
-  margin: 0;
+  margin: 0 auto;
   overflow-x: hidden;
 }
 
@@ -275,7 +275,8 @@ section[data-pane].active { display: block; }
 }
 .btn-primary {
   background: var(--accent);
-  color: white;
+  color: #0c0c0d;
+  font-weight: 600;
 }
 .btn-primary:hover { background: var(--accent-hover); }
 .btn-primary:active { transform: translateY(0.5px); }
@@ -373,13 +374,21 @@ section[data-pane].active { display: block; }
 .status-meta-time  { font-variant-numeric: tabular-nums; }
 
 /* ─── Settings card ──────────────────────────────────────────── */
+/* Winters' Glass surface: a faint accent-tinted panel over the dark page, a
+   1px translucent accent border, and a soft inset top-highlight for the bevel.
+   No outer glow — depth comes from the inset light edge, not a halo. */
 .settings-card,
 .info-card {
-  background: var(--bg-2);
+  background:
+    linear-gradient(var(--accent-soft), var(--accent-soft)),
+    var(--bg-2);
   border: 1px solid var(--border);
   border-radius: var(--r-3);
   padding: 32px 36px;
   margin-bottom: 24px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    var(--elev-1);
 }
 .settings-card-title,
 .info-card-title {
@@ -480,7 +489,7 @@ section[data-pane].active { display: block; }
 .field select {
   appearance: none;
   background-image:
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'><path d='M3 4.5l3 3 3-3' stroke='%238a909a' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'><path d='M3 4.5l3 3 3-3' stroke='%2397b1b9' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   background-repeat: no-repeat;
   background-position: right 12px center;
   padding-right: 32px;
@@ -696,3 +705,231 @@ section[data-pane].active { display: block; }
   .page-header { flex-direction: column; align-items: stretch; gap: 8px; }
   .field-row { grid-template-columns: 1fr; }
 }
+
+/* Server detection (Subsonic URL field) */
+.field-inline { display: flex; gap: 8px; align-items: stretch; }
+.field-inline input { flex: 1 1 auto; min-width: 0; }
+.field-inline .btn { flex: 0 0 auto; white-space: nowrap; }
+.detect-result {
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg-mute);
+}
+.detect-result code { font-size: 12px; }
+.detect-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+.detect-pick { justify-content: space-between; text-align: left; }
+.detect-tag { color: var(--fg-mute); font-size: 12px; }
+
+/* Inline notice banner (e.g. discovery-off warning) */
+.notice {
+  padding: 12px 14px;
+  border-radius: var(--r-2);
+  font-size: 13px;
+  line-height: 1.55;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.notice a { color: var(--accent-hover); }
+.notice-warn {
+  border-color: rgba(251, 191, 36, 0.35);
+  background: rgba(251, 191, 36, 0.08);
+  color: var(--fg-soft);
+}
+.notice-warn strong { color: var(--warn); }
+
+/* Setup callout — "point your apps at Octo" (Status pane) */
+.callout {
+  border-radius: var(--r-3);
+  padding: 20px 22px;
+  margin-bottom: 32px;
+  border: 1px solid var(--border);
+  background:
+    linear-gradient(var(--accent-soft), var(--accent-soft)),
+    var(--bg-2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+.callout-accent { border-color: var(--accent-soft); border-left: 2px solid var(--accent); }
+.callout-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 8px;
+}
+.callout p { margin: 0 0 10px; color: var(--fg-soft); font-size: 13.5px; line-height: 1.6; }
+.callout p:last-child { margin-bottom: 0; }
+.callout strong { color: var(--fg); }
+.callout-fine { color: var(--fg-mute) !important; font-size: 12.5px !important; }
+.callout-address {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 12px 0;
+}
+.callout-address code {
+  font-size: 14px;
+  padding: 8px 12px;
+  background: var(--bg-0);
+  border: 1px solid var(--border);
+  color: var(--accent-hover);
+  letter-spacing: 0.01em;
+}
+
+/* ══════════════════════════════════════════════════════════════ */
+/*  Settings design system (StreamNook "Winters' Glass" patterns)   */
+/*  Section header ABOVE a faint slab card; horizontal rows with     */
+/*  info on the left and the control on the right; sliding toggles   */
+/*  and segmented controls instead of checkboxes and dropdowns.      */
+/* ══════════════════════════════════════════════════════════════ */
+.set-section { margin-bottom: 30px; }
+.set-head { padding: 0 4px 10px; }
+.set-title {
+  margin: 0;
+  font-size: 12px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.13em;
+  color: var(--fg);
+}
+.set-desc { margin: 4px 0 0; font-size: 12px; color: var(--fg-mute); line-height: 1.5; }
+
+/* Faint slab card — depth from the fill + hairlines, not a heavy border. */
+.set-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  overflow: hidden;
+}
+
+.set-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 15px 18px;
+  transition: background var(--t-fast);
+}
+.set-row:hover { background: rgba(255, 255, 255, 0.035); }
+.set-row + .set-row { border-top: 1px solid rgba(151, 177, 185, 0.08); }
+.set-row.stack { flex-direction: column; align-items: stretch; gap: 12px; }
+
+.set-info { min-width: 0; }
+.set-info-t { font-size: 13px; font-weight: 500; color: var(--fg); }
+.set-info-d { margin-top: 3px; font-size: 12px; color: var(--fg-soft); line-height: 1.5; max-width: 52ch; }
+.set-opt { color: var(--fg-faint); font-weight: 400; }
+.set-ctrl { flex-shrink: 0; display: flex; align-items: center; gap: 8px; }
+
+.set-input {
+  width: 100%;
+  background: var(--bg-3);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  padding: 10px 13px;
+  font-size: 13.5px;
+  font-variant-numeric: tabular-nums;
+  outline: none;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+.set-input::placeholder { color: var(--fg-faint); }
+.set-input:hover { border-color: var(--border-strong); }
+.set-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-ring); }
+.set-inline { display: flex; gap: 8px; }
+.set-inline .set-input { flex: 1 1 auto; min-width: 0; }
+.set-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+/* ── Sliding toggle switch ── */
+.switch { position: relative; display: inline-block; width: 42px; height: 24px; flex-shrink: 0; cursor: pointer; }
+.switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+.sw-track {
+  position: absolute; inset: 0; border-radius: 999px;
+  background: rgba(151, 177, 185, 0.18);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
+  transition: background var(--t-med);
+}
+.sw-thumb {
+  position: absolute; top: 3px; left: 3px; width: 18px; height: 18px; border-radius: 50%;
+  background: #cdd8dc;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  transition: transform 200ms cubic-bezier(.34, 1.4, .5, 1), background var(--t-med);
+}
+.switch input:checked ~ .sw-track { background: var(--accent); }
+.switch input:checked ~ .sw-thumb { transform: translateX(18px); background: #0c0c0d; }
+.switch input:focus-visible ~ .sw-track { outline: 2px solid var(--accent-hover); outline-offset: 2px; }
+
+/* ── Segmented control (recessed track + sliding thumb) ── */
+.seg {
+  position: relative; display: inline-flex; gap: 2px; padding: 3px; border-radius: 9px;
+  background: rgba(151, 177, 185, 0.06);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.32), inset 0 0 0 1px rgba(151, 177, 185, 0.12);
+}
+.seg-thumb {
+  position: absolute; top: 3px; bottom: 3px; border-radius: 7px;
+  background: rgba(151, 177, 185, 0.16);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.22), inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  transition: left 280ms cubic-bezier(.34, 1.4, .5, 1), width 280ms cubic-bezier(.34, 1.4, .5, 1), opacity 140ms;
+  z-index: 0; opacity: 0;
+}
+.seg button {
+  position: relative; z-index: 1; border: none; background: transparent; cursor: pointer;
+  font: inherit; font-size: 12.5px; font-weight: 500; padding: 6px 13px; border-radius: 7px;
+  color: var(--fg-mute); transition: color var(--t-fast); white-space: nowrap;
+}
+.seg button:hover { color: var(--fg-soft); }
+.seg button.active { color: var(--fg); }
+
+/* Save bar as a proper footer inside the slab card (rows have no padding of
+   their own, so the injected .form-actions needs its own to line up). */
+.set-card .form-actions {
+  margin-top: 0;
+  padding: 13px 18px;
+  border-top: 1px solid rgba(151, 177, 185, 0.10);
+  background: rgba(151, 177, 185, 0.03);
+  gap: 14px;
+}
+.set-card .form-actions .btn-primary {
+  padding: 7px 18px;
+}
+
+/* ── Fetched songs (download log) ── */
+.dl-list {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  overflow: hidden;
+}
+.dl-empty { padding: 40px 20px; text-align: center; color: var(--fg-mute); font-size: 13.5px; }
+.dl-item {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 16px;
+  transition: background var(--t-fast);
+}
+.dl-item:hover { background: rgba(255, 255, 255, 0.035); }
+.dl-item + .dl-item { border-top: 1px solid rgba(151, 177, 185, 0.08); }
+.dl-art {
+  width: 46px; height: 46px; border-radius: var(--r-2); flex-shrink: 0;
+  object-fit: cover; background: var(--bg-3); border: 1px solid var(--border);
+}
+.dl-art-ph {
+  background:
+    radial-gradient(circle at 35% 30%, rgba(151,177,185,0.22), transparent 70%),
+    var(--bg-3);
+}
+.dl-main { min-width: 0; flex: 1; }
+.dl-title { font-size: 13.5px; font-weight: 500; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dl-dash { color: var(--fg-faint); }
+.dl-path {
+  font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  font-size: 11.5px; color: var(--fg-mute);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  margin-top: 3px; direction: rtl; text-align: left;
+}
+.dl-side { flex-shrink: 0; display: flex; flex-direction: column; align-items: flex-end; gap: 5px; }
+.dl-tags { display: flex; align-items: center; gap: 7px; }
+.dl-badge {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.04em;
+  padding: 2px 7px; border-radius: var(--r-1); text-transform: uppercase;
+}
+.dl-badge.flac { background: rgba(34, 197, 94, 0.14); color: var(--good); }
+.dl-badge.mp3  { background: rgba(151, 177, 185, 0.14); color: var(--accent-hover); }
+.dl-source { font-size: 12px; color: var(--fg-soft); }
+.dl-sub { font-size: 11.5px; color: var(--fg-mute); font-variant-numeric: tabular-nums; }

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -10,6 +10,9 @@ function activateTab(name) {
   navItems.forEach(b => b.classList.toggle('active', b.dataset.tab === name));
   panes.forEach(p => p.classList.toggle('active', p.dataset.pane === name));
   if (location.hash !== `#${name}`) location.hash = name;
+  // Segmented thumbs can only be measured once their pane is visible.
+  if (typeof syncSegments === 'function') syncSegments(false);
+  if (name === 'fetched' && typeof loadFetched === 'function') loadFetched();
 }
 
 navItems.forEach(btn => btn.addEventListener('click', () => activateTab(btn.dataset.tab)));
@@ -121,6 +124,10 @@ async function loadSettings() {
     slskdLink.href = `${here.protocol}//${here.hostname}:5030`;
     slskdLink.textContent = `${here.hostname}:5030`;
   }
+
+  updateDiscoveryBanner();
+  buildSegments();
+  syncSegments(false);
 
   // Initial dirty-check pass: all forms start clean.
   document.querySelectorAll('form[data-section]').forEach(form => {
@@ -381,6 +388,183 @@ document.getElementById('restart-btn').addEventListener('click', async () => {
   btn.disabled = false;
   if (label) label.textContent = 'Restart';
 });
+
+// ────────────────────────────────────────────────────────────────
+// Discovery-off banner: loud when no Last.fm key is set
+// ────────────────────────────────────────────────────────────────
+function updateDiscoveryBanner() {
+  const banner = document.getElementById('discovery-off-banner');
+  const keyInput = document.getElementById('f-lastfm-key');
+  if (!banner || !keyInput) return;
+  banner.hidden = !!keyInput.value.trim();
+}
+document.getElementById('f-lastfm-key')?.addEventListener('input', updateDiscoveryBanner);
+
+// ────────────────────────────────────────────────────────────────
+// Detect Subsonic/Navidrome server on the local network
+// ────────────────────────────────────────────────────────────────
+const detectBtn = document.getElementById('btn-detect-server');
+detectBtn?.addEventListener('click', async () => {
+  const urlInput = document.getElementById('f-subsonic-url');
+  const result = document.getElementById('detect-server-result');
+  detectBtn.disabled = true;
+  const original = detectBtn.textContent;
+  detectBtn.textContent = 'Scanning…';
+  if (result) { result.hidden = false; result.textContent = 'Scanning the local network…'; }
+  try {
+    const r = await fetch('/api/admin/discover-servers', { cache: 'no-store' });
+    const data = await r.json();
+    const servers = data.servers || [];
+    if (!servers.length) {
+      if (result) result.innerHTML =
+        'No server found on this network. If Octo runs in a Docker bridge network it cannot see your LAN — use host networking, or enter the URL manually.';
+    } else if (servers.length === 1) {
+      urlInput.value = servers[0].url;
+      urlInput.dispatchEvent(new Event('input', { bubbles: true }));
+      if (result) result.innerHTML =
+        `Found <strong>${servers[0].type || 'Subsonic'}</strong> ${servers[0].serverVersion || ''} at <code>${servers[0].url}</code> — filled in above. Save to apply.`;
+    } else {
+      const rows = servers.map(s =>
+        `<button type="button" class="btn btn-ghost detect-pick" data-url="${s.url}">${s.url} <span class="detect-tag">${s.type || 'subsonic'} ${s.serverVersion || ''}</span></button>`).join('');
+      if (result) result.innerHTML = `Found ${servers.length} servers — pick one:<div class="detect-list">${rows}</div>`;
+      result.querySelectorAll('.detect-pick').forEach(b =>
+        b.addEventListener('click', () => {
+          urlInput.value = b.dataset.url;
+          urlInput.dispatchEvent(new Event('input', { bubbles: true }));
+          if (typeof toast === 'function') toast('URL filled in — Save to apply.', 'ok');
+        }));
+    }
+  } catch (e) {
+    if (result) result.textContent = 'Scan failed: ' + (e?.message || 'unknown error');
+  } finally {
+    detectBtn.disabled = false;
+    detectBtn.textContent = original;
+  }
+});
+
+// ────────────────────────────────────────────────────────────────
+// Fetched songs — running download log
+// ────────────────────────────────────────────────────────────────
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+function relTime(iso) {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  const s = Math.max(0, (Date.now() - t) / 1000);
+  if (s < 60) return 'just now';
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  if (s < 604800) return `${Math.floor(s / 86400)}d ago`;
+  return new Date(t).toLocaleDateString();
+}
+function fmtSize(bytes) {
+  if (!bytes) return '';
+  const mb = bytes / 1048576;
+  return mb >= 1 ? `${mb.toFixed(1)} MB` : `${Math.round(bytes / 1024)} KB`;
+}
+async function loadFetched() {
+  const list = document.getElementById('fetched-list');
+  if (!list) return;
+  try {
+    const r = await fetch('/api/admin/downloads', { cache: 'no-store' });
+    const data = await r.json();
+    const items = data.downloads || [];
+    if (!items.length) {
+      list.innerHTML = '<div class="dl-empty">No downloads yet. Star a song in your music app and it will appear here.</div>';
+      return;
+    }
+    list.innerHTML = items.map(d => {
+      const fmt = (d.format || '?').toUpperCase();
+      const badgeClass = fmt === 'FLAC' ? 'flac' : 'mp3';
+      const art = d.coverArtUrl
+        ? `<img class="dl-art" src="${escapeHtml(d.coverArtUrl)}" alt="" loading="lazy" onerror="this.replaceWith(Object.assign(document.createElement('div'),{className:'dl-art dl-art-ph'}))">`
+        : `<div class="dl-art dl-art-ph"></div>`;
+      const size = fmtSize(d.sizeBytes);
+      return `<div class="dl-item">
+        ${art}
+        <div class="dl-main">
+          <div class="dl-title">${escapeHtml(d.artist)} <span class="dl-dash">—</span> ${escapeHtml(d.title)}</div>
+          <div class="dl-path" title="${escapeHtml(d.path)}">${escapeHtml(d.path)}</div>
+        </div>
+        <div class="dl-side">
+          <div class="dl-tags"><span class="dl-badge ${badgeClass}">${escapeHtml(fmt)}</span><span class="dl-source">${escapeHtml(d.source)}</span></div>
+          <div class="dl-sub">${escapeHtml(relTime(d.downloadedAt))}${size ? ' · ' + size : ''}</div>
+        </div>
+      </div>`;
+    }).join('');
+  } catch (e) {
+    list.innerHTML = `<div class="dl-empty">Couldn't load the log: ${escapeHtml(e.message || 'error')}</div>`;
+  }
+}
+document.getElementById('fetched-refresh')?.addEventListener('click', loadFetched);
+
+// ────────────────────────────────────────────────────────────────
+// Segmented controls — buttons built from a hidden <select> they proxy to,
+// so the load/save logic keeps reading the select's name + value.
+// ────────────────────────────────────────────────────────────────
+function buildSegments() {
+  document.querySelectorAll('.seg[data-seg-for]').forEach(seg => {
+    if (seg.dataset.built) return;
+    const sel = document.getElementById(seg.dataset.segFor);
+    if (!sel) return;
+    Array.from(sel.options).forEach(opt => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.textContent = opt.textContent;
+      b.dataset.value = opt.value;
+      b.addEventListener('click', () => {
+        sel.value = opt.value;
+        sel.dispatchEvent(new Event('input', { bubbles: true }));
+        sel.dispatchEvent(new Event('change', { bubbles: true }));
+        syncSegment(seg, true);
+      });
+      seg.appendChild(b);
+    });
+    seg.dataset.built = '1';
+  });
+}
+function syncSegment(seg, animate) {
+  const sel = document.getElementById(seg.dataset.segFor);
+  if (!sel) return;
+  const thumb = seg.querySelector('.seg-thumb');
+  let active = null;
+  seg.querySelectorAll('button').forEach(b => {
+    const on = b.dataset.value === sel.value;
+    b.classList.toggle('active', on);
+    if (on) active = b;
+  });
+  if (active && thumb && active.offsetWidth) {
+    if (!animate) thumb.style.transition = 'none';
+    thumb.style.left = active.offsetLeft + 'px';
+    thumb.style.width = active.offsetWidth + 'px';
+    thumb.style.opacity = '1';
+    if (!animate) requestAnimationFrame(() => { thumb.style.transition = ''; });
+  }
+}
+function syncSegments(animate) {
+  document.querySelectorAll('.seg[data-seg-for]').forEach(s => syncSegment(s, animate));
+}
+buildSegments();
+window.addEventListener('resize', () => syncSegments(false));
+
+// ────────────────────────────────────────────────────────────────
+// "Point your apps at Octo" address + copy
+// ────────────────────────────────────────────────────────────────
+(function initOctoAddress() {
+  const el = document.getElementById('octo-address');
+  if (!el) return;
+  const here = new URL(location.href);
+  const addr = `${here.protocol}//${here.hostname}:${here.port || '5274'}`;
+  el.textContent = addr;
+  document.getElementById('copy-octo-address')?.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(addr);
+      if (typeof toast === 'function') toast('Address copied.', 'ok');
+    } catch { /* clipboard blocked; user can select manually */ }
+  });
+})();
 
 // ────────────────────────────────────────────────────────────────
 // Boot

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -35,6 +35,12 @@
             <span>Status</span>
             <span class="sidebar-nav-badge" data-status-badge></span>
           </button>
+          <button class="sidebar-nav-item" data-tab="fetched">
+            <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M2 4.5v7a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-7"/><path d="M8 2v6.5m0 0L5.5 6M8 8.5 10.5 6"/>
+            </svg>
+            <span>Fetched songs</span>
+          </button>
         </div>
 
         <div class="sidebar-nav-section">
@@ -131,6 +137,21 @@
           </button>
         </header>
 
+        <div class="callout callout-accent" id="point-at-octo">
+          <div class="callout-title">Point your music apps here, not at Navidrome</div>
+          <p>
+            Octo sits in front of Navidrome. In Feishin, Symfonium, Arpeggi, or any Subsonic app,
+            set the <strong>server address</strong> to Octo:
+          </p>
+          <div class="callout-address"><code id="octo-address">http://this-host:5274</code>
+            <button type="button" class="btn btn-ghost" id="copy-octo-address">Copy</button>
+          </div>
+          <p class="callout-fine">
+            Use your Subsonic username and password as usual. If an app points straight at Navidrome
+            it bypasses Octo, and discovery and download-on-star won't work.
+          </p>
+        </div>
+
         <div class="status-grid" id="status-grid">
           <article class="status-card" data-svc="octo">
             <div class="status-card-head">
@@ -180,6 +201,22 @@
         </div>
       </section>
 
+      <!-- ─── FETCHED SONGS ──────────────────────────────────── -->
+      <section data-pane="fetched">
+        <header class="page-header">
+          <div>
+            <h1>Fetched songs</h1>
+            <p>A running log of every song Octo has pulled into your library, newest first. Each one is tagged with real album metadata and cover art on the way in. See its source, format, save path, size, and when it landed.</p>
+          </div>
+          <button class="btn btn-ghost" id="fetched-refresh" aria-label="Refresh">
+            <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9"/><path d="M13.5 2v3h-3"/>
+            </svg>
+          </button>
+        </header>
+        <div id="fetched-list" class="dl-list"><div class="dl-empty">Loading…</div></div>
+      </section>
+
       <!-- ─── LIBRARY ────────────────────────────────────────── -->
       <section data-pane="library">
         <header class="page-header">
@@ -189,45 +226,72 @@
           </div>
         </header>
 
-        <form data-section="library" class="settings-card">
-          <h3 class="settings-card-title">Storage</h3>
-          <div class="field">
-            <label for="f-download-path">Download path</label>
-            <input id="f-download-path" name="Library.DownloadPath" data-restart="true" placeholder="/music" />
-            <div class="field-help">Container path where downloaded files land. Must be a bind-mount that Navidrome scans.</div>
-          </div>
-        </form>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Storage</h3></div>
+          <form data-section="library" class="set-card">
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Auto-detect download path from Navidrome</div>
+                <div class="set-info-d">Octo asks Navidrome where its music folder is and writes there, so downloads always land where Navidrome scans. Only adopts a path Octo can see; otherwise it uses the field below.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-autodetect-path" name="Subsonic.AutoDetectDownloadPath" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Download path <span class="set-opt">override / fallback</span></div>
+                <div class="set-info-d">Container path where downloaded files land. With auto-detect on, this is only used until Navidrome's folder is detected. Turn auto-detect off to force this exact path.</div>
+              </div>
+              <input class="set-input" id="f-download-path" name="Library.DownloadPath" data-restart="true" placeholder="/music" />
+            </div>
+          </form>
+        </div>
 
-        <form data-section="subsonic-storage" class="settings-card">
-          <h3 class="settings-card-title">File layout</h3>
-          <div class="field">
-            <label for="f-folder-structure">Folder structure</label>
-            <select id="f-folder-structure" name="Subsonic.FolderStructure">
-              <option value="Flat">Flat — Artist - Title.flac (no folder)</option>
-              <option value="Organized">Organized — Artist/Title/file.flac</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="f-storage-mode">Storage mode</label>
-            <select id="f-storage-mode" name="Subsonic.StorageMode">
-              <option value="Stream">Stream — preview only, download on star</option>
-              <option value="Permanent">Permanent — download every played track</option>
-              <option value="Cache">Cache — temporary, auto-cleanup</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="f-cache-hours">Cache duration (hours)</label>
-            <input id="f-cache-hours" name="Subsonic.CacheDurationHours" type="number" min="1" />
-            <div class="field-help">How long Cache-mode files live before auto-cleanup.</div>
-          </div>
-          <div class="field field-check">
-            <input type="checkbox" id="f-local-staging" name="Subsonic.UseLocalStaging" />
-            <label for="f-local-staging">
-              <span class="field-check-label">Use local staging</span>
-              <span class="field-help">Required when download path is a cloud/FUSE mount (rclone, pCloud).</span>
-            </label>
-          </div>
-        </form>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">File layout</h3></div>
+          <form data-section="subsonic-storage" class="set-card">
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Folder structure</div>
+                <div class="set-info-d">Flat is <code>Artist - Title.flac</code>; Organized nests into <code>Artist/Title/</code>.</div>
+              </div>
+              <div class="set-ctrl">
+                <div class="seg" data-seg-for="f-folder-structure"><span class="seg-thumb"></span></div>
+                <select id="f-folder-structure" name="Subsonic.FolderStructure" class="seg-src" hidden>
+                  <option value="Flat">Flat</option>
+                  <option value="Organized">Organized</option>
+                </select>
+              </div>
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Storage mode</div>
+                <div class="set-info-d">Stream previews and download on star, keep every played track, or cache temporarily.</div>
+              </div>
+              <div class="set-ctrl">
+                <div class="seg" data-seg-for="f-storage-mode"><span class="seg-thumb"></span></div>
+                <select id="f-storage-mode" name="Subsonic.StorageMode" class="seg-src" hidden>
+                  <option value="Stream">Stream</option>
+                  <option value="Permanent">Permanent</option>
+                  <option value="Cache">Cache</option>
+                </select>
+              </div>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Cache duration (hours)</div>
+                <div class="set-info-d">How long Cache-mode files live before auto-cleanup.</div>
+              </div>
+              <input class="set-input" id="f-cache-hours" name="Subsonic.CacheDurationHours" type="number" min="1" />
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Use local staging</div>
+                <div class="set-info-d">Required when the download path is a cloud/FUSE mount (rclone, pCloud).</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-local-staging" name="Subsonic.UseLocalStaging" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+          </form>
+        </div>
       </section>
 
       <!-- ─── DOWNLOADS ──────────────────────────────────────── -->
@@ -239,29 +303,32 @@
           </div>
         </header>
 
-        <form data-section="downloads" class="settings-card">
-          <h3 class="settings-card-title">Source</h3>
-          <div class="field">
-            <label for="f-download-source">Download source</label>
-            <select id="f-download-source" name="Subsonic.DownloadSource">
-              <option value="Soulseek">Soulseek — lossless FLAC from peers</option>
-              <option value="YouTube">YouTube — lossy MP3 via yt-dlp</option>
-              <option value="SoulseekThenYouTube">Soulseek, then YouTube — FLAC first, MP3 fallback</option>
-            </select>
-            <div class="field-help">
-              Soulseek gives lossless FLAC but depends on a peer having the file.
-              YouTube always resolves but is lossy MP3. "Soulseek, then YouTube"
-              tries FLAC first and falls back to MP3 only when no peer delivers.
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Source</h3></div>
+          <form data-section="downloads" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Download source</div>
+                <div class="set-info-d">Soulseek gives lossless FLAC but depends on a peer having the file. YouTube always resolves but is lossy MP3. "Soulseek, then YouTube" tries FLAC first and falls back to MP3 only when no peer delivers.</div>
+              </div>
+              <div class="set-ctrl">
+                <div class="seg" data-seg-for="f-download-source"><span class="seg-thumb"></span></div>
+                <select id="f-download-source" name="Subsonic.DownloadSource" class="seg-src" hidden>
+                  <option value="Soulseek">Soulseek</option>
+                  <option value="YouTube">YouTube</option>
+                  <option value="SoulseekThenYouTube">Soulseek → YouTube</option>
+                </select>
+              </div>
             </div>
-          </div>
-          <div class="field field-check">
-            <input type="checkbox" id="f-download-on-star" name="Subsonic.DownloadOnStar" />
-            <label for="f-download-on-star">
-              <span class="field-check-label">Download a song when starred</span>
-              <span class="field-help">Stream/Cache modes only. Permanent already downloads every play.</span>
-            </label>
-          </div>
-        </form>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Download a song when starred</div>
+                <div class="set-info-d">Stream/Cache modes only. Permanent already downloads every play.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-download-on-star" name="Subsonic.DownloadOnStar" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+          </form>
+        </div>
       </section>
 
       <!-- ─── SUBSONIC ───────────────────────────────────────── -->
@@ -273,44 +340,79 @@
           </div>
         </header>
 
-        <form data-section="subsonic" class="settings-card">
-          <h3 class="settings-card-title">Connection</h3>
-          <div class="field">
-            <label for="f-subsonic-url">Navidrome URL</label>
-            <input id="f-subsonic-url" name="Subsonic.Url" data-restart="true" placeholder="http://192.168.1.10:4533" />
-            <div class="field-help">Use the LAN IP if Octo and Navidrome are on the same docker network.</div>
-          </div>
-        </form>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Connection</h3></div>
+          <form data-section="subsonic" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Navidrome URL</div>
+                <div class="set-info-d">Leave blank to let Octo find it on the network at first run. "Detect on network" scans your LAN now. Use a LAN IP, not localhost, from inside a container.</div>
+              </div>
+              <div class="set-inline">
+                <input class="set-input" id="f-subsonic-url" name="Subsonic.Url" data-restart="true" placeholder="http://192.168.1.10:4533" />
+                <button type="button" id="btn-detect-server" class="btn btn-ghost">Detect on network</button>
+              </div>
+              <div id="detect-server-result" class="detect-result" hidden></div>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Admin credentials <span class="set-opt">optional</span></div>
+                <div class="set-info-d">Lets Octo detect the music folder and run authenticated rescans on its own. Leave blank to have Octo learn an admin token from a client sign-in instead.</div>
+              </div>
+              <div class="set-grid2">
+                <input class="set-input" id="f-admin-user" name="Subsonic.AdminUsername" placeholder="admin username" autocomplete="off" />
+                <input class="set-input" id="f-admin-pass" name="Subsonic.AdminPassword" type="password" placeholder="••••••••" autocomplete="off" />
+              </div>
+            </div>
+          </form>
+        </div>
 
-        <form data-section="subsonic-behavior" class="settings-card">
-          <h3 class="settings-card-title">Behavior</h3>
-          <div class="field">
-            <label for="f-download-mode">Download mode</label>
-            <select id="f-download-mode" name="Subsonic.DownloadMode">
-              <option value="Track">Track — only the played song</option>
-              <option value="Album">Album — fetch the whole album in background</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="f-explicit">Explicit content</label>
-            <select id="f-explicit" name="Subsonic.ExplicitFilter">
-              <option value="All">All</option>
-              <option value="ExplicitOnly">Explicit only</option>
-              <option value="CleanOnly">Clean only</option>
-            </select>
-          </div>
-          <div class="field field-check">
-            <input type="checkbox" id="f-playlists" name="Subsonic.EnableExternalPlaylists" />
-            <label for="f-playlists">
-              <span class="field-check-label">External playlist search</span>
-              <span class="field-help">Discover and download playlists from streaming providers.</span>
-            </label>
-          </div>
-          <div class="field">
-            <label for="f-playlists-dir">Playlists directory</label>
-            <input id="f-playlists-dir" name="Subsonic.PlaylistsDirectory" placeholder="playlists" />
-          </div>
-        </form>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Behavior</h3></div>
+          <form data-section="subsonic-behavior" class="set-card">
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Download mode</div>
+                <div class="set-info-d">Fetch only the played song, or pull the whole album in the background.</div>
+              </div>
+              <div class="set-ctrl">
+                <div class="seg" data-seg-for="f-download-mode"><span class="seg-thumb"></span></div>
+                <select id="f-download-mode" name="Subsonic.DownloadMode" class="seg-src" hidden>
+                  <option value="Track">Track</option>
+                  <option value="Album">Album</option>
+                </select>
+              </div>
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Explicit content</div>
+                <div class="set-info-d">Filter external results by explicit-content tag (Deezer metadata).</div>
+              </div>
+              <div class="set-ctrl">
+                <div class="seg" data-seg-for="f-explicit"><span class="seg-thumb"></span></div>
+                <select id="f-explicit" name="Subsonic.ExplicitFilter" class="seg-src" hidden>
+                  <option value="All">All</option>
+                  <option value="ExplicitOnly">Explicit</option>
+                  <option value="CleanOnly">Clean</option>
+                </select>
+              </div>
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">External playlist search</div>
+                <div class="set-info-d">Discover and download playlists from streaming providers.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-playlists" name="Subsonic.EnableExternalPlaylists" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Playlists directory</div>
+                <div class="set-info-d">Where downloaded playlists are written, relative to the library root.</div>
+              </div>
+              <input class="set-input" id="f-playlists-dir" name="Subsonic.PlaylistsDirectory" placeholder="playlists" />
+            </div>
+          </form>
+        </div>
       </section>
 
       <!-- ─── LAST.FM ────────────────────────────────────────── -->
@@ -322,35 +424,50 @@
           </div>
         </header>
 
-        <form data-section="lastfm" class="settings-card">
-          <h3 class="settings-card-title">Account</h3>
-          <div class="field">
-            <label for="f-lastfm-key">API key</label>
-            <input id="f-lastfm-key" name="LastFm.ApiKey" type="password" autocomplete="off" placeholder="32-char hex string" />
-            <div class="field-help">Required. Without it, search and radio fall back to local-only.</div>
-          </div>
-        </form>
+        <div id="discovery-off-banner" class="notice notice-warn" hidden>
+          <strong>Discovery is off.</strong> Octo needs a free Last.fm API key to find and recommend music. Without it, search and radio only return what's already in your library.
+          <a href="https://www.last.fm/api/account/create" target="_blank" rel="noopener">Create a key →</a> then paste it below and Save.
+        </div>
 
-        <form data-section="lastfm-radio" class="settings-card">
-          <h3 class="settings-card-title">Radio</h3>
-          <div class="field field-check">
-            <input type="checkbox" id="f-lastfm-radio" name="LastFm.EnableRadio" />
-            <label for="f-lastfm-radio">
-              <span class="field-check-label">Enable radio</span>
-              <span class="field-help">Powers <code>/rest/getSimilarSongs2</code> in your Subsonic clients.</span>
-            </label>
-          </div>
-          <div class="field">
-            <label for="f-lastfm-count">Track count</label>
-            <input id="f-lastfm-count" name="LastFm.RadioTrackCount" type="number" min="5" max="200" />
-            <div class="field-help">How many similar tracks Last.fm returns per radio request.</div>
-          </div>
-          <div class="field">
-            <label for="f-lastfm-cache">Cache (hours)</label>
-            <input id="f-lastfm-cache" name="LastFm.RadioCacheDurationHours" type="number" min="0" />
-            <div class="field-help">How long Last.fm responses are cached server-side.</div>
-          </div>
-        </form>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Account</h3></div>
+          <form data-section="lastfm" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">API key</div>
+                <div class="set-info-d">Required for discovery. Without it, search and radio fall back to your local library only.</div>
+              </div>
+              <input class="set-input" id="f-lastfm-key" name="LastFm.ApiKey" type="password" autocomplete="off" placeholder="32-char hex string" />
+            </div>
+          </form>
+        </div>
+
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Radio</h3></div>
+          <form data-section="lastfm-radio" class="set-card">
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Enable radio</div>
+                <div class="set-info-d">Powers <code>/rest/getSimilarSongs2</code> in your Subsonic clients.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-lastfm-radio" name="LastFm.EnableRadio" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Track count</div>
+                <div class="set-info-d">How many similar tracks Last.fm returns per radio request.</div>
+              </div>
+              <input class="set-input" id="f-lastfm-count" name="LastFm.RadioTrackCount" type="number" min="5" max="200" />
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Cache (hours)</div>
+                <div class="set-info-d">How long Last.fm responses are cached server-side.</div>
+              </div>
+              <input class="set-input" id="f-lastfm-cache" name="LastFm.RadioCacheDurationHours" type="number" min="0" />
+            </div>
+          </form>
+        </div>
       </section>
 
       <!-- ─── SOULSEEK ───────────────────────────────────────── -->
@@ -362,52 +479,54 @@
           </div>
         </header>
 
-        <form data-section="soulseek-conn" class="settings-card">
-          <h3 class="settings-card-title">Connection</h3>
-          <div class="field">
-            <label for="f-slskd-url">Base URL</label>
-            <input id="f-slskd-url" name="Soulseek.BaseUrl" data-restart="true" placeholder="http://slskd:5030" />
-            <div class="field-help">Default works inside the docker network.</div>
-          </div>
-          <div class="field-row">
-            <div class="field">
-              <label for="f-slskd-user">Web admin username</label>
-              <input id="f-slskd-user" name="Soulseek.Username" data-restart="true" autocomplete="off" />
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Connection</h3></div>
+          <form data-section="soulseek-conn" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Base URL</div>
+                <div class="set-info-d">The slskd API. Default works inside the docker network.</div>
+              </div>
+              <input class="set-input" id="f-slskd-url" name="Soulseek.BaseUrl" data-restart="true" placeholder="http://slskd:5030" />
             </div>
-            <div class="field">
-              <label for="f-slskd-pass">Web admin password</label>
-              <input id="f-slskd-pass" name="Soulseek.Password" type="password" data-restart="true" autocomplete="off" />
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Web admin credentials</div>
+                <div class="set-info-d">These authenticate Octo against slskd's API. Not your Soulseek-network account — that's <code>SLSKD_SOULSEEK_USERNAME/PASSWORD</code> in <code>.env</code>.</div>
+              </div>
+              <div class="set-grid2">
+                <input class="set-input" id="f-slskd-user" name="Soulseek.Username" data-restart="true" placeholder="username" autocomplete="off" />
+                <input class="set-input" id="f-slskd-pass" name="Soulseek.Password" type="password" data-restart="true" placeholder="password" autocomplete="off" />
+              </div>
             </div>
-          </div>
-          <div class="field-help" style="margin-top: -8px;">These authenticate Octo against slskd's API. Not your Soulseek-network account — that's set in <code>SLSKD_SOULSEEK_USERNAME/PASSWORD</code> in <code>.env</code>.</div>
-        </form>
+          </form>
+        </div>
 
-        <form data-section="soulseek-search" class="settings-card">
-          <h3 class="settings-card-title">Search &amp; download</h3>
-          <div class="field-row">
-            <div class="field">
-              <label for="f-slskd-wait">Search wait (s)</label>
-              <input id="f-slskd-wait" name="Soulseek.SearchWaitSeconds" type="number" min="2" max="30" />
-              <div class="field-help">Time to wait for peer responses before picking.</div>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Search &amp; download</h3></div>
+          <form data-section="soulseek-search" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Search wait / per-peer timeout <span class="set-opt">seconds</span></div>
+                <div class="set-info-d">How long to wait for peer responses, and how long each of up to 5 peer downloads may take.</div>
+              </div>
+              <div class="set-grid2">
+                <input class="set-input" id="f-slskd-wait" name="Soulseek.SearchWaitSeconds" type="number" min="2" max="30" />
+                <input class="set-input" id="f-slskd-timeout" name="Soulseek.DownloadTimeoutSeconds" type="number" min="30" />
+              </div>
             </div>
-            <div class="field">
-              <label for="f-slskd-timeout">Per-peer timeout (s)</label>
-              <input id="f-slskd-timeout" name="Soulseek.DownloadTimeoutSeconds" type="number" min="30" />
-              <div class="field-help">Octo tries up to 5 peers in sequence.</div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Min file size <span class="set-opt">bytes</span> / extension</div>
+                <div class="set-info-d">Filter out clip-sized fakes and prefer a file type.</div>
+              </div>
+              <div class="set-grid2">
+                <input class="set-input" id="f-slskd-minsize" name="Soulseek.MinFileSizeBytes" type="number" min="0" />
+                <input class="set-input" id="f-slskd-ext" name="Soulseek.PreferredExtension" placeholder="flac" />
+              </div>
             </div>
-          </div>
-          <div class="field-row">
-            <div class="field">
-              <label for="f-slskd-minsize">Min file size (bytes)</label>
-              <input id="f-slskd-minsize" name="Soulseek.MinFileSizeBytes" type="number" min="0" />
-              <div class="field-help">Filters out clip-sized fakes.</div>
-            </div>
-            <div class="field">
-              <label for="f-slskd-ext">Extension</label>
-              <input id="f-slskd-ext" name="Soulseek.PreferredExtension" placeholder="flac" />
-            </div>
-          </div>
-        </form>
+          </form>
+        </div>
       </section>
 
       <!-- ─── YOUTUBE ────────────────────────────────────────── -->
@@ -419,14 +538,18 @@
           </div>
         </header>
 
-        <form data-section="youtube" class="settings-card">
-          <h3 class="settings-card-title">Shim</h3>
-          <div class="field">
-            <label for="f-yt-url">Shim URL</label>
-            <input id="f-yt-url" name="YouTube.ShimUrl" data-restart="true" placeholder="http://yt-dlp-shim:8080" />
-            <div class="field-help">Default works inside the docker network.</div>
-          </div>
-        </form>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Shim</h3></div>
+          <form data-section="youtube" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Shim URL</div>
+                <div class="set-info-d">The yt-dlp sidecar. Default works inside the docker network.</div>
+              </div>
+              <input class="set-input" id="f-yt-url" name="YouTube.ShimUrl" data-restart="true" placeholder="http://yt-dlp-shim:8080" />
+            </div>
+          </form>
+        </div>
 
         <div class="info-card">
           <h3 class="info-card-title">How it works</h3>

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -45,6 +45,12 @@
             </svg>
             <span>Library</span>
           </button>
+          <button class="sidebar-nav-item" data-tab="downloads">
+            <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M8 2.5v7M5 7l3 3 3-3M3.5 13h9"/>
+            </svg>
+            <span>Downloads</span>
+          </button>
           <button class="sidebar-nav-item" data-tab="subsonic">
             <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
               <circle cx="8" cy="8" r="5.5"/><path d="M3 8a5 5 0 0 1 10 0"/>
@@ -209,13 +215,6 @@
               <option value="Cache">Cache — temporary, auto-cleanup</option>
             </select>
           </div>
-          <div class="field field-check">
-            <input type="checkbox" id="f-download-on-star" name="Subsonic.DownloadOnStar" />
-            <label for="f-download-on-star">
-              <span class="field-check-label">Download a song when starred</span>
-              <span class="field-help">Stream/Cache modes only. Permanent already downloads every play.</span>
-            </label>
-          </div>
           <div class="field">
             <label for="f-cache-hours">Cache duration (hours)</label>
             <input id="f-cache-hours" name="Subsonic.CacheDurationHours" type="number" min="1" />
@@ -226,6 +225,40 @@
             <label for="f-local-staging">
               <span class="field-check-label">Use local staging</span>
               <span class="field-help">Required when download path is a cloud/FUSE mount (rclone, pCloud).</span>
+            </label>
+          </div>
+        </form>
+      </section>
+
+      <!-- ─── DOWNLOADS ──────────────────────────────────────── -->
+      <section data-pane="downloads">
+        <header class="page-header">
+          <div>
+            <h1>Downloads</h1>
+            <p>Where a starred song's permanent copy comes from, and when Octo fetches it.</p>
+          </div>
+        </header>
+
+        <form data-section="downloads" class="settings-card">
+          <h3 class="settings-card-title">Source</h3>
+          <div class="field">
+            <label for="f-download-source">Download source</label>
+            <select id="f-download-source" name="Subsonic.DownloadSource">
+              <option value="Soulseek">Soulseek — lossless FLAC from peers</option>
+              <option value="YouTube">YouTube — lossy MP3 via yt-dlp</option>
+              <option value="SoulseekThenYouTube">Soulseek, then YouTube — FLAC first, MP3 fallback</option>
+            </select>
+            <div class="field-help">
+              Soulseek gives lossless FLAC but depends on a peer having the file.
+              YouTube always resolves but is lossy MP3. "Soulseek, then YouTube"
+              tries FLAC first and falls back to MP3 only when no peer delivers.
+            </div>
+          </div>
+          <div class="field field-check">
+            <input type="checkbox" id="f-download-on-star" name="Subsonic.DownloadOnStar" />
+            <label for="f-download-on-star">
+              <span class="field-check-label">Download a song when starred</span>
+              <span class="field-help">Stream/Cache modes only. Permanent already downloads every play.</span>
             </label>
           </div>
         </form>

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
 import subprocess
 import threading
 import time
@@ -286,6 +287,72 @@ def _search_with_hint(q: str, duration_hint: int) -> Optional[dict]:
 _META_CACHE_LOCK = threading.Lock()
 _META_CACHE: "OrderedDict[str, dict]" = OrderedDict()
 
+# Persistent duration cache. YouTube is the single source of truth for a track's
+# length, and a resolved "artist - title" -> {video_id, duration} mapping is
+# stable forever, so it is worth surviving process restarts. This is what turns
+# the speed-vs-accuracy tradeoff into "both": once a track is resolved (by a real
+# search or a background warm) its accurate duration is a disk lookup for every
+# future search and play, in BOTH Subsonic and Navidrome modes. The in-memory
+# _META_CACHE stays as a hot front; this is the durable backing store.
+# Mount META_DB_PATH's directory as a volume to also survive container recreation.
+_META_DB_PATH = os.environ.get("META_DB_PATH", "/var/lib/ytshim/meta.db")
+_META_DB_LOCK = threading.Lock()
+
+
+def _norm_q(q: str) -> str:
+    """Normalize a query so trivially-different spellings share a cache row:
+    lowercase and collapse runs of whitespace. The duration hint is deliberately
+    NOT part of the key — a resolved track's YouTube length is what we trust, and
+    a slightly different Deezer hint next time must still hit the same row."""
+    return " ".join(q.lower().split())
+
+
+def _meta_db_init() -> None:
+    try:
+        os.makedirs(os.path.dirname(_META_DB_PATH) or ".", exist_ok=True)
+        with sqlite3.connect(_META_DB_PATH, timeout=5) as c:
+            c.execute("PRAGMA journal_mode=WAL")
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS meta ("
+                "key TEXT PRIMARY KEY, video_id TEXT, title TEXT, "
+                "duration INTEGER, updated REAL)"
+            )
+    except Exception as e:  # a broken db must never take the shim down
+        log.warning("meta db init failed (%s); persistence disabled", e)
+
+
+def _meta_db_get(key: str) -> Optional[dict]:
+    try:
+        with sqlite3.connect(_META_DB_PATH, timeout=5) as c:
+            c.execute("PRAGMA busy_timeout=5000")
+            row = c.execute(
+                "SELECT video_id, title, duration FROM meta WHERE key=?", (key,)
+            ).fetchone()
+        if row and row[0]:
+            return {"video_id": row[0], "title": row[1], "duration": row[2]}
+    except Exception as e:
+        log.warning("meta db get failed: %s", e)
+    return None
+
+
+def _meta_db_put(key: str, payload: dict) -> None:
+    if not payload.get("video_id"):
+        return
+    try:
+        with _META_DB_LOCK, sqlite3.connect(_META_DB_PATH, timeout=5) as c:
+            c.execute("PRAGMA busy_timeout=5000")
+            c.execute(
+                "INSERT OR REPLACE INTO meta(key, video_id, title, duration, updated) "
+                "VALUES(?,?,?,?,?)",
+                (key, payload.get("video_id"), payload.get("title"),
+                 payload.get("duration"), time.time()),
+            )
+    except Exception as e:
+        log.warning("meta db put failed: %s", e)
+
+
+_meta_db_init()
+
 
 @app.get("/meta")
 def meta():
@@ -299,12 +366,20 @@ def meta():
     hint_str = request.args.get("duration", "").strip()
     duration_hint = int(hint_str) if hint_str.isdigit() else None
 
-    key = f"{q.lower()}|{duration_hint or ''}"
+    key = _norm_q(q)
+    # Hot front: exact repeat within this process.
     with _META_CACHE_LOCK:
         c = _META_CACHE.get(key)
         if c is not None:
             _META_CACHE.move_to_end(key)
             return jsonify(**c)
+    # Durable backing: resolved in a past search/warm, possibly a past process.
+    persisted = _meta_db_get(key)
+    if persisted is not None:
+        with _META_CACHE_LOCK:
+            _META_CACHE[key] = persisted
+            _META_CACHE.move_to_end(key)
+        return jsonify(**persisted)
 
     if duration_hint is not None:
         out = _run([f"ytsearch5:{q}", "--flat-playlist", "--print", "%(.{id,title,duration})j"],
@@ -342,6 +417,7 @@ def meta():
             _META_CACHE.move_to_end(key)
             while len(_META_CACHE) > _SEARCH_CACHE_MAX:
                 _META_CACHE.popitem(last=False)
+        _meta_db_put(key, payload)  # persist so it survives restarts, for both modes
     return jsonify(**payload)
 
 

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -39,6 +39,11 @@ from flask import Flask, Response, abort, jsonify, request, stream_with_context
 YTDLP = os.environ.get("YTDLP_PATH", "/usr/local/bin/yt-dlp")
 PORT = int(os.environ.get("PORT", "8080"))
 
+# Root the /download endpoint is allowed to write under (the shared music mount).
+# dest arrives over the wire, so downloads are confined here even though the shim
+# is internal-only.
+_DOWNLOAD_ROOT = os.path.realpath(os.environ.get("DOWNLOAD_ROOT", "/music"))
+
 # Audio format selector shared by /search (single-extraction warm) and
 # /stream's _resolve_url (cold path), so both request the exact same format.
 # Format 140 is audio-only m4a (AAC); yt-dlp -g / --print returns one
@@ -392,6 +397,81 @@ def stream():
         if v is not None:
             headers[h] = v
     return Response(generator(), headers=headers, status=upstream.status_code)
+
+
+@app.get("/download")
+def download():
+    """Download a YouTube video as a tagged MP3 to <dest>.mp3.
+
+    GET /download?id=<videoId>&dest=<path_no_ext>[&artist=<a>&title=<t>]
+    Returns {"path": "<dest>.mp3"} on success.
+    """
+    video_id = request.args.get("id", "").strip()
+    dest = request.args.get("dest", "").strip()
+    artist = request.args.get("artist", "").strip()
+    title = request.args.get("title", "").strip()
+    if not video_id or not dest:
+        abort(400, "missing id or dest")
+
+    # Confine writes to the shared music root.
+    full_dest = os.path.realpath(dest)
+    if not (full_dest == _DOWNLOAD_ROOT or full_dest.startswith(_DOWNLOAD_ROOT + os.sep)):
+        abort(400, "dest outside download root")
+    os.makedirs(os.path.dirname(full_dest) or ".", exist_ok=True)
+
+    out = _run(
+        [
+            "-x",
+            "-f", "141/140/bestaudio[ext=m4a]/bestaudio",
+            "--audio-format", "mp3",
+            "--audio-quality", "0",
+            "--embed-metadata",
+            "--embed-thumbnail",
+            "--convert-thumbnails", "jpg",
+            "-o", f"{full_dest}.%(ext)s",
+            f"https://www.youtube.com/watch?v={video_id}",
+        ],
+        timeout=300,
+        label="download",
+    )
+    path = f"{full_dest}.mp3"
+    if out is None or not os.path.exists(path):
+        for ext in (".jpg", ".webp", ".png", ".mp3"):
+            leftover = full_dest + ext
+            if os.path.exists(leftover):
+                try:
+                    os.remove(leftover)
+                except OSError:
+                    pass
+        return jsonify(error="download_failed", expected=path), 502
+
+    # Overwrite yt-dlp's video-derived title/artist with the clean values Octo
+    # passed, so Navidrome groups the track correctly. Codec-copy keeps the audio
+    # and the embedded cover; list args are quoting-safe for spaces. Best-effort:
+    # on failure we keep the original mp3.
+    if artist or title:
+        tagged = f"{full_dest}.tagged.mp3"
+        meta = []
+        if artist:
+            meta += ["-metadata", f"artist={artist}", "-metadata", f"album_artist={artist}"]
+        if title:
+            meta += ["-metadata", f"title={title}"]
+        try:
+            rc = subprocess.run(
+                ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+                 "-i", path, "-map", "0", "-map_metadata", "0", "-codec", "copy",
+                 *meta, tagged],
+                timeout=60, check=False,
+            ).returncode
+            if rc == 0 and os.path.exists(tagged):
+                os.replace(tagged, path)
+            elif os.path.exists(tagged):
+                os.remove(tagged)
+        except Exception as e:
+            log.warning("retag failed for %s: %s", video_id, e)
+
+    log.info("downloaded %s -> %s", video_id, path)
+    return jsonify(path=path)
 
 
 if __name__ == "__main__":

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -283,6 +283,68 @@ def _search_with_hint(q: str, duration_hint: int) -> Optional[dict]:
     return payload
 
 
+_META_CACHE_LOCK = threading.Lock()
+_META_CACHE: "OrderedDict[str, dict]" = OrderedDict()
+
+
+@app.get("/meta")
+def meta():
+    """Fast metadata-only lookup (flat search, NO url solve) for an accurate
+    duration on search rows. With a duration hint it picks the closest-length of
+    5 candidates (avoids long-form/compilation uploads); otherwise the top result.
+    Cached, so repeat searches are a dict lookup."""
+    q = request.args.get("q", "").strip()
+    if not q:
+        abort(400, "missing q")
+    hint_str = request.args.get("duration", "").strip()
+    duration_hint = int(hint_str) if hint_str.isdigit() else None
+
+    key = f"{q.lower()}|{duration_hint or ''}"
+    with _META_CACHE_LOCK:
+        c = _META_CACHE.get(key)
+        if c is not None:
+            _META_CACHE.move_to_end(key)
+            return jsonify(**c)
+
+    if duration_hint is not None:
+        out = _run([f"ytsearch5:{q}", "--flat-playlist", "--print", "%(.{id,title,duration})j"],
+                   timeout=20, label="meta5")
+        cands = []
+        for ln in (out or "").strip().split("\n"):
+            ln = ln.strip()
+            if ln:
+                try:
+                    cands.append(json.loads(ln))
+                except json.JSONDecodeError:
+                    pass
+        if not cands:
+            return jsonify(error="no_hit"), 404
+        cands.sort(key=lambda r: abs((r.get("duration") or 0) - duration_hint)
+                   if r.get("duration") else float("inf"))
+        data = cands[0]
+    else:
+        out = _run([f"ytsearch1:{q}", "--flat-playlist", "--print", "%(.{id,title,duration})j"],
+                   timeout=15, label="meta")
+        if out is None:
+            return jsonify(error="search_failed"), 502
+        line = next((ln.strip() for ln in out.strip().split("\n") if ln.strip()), "")
+        if not line:
+            return jsonify(error="no_hit"), 404
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            return jsonify(error="bad_yt_response"), 502
+
+    payload = {"video_id": data.get("id"), "title": data.get("title"), "duration": data.get("duration")}
+    if payload["video_id"]:
+        with _META_CACHE_LOCK:
+            _META_CACHE[key] = payload
+            _META_CACHE.move_to_end(key)
+            while len(_META_CACHE) > _SEARCH_CACHE_MAX:
+                _META_CACHE.popitem(last=False)
+    return jsonify(**payload)
+
+
 def _resolve_url(video_id: str) -> Optional[str]:
     cached = _url_cache_get(video_id)
     if cached:

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -8,12 +8,16 @@ Why this is a separate container instead of in-process inside Octo:
   HTTP to this service, and any process-management quirks stay sandboxed.
 
 Endpoints:
-  GET /search?q=<query>
-      Runs `yt-dlp ytsearch1:<query>` and returns {video_id, title, duration}.
+  GET /search?q=<query>[&duration=<sec>]
+      One yt-dlp extraction returning {video_id, title, duration, channel}.
+      Without a duration hint it also resolves and caches the stream URL in
+      the SAME extraction, so a later /stream is a deterministic cache hit.
+      With a hint it picks the closest-length of several flat candidates
+      (cheap, no per-video extraction), then resolves the winner's URL.
 
   GET /stream?id=<videoId>
-      Resolves the best-audio URL via `yt-dlp -g`, then proxies bytes
-      from YouTube's CDN to the caller. Streaming chunks so this stays
+      Resolves the best-audio URL (cached), then proxies bytes from
+      YouTube's CDN to the caller. Streaming chunks so this stays
       flat-memory regardless of song length, and so cancellation is
       honored immediately (the upstream connection closes when the
       caller disconnects).
@@ -25,13 +29,25 @@ import logging
 import os
 import subprocess
 import threading
+import time
 from typing import Optional
 
 import requests
+from requests.adapters import HTTPAdapter
 from flask import Flask, Response, abort, jsonify, request, stream_with_context
 
 YTDLP = os.environ.get("YTDLP_PATH", "/usr/local/bin/yt-dlp")
 PORT = int(os.environ.get("PORT", "8080"))
+
+# Audio format selector shared by /search (single-extraction warm) and
+# /stream's _resolve_url (cold path), so both request the exact same format.
+# Format 140 is audio-only m4a (AAC); yt-dlp -g / --print returns one
+# contiguous googlevideo URL with a Content-Length for it. Format 18 (the old
+# muxed 360p mp4) is being phased out by YouTube and 502s on a growing share.
+_AUDIO_FORMAT = os.environ.get(
+    "YTDLP_AUDIO_FORMAT",
+    "140/bestaudio[ext=m4a]/bestaudio[ext=webm]/bestaudio",
+)
 
 # In-memory LRU cache of search-query -> json result. Cuts repeat searches
 # from a 3-8s yt-dlp invocation to a dict lookup. Bounded so we never grow
@@ -49,6 +65,18 @@ _URL_CACHE: "OrderedDict[str, tuple[float, str]]" = OrderedDict()
 _URL_CACHE_MAX = int(os.environ.get("URL_CACHE_MAX", "512"))
 _URL_CACHE_TTL = int(os.environ.get("URL_CACHE_TTL", "3600"))  # 1 hour, well under signed-URL lifetime
 
+# Single-flight: collapse concurrent resolves of the same video id onto one
+# yt-dlp -g. Second callers wait on the per-id lock and reuse the cached URL.
+_INFLIGHT_LOCK = threading.Lock()
+_INFLIGHT: "dict[str, threading.Lock]" = {}
+
+# One pooled HTTPS session for all upstream googlevideo byte-proxying. Reuses
+# the TCP+TLS connection across an iOS client's `Range: bytes=0-1` probe and
+# the real range GET that follows, instead of a fresh handshake per request.
+_SESSION = requests.Session()
+_SESSION.mount("https://", HTTPAdapter(pool_connections=32, pool_maxsize=64))
+
+
 def _cache_get(key: str):
     with _SEARCH_CACHE_LOCK:
         v = _SEARCH_CACHE.get(key)
@@ -64,25 +92,27 @@ def _cache_put(key: str, value: dict):
             _SEARCH_CACHE.popitem(last=False)
 
 def _url_cache_get(video_id: str):
-    import time as _t
     with _URL_CACHE_LOCK:
         entry = _URL_CACHE.get(video_id)
         if not entry:
             return None
         ts, url = entry
-        if _t.time() - ts > _URL_CACHE_TTL:
+        if time.time() - ts > _URL_CACHE_TTL:
             del _URL_CACHE[video_id]
             return None
         _URL_CACHE.move_to_end(video_id)
         return url
 
 def _url_cache_put(video_id: str, url: str):
-    import time as _t
     with _URL_CACHE_LOCK:
-        _URL_CACHE[video_id] = (_t.time(), url)
+        _URL_CACHE[video_id] = (time.time(), url)
         _URL_CACHE.move_to_end(video_id)
         while len(_URL_CACHE) > _URL_CACHE_MAX:
             _URL_CACHE.popitem(last=False)
+
+def _url_cache_evict(video_id: str):
+    with _URL_CACHE_LOCK:
+        _URL_CACHE.pop(video_id, None)
 
 # Cap concurrent yt-dlp processes globally. Each one is fork+exec heavy;
 # letting them stack starves a small container.
@@ -98,13 +128,24 @@ log = logging.getLogger("ytdlp-shim")
 app = Flask(__name__)
 
 
-def _run(args: list[str], timeout: int = 20) -> Optional[str]:
-    """Run yt-dlp with a hard timeout. Returns stdout or None on any failure."""
+def _run(args: list[str], timeout: int = 20, label: str = "ytdlp") -> Optional[str]:
+    """Run yt-dlp with a hard timeout. Returns stdout or None on any failure.
+
+    Logs gate-wait and wall time so a real box can show whether interactive
+    resolves are queuing behind background prewarm (grep `gate_wait_ms`).
+    """
+    t_acquire = time.monotonic()
     if not _GATE.acquire(timeout=_GATE_WAIT_SEC):
         log.warning("yt-dlp gate full after %ds, dropping: %s", _GATE_WAIT_SEC, " ".join(args))
         return None
+    gate_ms = (time.monotonic() - t_acquire) * 1000.0
     try:
-        full = [YTDLP, "--no-warnings", "--no-cache-dir", "--no-playlist", *args]
+        # NOTE: --no-cache-dir intentionally removed. The cache stores the
+        # player base.js + solved nsig signatures; disabling it forced a
+        # re-download and re-solve on every fork. A persistent cache volume is
+        # mounted in compose.
+        full = [YTDLP, "--no-warnings", "--no-playlist", *args]
+        t_run = time.monotonic()
         try:
             cp = subprocess.run(
                 full,
@@ -114,10 +155,12 @@ def _run(args: list[str], timeout: int = 20) -> Optional[str]:
                 check=False,
             )
         except subprocess.TimeoutExpired:
-            log.warning("yt-dlp timed out: %s", " ".join(args))
+            log.warning("yt-dlp timed out (%s, gate_wait_ms=%.0f): %s", label, gate_ms, " ".join(args))
             return None
+        wall_ms = (time.monotonic() - t_run) * 1000.0
+        log.info("ytdlp label=%s gate_wait_ms=%.0f wall_ms=%.0f rc=%d", label, gate_ms, wall_ms, cp.returncode)
         if cp.returncode != 0:
-            log.warning("yt-dlp exit %d: %s", cp.returncode, cp.stderr.strip()[:300])
+            log.warning("yt-dlp exit %d (%s): %s", cp.returncode, label, cp.stderr.strip()[:300])
             return None
         return cp.stdout
     finally:
@@ -135,85 +178,147 @@ def search():
     if not q:
         abort(400, "missing q")
 
-    cache_key = q.lower()
+    hint_str = request.args.get("duration", "").strip()
+    duration_hint = int(hint_str) if hint_str.isdigit() else None
+
+    cache_key = f"{q.lower()}|{duration_hint or ''}"
     cached = _cache_get(cache_key)
     if cached is not None:
         return jsonify(**cached)
 
-    out = _run(
-        [
-            f"ytsearch1:{q}",
-            "--print",
-            "%(.{id,title,duration,channel})j",
-        ],
-        timeout=15,
-    )
-    if not out:
+    payload = _search_with_hint(q, duration_hint) if duration_hint is not None else _search_single(q)
+    if payload is None:
         return jsonify(error="search_failed"), 502
-
-    line = out.strip().split("\n", 1)[0].strip()
-    if not line:
+    if not payload.get("video_id"):
         return jsonify(error="no_hit"), 404
-    try:
-        data = json.loads(line)
-    except json.JSONDecodeError as e:
-        log.warning("search: bad json from yt-dlp: %s", e)
-        return jsonify(error="bad_yt_response"), 502
 
-    payload = {
+    _cache_put(cache_key, payload)
+    return jsonify(**payload)
+
+
+def _payload_from(data: dict) -> dict:
+    return {
         "video_id": data.get("id"),
         "title": data.get("title"),
         "duration": data.get("duration"),
         "channel": data.get("channel"),
     }
-    if payload["video_id"]:
-        _cache_put(cache_key, payload)
-        # Pre-resolve the stream URL in the background so /stream is instant
-        # when the user actually plays this track. Best-effort; failures are
-        # silent and just mean /stream pays the lookup cost on first hit.
-        threading.Thread(
-            target=_prefetch_stream_url,
-            args=(payload["video_id"],),
-            daemon=True,
-        ).start()
-    return jsonify(**payload)
 
 
-def _prefetch_stream_url(video_id: str) -> None:
-    if _url_cache_get(video_id) is not None:
-        return
-    url = _resolve_url(video_id)
-    if url:
-        _url_cache_put(video_id, url)
-        log.info("prefetched stream url for %s", video_id)
+def _search_single(q: str) -> Optional[dict]:
+    """No duration hint: fast path. One extraction yields metadata AND the
+    stream URL, which we warm into the URL cache so /stream is a cache hit."""
+    out = _run(
+        [
+            f"ytsearch1:{q}",
+            "-f", _AUDIO_FORMAT,
+            "--ignore-no-formats-error",
+            "--print", "%(.{id,title,duration,channel})j",
+            "--print", "%(urls)s",
+        ],
+        timeout=15,
+        label="search+resolve",
+    )
+    if out is None:
+        return None
+    lines = [ln.strip() for ln in out.strip().split("\n") if ln.strip()]
+    if not lines:
+        return {}
+    try:
+        data = json.loads(lines[0])
+    except json.JSONDecodeError as e:
+        log.warning("search: bad json from yt-dlp: %s", e)
+        return None
+    payload = _payload_from(data)
+    stream_url = lines[1] if len(lines) > 1 else None
+    if payload.get("video_id") and stream_url:
+        # Warm the URL cache from the SAME extraction. This used to be a second
+        # `yt-dlp -g` on a detached daemon thread; folding it in removes an
+        # entire yt-dlp invocation per track and makes the warm /stream path a
+        # deterministic cache hit instead of a gate-race.
+        _url_cache_put(payload["video_id"], stream_url)
+    return payload
+
+
+def _search_with_hint(q: str, duration_hint: int) -> Optional[dict]:
+    """Duration hint present: pick the closest-length of 5 flat candidates
+    (cheap, no per-video extraction), then resolve the winner's URL once."""
+    out = _run(
+        [
+            f"ytsearch5:{q}",
+            "--flat-playlist",
+            "--print", "%(.{id,title,duration,channel})j",
+        ],
+        timeout=20,
+        label="search5",
+    )
+    if out is None:
+        return None
+    candidates = []
+    for ln in out.strip().split("\n"):
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            candidates.append(json.loads(ln))
+        except json.JSONDecodeError:
+            pass
+    if not candidates:
+        return {}
+    # Closest duration wins; candidates without a duration sort last so a hint
+    # never drags us onto an entry we can't length-match.
+    candidates.sort(
+        key=lambda r: abs((r.get("duration") or 0) - duration_hint)
+        if r.get("duration") else float("inf")
+    )
+    payload = _payload_from(candidates[0])
+    if payload.get("video_id"):
+        # Warm the URL cache for the coming /stream (single-flight + cached).
+        _resolve_url(payload["video_id"])
+    return payload
 
 
 def _resolve_url(video_id: str) -> Optional[str]:
     cached = _url_cache_get(video_id)
     if cached:
         return cached
-    # Format 140 is audio-only m4a (AAC). Despite often being labeled "DASH" in
-    # yt-dlp's table, `yt-dlp -g` returns a single contiguous googlevideo.com
-    # URL with a Content-Length — proxying the body through requests.get works.
-    # Format 18 (the muxed 360p mp4 we used to use) is being phased out by
-    # YouTube and is missing on a growing share of videos; relying on it gave
-    # us many silent /stream 502s. Audio-only is what the Subsonic client
-    # actually wants anyway.
-    out = _run(
-        [
-            "-g",
-            "-f",
-            "140/bestaudio[ext=m4a]/bestaudio[ext=webm]/bestaudio",
-            f"https://www.youtube.com/watch?v={video_id}",
-        ],
-        timeout=15,
-    )
-    if not out:
+
+    # Single-flight per video id: if a prefetch/other /stream is already
+    # resolving this id, wait for it and reuse its result instead of forking a
+    # second identical `yt-dlp -g`.
+    with _INFLIGHT_LOCK:
+        lock = _INFLIGHT.setdefault(video_id, threading.Lock())
+    with lock:
+        cached = _url_cache_get(video_id)
+        if cached:
+            return cached
+        try:
+            out = _run(
+                [
+                    "-g",
+                    "-f", _AUDIO_FORMAT,
+                    f"https://www.youtube.com/watch?v={video_id}",
+                ],
+                timeout=15,
+                label="resolve",
+            )
+            if not out:
+                return None
+            url = out.strip().split("\n", 1)[0].strip()
+            if url:
+                _url_cache_put(video_id, url)
+            return url or None
+        finally:
+            with _INFLIGHT_LOCK:
+                _INFLIGHT.pop(video_id, None)
+
+
+def _open_upstream(url: str, headers: dict, video_id: str):
+    try:
+        return _SESSION.get(url, stream=True, timeout=(8, 30), headers=headers)
+    except Exception as e:
+        log.warning("stream upstream failed for %s: %s", video_id, e)
         return None
-    url = out.strip().split("\n", 1)[0].strip()
-    if url:
-        _url_cache_put(video_id, url)
-    return url or None
 
 
 @app.get("/stream")
@@ -221,6 +326,7 @@ def stream():
     video_id = request.args.get("id", "").strip()
     if not video_id:
         abort(400, "missing id")
+    t_enter = time.monotonic()
 
     url = _resolve_url(video_id)
     if not url:
@@ -237,22 +343,36 @@ def stream():
     if incoming_range:
         upstream_headers["Range"] = incoming_range
 
-    try:
-        upstream = requests.get(url, stream=True, timeout=(8, 30), headers=upstream_headers)
-        # Accept both 200 (full body) and 206 (partial). Anything else is a real
-        # failure we need to surface.
-        if upstream.status_code not in (200, 206):
-            log.warning("stream upstream %d for %s", upstream.status_code, video_id)
-            return jsonify(error="upstream_failed", status=upstream.status_code), 502
-    except Exception as e:
-        log.warning("stream upstream failed for %s: %s", video_id, e)
+    upstream = _open_upstream(url, upstream_headers, video_id)
+    # A signed googlevideo URL can expire between resolve and play (long or
+    # paused song, or a stale cache entry). Expiry shows up as 403/410. Evict
+    # the bad entry, re-resolve once, and retry before surfacing a failure, so
+    # one stale URL does not fail every play of this id for the cache TTL.
+    if upstream is not None and upstream.status_code in (403, 410):
+        upstream.close()
+        log.info("stream %s: signed url expired (%d), re-resolving", video_id, upstream.status_code)
+        _url_cache_evict(video_id)
+        url = _resolve_url(video_id)
+        upstream = _open_upstream(url, upstream_headers, video_id) if url else None
+
+    if upstream is None or upstream.status_code not in (200, 206):
+        code = upstream.status_code if upstream is not None else "n/a"
+        if upstream is not None:
+            upstream.close()
+        log.warning("stream upstream %s for %s", code, video_id)
         return jsonify(error="upstream_failed"), 502
 
     @stream_with_context
     def generator():
+        first = True
         try:
             for chunk in upstream.iter_content(chunk_size=64 * 1024):
                 if chunk:
+                    if first:
+                        log.info("stream %s ttfb_ms=%.0f status=%d",
+                                 video_id, (time.monotonic() - t_enter) * 1000.0,
+                                 upstream.status_code)
+                        first = False
                     yield chunk
         finally:
             try:


### PR DESCRIPTION
Fixes the slow external streaming (#2) and the "installed it and nothing happened" setup friction (#1), then builds out discovery, downloads, and the dashboard.

## Faster external streaming
- Single-extraction search, pooled sessions, per-id single-flight resolution, and expired-URL retry in the shim. Cold time-to-first-byte dropped roughly 5.1s to 2.9s, and about 10.9s to 3.75s under a burst.
- Persistent SQLite duration cache in the shim, keyed on the normalized artist-title, so a resolved YouTube length survives restarts. Cold about 1.7s, warm about 0.01s. Serves both Subsonic and Navidrome modes.

## Discovery in Navidrome mode
- External discovery is now injected into the native `/api/song` search (and single-song detail), not just Subsonic `search3`, off one shared core. Feishin and other Navidrome-mode clients get the same results.
- Playback and cover art reuse the existing `/rest/stream` and `/rest/getCoverArt` handlers, since native clients stream via Subsonic anyway.

## Self-configuring setup
- LAN server discovery: a credential-free Subsonic ping probe finds the Navidrome/Subsonic server on the local network, behind a "Detect on network" button, with a first-run auto-config that adopts a single detected server.
- Octo gets an identity toward Navidrome (captured from a relayed admin login, or optional configured admin credentials) used to auto-detect the music folder from `/api/library` and to run authenticated library rescans. Downloads follow the detected folder so they always land where Navidrome scans.
- A brand-new install can start with no URL set and configure itself.

## Rich downloads
- Every downloaded file is now properly tagged: title, artist, album, album artist, year, genre, track, ISRC, and an embedded 1000x1000 album cover, enriched from Deezer. Existing tags win, so a well-tagged FLAC is filled in rather than overwritten.
- Redundant "Artist - " title prefixes are stripped from both the tags and the filename.
- A persistent "Fetched songs" log records every download with cover art, save path, format, source, size, and time, shown in the dashboard.
- Download source is selectable: Soulseek FLAC, YouTube MP3, or Soulseek-then-YouTube fallback.

## Dashboard and setup clarity
- Restyled to the app's own design language: near-black ground, blue-gray accent, section headers above slab cards, horizontal setting rows, sliding toggles, and segmented controls.
- A prominent "point your apps at Octo, not Navidrome" callout with the live address, since that is the one setup step that trips people up (#1).
- A loud "discovery is off, add a Last.fm key" banner when no key is set, instead of silently returning nothing.

## Config
- New settings surfaced in `docker-compose.yml` and `.env.example` (admin credentials, auto-detect path). `SUBSONIC_URL` is optional now, auto-detected if blank.
- A `ytshim-cache` volume so the duration cache survives container recreate.

Update path is unchanged: `git pull && docker compose up -d --build`. All state stays on host mounts, so nothing is lost. Auto-detect-path only adopts a folder Octo can actually see, so it is safe on existing installs.
