### PR TITLE
Dated releases, and fix the image tagging that never ran

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,9 @@ name: Docker Build & Push
 on:
   workflow_dispatch:
   push:
-    tags: ['v*']
+    # Dated releases (2026.07.29) as well as any future v-prefixed ones. Without the
+    # second pattern a dated tag pushes silently and never builds an image.
+    tags: ['v*', '[0-9][0-9][0-9][0-9].*']
     branches: [main]
   pull_request:
     types: [closed]
@@ -73,11 +75,17 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
+            # Tags the image with the release name verbatim, e.g. 2026.07.29. The semver
+            # patterns below cannot match a dated tag (07 is not valid semver), so this
+            # is what actually labels a release build.
+            type=ref,event=tag
             type=sha,prefix=
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/dev' || github.event_name == 'workflow_dispatch' }}
+            # Was gated on refs/heads/dev, a branch this repo does not have, so `latest`
+            # was never published at all and `docker pull ...:latest` failed for everyone.
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ git pull && ./install.sh
 
 Re-running the installer keeps your existing answers.
 
+Octo builds from source, so `git pull` is what actually updates it. `docker compose pull` only refreshes slskd.
+
+### Which version am I on
+
+Releases are dated, so `2026.07.29` is the release cut on that day. Your running version is shown under **About** in the admin dashboard, and it is the single most useful thing to include in a bug report.
+
+To pin to a release instead of tracking `main`:
+
+```bash
+git checkout 2026.07.29 && ./install.sh
+```
+
+Prebuilt multi-arch images are also published to `ghcr.io/winters27/octo`, tagged `latest`, the release date, and the commit sha.
+
 ## Admin dashboard
 
 `http://<your-host>:5274/admin`

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -172,6 +172,9 @@ public class AdminController : ControllerBase
             {
                 ["ConfigFilePath"] = _settings.FilePath,
                 ["ConfigFileExists"] = System.IO.File.Exists(_settings.FilePath),
+                // So a bug report can name a build. Comes from <InformationalVersion>
+                // in octo.csproj, which is bumped when a release is tagged.
+                ["Version"] = OctoVersion,
             }
         };
         return new JsonResult(resp);
@@ -495,4 +498,16 @@ public class AdminController : ControllerBase
     }
 
     private record ServiceProbe(bool Ok, string Detail);
+
+    /// <summary>The release this build came from, e.g. "2026.07.29". Falls back to the
+    /// assembly version if the informational version was not stamped.</summary>
+    private static string OctoVersion =>
+        typeof(AdminController).Assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion
+            // .NET appends "+<commit sha>" to the informational version; trim it.
+            ?.Split('+')[0]
+        ?? typeof(AdminController).Assembly.GetName().Version?.ToString()
+        ?? "unknown";
 }

--- a/octo/octo.csproj
+++ b/octo/octo.csproj
@@ -5,6 +5,11 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>Octo</RootNamespace>
+        <!-- Dated releases. Version must be numeric for the assembly, so 07 loses its
+             leading zero there; InformationalVersion carries the tag name verbatim and
+             is what the dashboard shows. Bump both when tagging a release. -->
+        <Version>2026.7.29</Version>
+        <InformationalVersion>2026.07.29</InformationalVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -118,6 +118,10 @@ async function loadSettings() {
   if (cfgPath && currentSettings?._meta?.ConfigFilePath) {
     cfgPath.textContent = currentSettings._meta.ConfigFilePath;
   }
+  const version = document.getElementById('meta-version');
+  if (version && currentSettings?._meta?.Version) {
+    version.textContent = currentSettings._meta.Version;
+  }
   const slskdLink = document.getElementById('slskd-link');
   if (slskdLink) {
     const here = new URL(location.href);

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -641,6 +641,11 @@
         </div>
 
         <div class="info-card">
+          <h3 class="info-card-title">Version</h3>
+          <p>You are running Octo <code id="meta-version">unknown</code>. Include this in any bug report. Releases are dated, so <code>2026.07.29</code> is the release cut on that day.</p>
+        </div>
+
+        <div class="info-card">
           <h3 class="info-card-title">Settings file</h3>
           <p>Anything you change in this UI is persisted to <code id="meta-config-path">/app/config/settings.json</code>. That file overrides env vars on next read. Editing it by hand also works — changes hot-reload.</p>
         </div>


### PR DESCRIPTION
Sets up dated releases so issue reports can name a build, and fixes two bugs that would have made the first tag do nothing.

## Why

There were no tags, no releases, and nothing in the app reporting a version. "Pull latest and try again" was the only diagnostic available.

## Two bugs found while setting this up

- The Docker workflow only triggered on `tags: ['v*']`, so a dated tag like `2026.07.29` would have pushed silently and never built an image.
- `latest` was gated on `refs/heads/dev`, **a branch this repo does not have**, so it was never published. Confirmed against the registry: `ghcr.io/winters27/octo` had only `main` and per-commit sha tags. Anyone following `docker pull ...:latest` got nothing.

## Changes

- Workflow triggers on dated tags, and `type=ref,event=tag` labels the image with the release name. The existing semver patterns cannot match a dated tag, since `07` is not valid semver.
- `latest` now publishes from the default branch.
- The admin **About** pane shows the running version, from `InformationalVersion` via the settings endpoint's `_meta`.
- README gains a "which version am I on" section, and states plainly that Octo builds from source so `git pull` is what updates it. `docker compose pull` only refreshes slskd, which has caused repeated confusion in issues.

Verified by publishing and loading the dashboard: About reports `2026.07.29`. 108 tests pass.
