### PR TITLE
Stop a Deezer throttle from permanently emptying an album

### DIFF
--- a/octo.Tests/DeezerMetadataServiceTests.cs
+++ b/octo.Tests/DeezerMetadataServiceTests.cs
@@ -38,6 +38,68 @@ public class DeezerMetadataServiceTests
         return new DeezerMetadataService(factory.Object, new Mock<ILogger<DeezerMetadataService>>().Object);
     }
 
+    /// <summary>Deezer reports throttling as HTTP 200 with this body, which is the whole
+    /// reason a parsed document cannot be treated as a successful call.</summary>
+    private const string QuotaEnvelope =
+        @"{""error"":{""type"":""Exception"",""message"":""Quota limit exceeded"",""code"":4}}";
+
+    /// <summary>Deezer's only "this really does not exist" answer, also HTTP 200.</summary>
+    private const string NoDataEnvelope =
+        @"{""error"":{""type"":""DataException"",""message"":""no data"",""code"":800}}";
+
+    /// <summary>Like <see cref="BuildService"/>, but each route serves its bodies in order
+    /// and repeats the last one once exhausted, so a test can make a call fail and then
+    /// succeed. Routes are matched by url SUBSTRING, so "/album/1/tracks" must be
+    /// registered before "/album/1" or the shorter needle swallows both.</summary>
+    private static DeezerMetadataService BuildSequencedService(
+        List<(string Needle, string[] Bodies)> routes, out Func<string, int> callCount)
+    {
+        var counts = new Dictionary<string, int>();
+        var gate = new object();
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                var url = req.RequestUri!.ToString();
+                lock (gate)
+                {
+                    foreach (var (needle, bodies) in routes)
+                    {
+                        if (!url.Contains(needle, StringComparison.OrdinalIgnoreCase)) continue;
+                        counts.TryGetValue(needle, out var n);
+                        counts[needle] = n + 1;
+                        return new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent(bodies[Math.Min(n, bodies.Length - 1)]),
+                        };
+                    }
+                }
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler.Object));
+
+        callCount = needle => { lock (gate) { return counts.TryGetValue(needle, out var n) ? n : 0; } };
+        return new DeezerMetadataService(factory.Object, new Mock<ILogger<DeezerMetadataService>>().Object);
+    }
+
+    private const string AlbumDetailJson =
+        @"{""id"":711108,""title"":""Canciones Prohibidas"",""nb_tracks"":10,""label"":""WM Spain"",
+           ""release_date"":""1998-04-30"",""cover_xl"":""https://cdn/xl.jpg"",
+           ""artist"":{""name"":""Extremoduro""},""genres"":{""data"":[{""name"":""Pop""}]}}";
+
+    private static string TracksJson(int count) =>
+        @"{""total"":" + count + @",""data"":[" + string.Join(",",
+            Enumerable.Range(1, count).Select(i =>
+                $@"{{""title"":""Track {i}"",""duration"":200,""track_position"":{i},
+                     ""disk_number"":1,""artist"":{{""name"":""Extremoduro""}}}}")) + "]}";
+
     [Fact]
     public async Task SearchAlbumsAsync_MapsFieldsAndDropsSingles()
     {
@@ -157,5 +219,166 @@ public class DeezerMetadataServiceTests
 
         Assert.Empty(await svc.SearchAlbumsAsync("", 10));
         Assert.Empty(await svc.SearchAlbumsAsync("q", 0));
+    }
+
+    // ---- Quota-poisoning regression tests (issue #8) ------------------------
+    // Deezer answers HTTP 200 even when refusing a call, so a parsed document is not
+    // a successful call. Caching one of those refusals is what made an album report
+    // songCount 0 permanently.
+
+    /// <summary>
+    /// The exact reported failure: the album call succeeds and the TRACKLIST call is
+    /// throttled, which used to build a valid AlbumDetail carrying real title/year/genre
+    /// with an empty tracklist and cache it forever.
+    /// </summary>
+    [Fact]
+    public async Task GetAlbumDetailAsync_TracklistThrottled_NotCachedAndRecoversOnRetry()
+    {
+        var svc = BuildSequencedService(new()
+        {
+            // Longest needle first: "/album/711108" is a prefix of the tracks url.
+            ("/album/711108/tracks", new[] { QuotaEnvelope, TracksJson(10) }),
+            ("/album/711108", new[] { AlbumDetailJson }),
+        }, out var calls);
+
+        var first = await svc.GetAlbumDetailAsync("711108");
+        Assert.Null(first);
+
+        var second = await svc.GetAlbumDetailAsync("711108");
+        Assert.NotNull(second);
+        Assert.Equal(10, second!.Tracks.Count);
+        Assert.Equal("Canciones Prohibidas", second.Title);
+        Assert.Equal(1998, second.Year);
+
+        // Proves it retried rather than serving a cached failure.
+        Assert.Equal(2, calls("/album/711108/tracks"));
+    }
+
+    /// <summary>The other poisoning branch: the album call itself is throttled.</summary>
+    [Fact]
+    public async Task GetAlbumDetailAsync_AlbumCallThrottled_NotCachedAndRecoversOnRetry()
+    {
+        var svc = BuildSequencedService(new()
+        {
+            ("/album/711108/tracks", new[] { TracksJson(10) }),
+            ("/album/711108", new[] { QuotaEnvelope, AlbumDetailJson }),
+        }, out _);
+
+        Assert.Null(await svc.GetAlbumDetailAsync("711108"));
+
+        var second = await svc.GetAlbumDetailAsync("711108");
+        Assert.NotNull(second);
+        Assert.Equal(10, second!.Tracks.Count);
+    }
+
+    /// <summary>
+    /// Int() returns int?, and a lifted "nbTracks > 0" is FALSE when nb_tracks is absent.
+    /// Testing that alone would let an empty tracklist through and cache it, leaving the
+    /// reported bug fixed only for albums that happen to report a track count.
+    /// </summary>
+    [Fact]
+    public async Task GetAlbumDetailAsync_EmptyTracklistAndNoTrackCount_NotCached()
+    {
+        const string noNbTracks =
+            @"{""id"":711108,""title"":""Canciones Prohibidas"",""artist"":{""name"":""Extremoduro""}}";
+
+        var svc = BuildSequencedService(new()
+        {
+            ("/album/711108/tracks", new[] { @"{""data"":[]}", TracksJson(10) }),
+            ("/album/711108", new[] { noNbTracks, AlbumDetailJson }),
+        }, out _);
+
+        Assert.Null(await svc.GetAlbumDetailAsync("711108"));
+
+        var second = await svc.GetAlbumDetailAsync("711108");
+        Assert.NotNull(second);
+        Assert.Equal(10, second!.Tracks.Count);
+    }
+
+    /// <summary>
+    /// The case the guard must NOT break: Deezer says the album has zero tracks and
+    /// returns zero tracks. That is an answer, so it is cached rather than refetched
+    /// on every getAlbum forever.
+    /// </summary>
+    [Fact]
+    public async Task GetAlbumDetailAsync_GenuinelyEmptyAlbum_IsAnsweredAndCached()
+    {
+        const string zeroTracks =
+            @"{""id"":42,""title"":""Empty"",""nb_tracks"":0,""artist"":{""name"":""Nobody""}}";
+
+        var svc = BuildSequencedService(new()
+        {
+            ("/album/42/tracks", new[] { @"{""total"":0,""data"":[]}" }),
+            ("/album/42", new[] { zeroTracks }),
+        }, out var calls);
+
+        var first = await svc.GetAlbumDetailAsync("42");
+        Assert.NotNull(first);
+        Assert.Empty(first!.Tracks);
+
+        await svc.GetAlbumDetailAsync("42");
+        Assert.Equal(1, calls("/album/42/tracks"));
+    }
+
+    /// <summary>A definitive "no data" is cacheable, unlike a throttle.</summary>
+    [Fact]
+    public async Task GetAlbumDetailAsync_DefinitiveNoData_IsCached()
+    {
+        var svc = BuildSequencedService(new()
+        {
+            ("/album/999/tracks", new[] { TracksJson(3) }),
+            ("/album/999", new[] { NoDataEnvelope, AlbumDetailJson }),
+        }, out var calls);
+
+        Assert.Null(await svc.GetAlbumDetailAsync("999"));
+        Assert.Null(await svc.GetAlbumDetailAsync("999"));
+
+        // One call only: a definitive answer is allowed to stick.
+        Assert.Equal(1, calls("/album/999"));
+    }
+
+    /// <summary>
+    /// A throttled album search used to cache an empty list, so external albums silently
+    /// stopped appearing in search3 for the life of the process.
+    /// </summary>
+    [Fact]
+    public async Task SearchAlbumsAsync_Throttled_NotCachedAndRecoversOnRetry()
+    {
+        const string results =
+            @"{""data"":[{""id"":711108,""title"":""Canciones Prohibidas"",""record_type"":""album"",
+               ""nb_tracks"":10,""cover_xl"":""https://cdn/xl.jpg"",""artist"":{""name"":""Extremoduro""}}]}";
+
+        var svc = BuildSequencedService(new()
+        {
+            ("/search/album", new[] { QuotaEnvelope, results }),
+        }, out _);
+
+        Assert.Empty(await svc.SearchAlbumsAsync("extremoduro golfa", 10));
+
+        var second = await svc.SearchAlbumsAsync("extremoduro golfa", 10);
+        Assert.Single(second);
+        Assert.Equal("711108", second[0].DeezerId);
+    }
+
+    /// <summary>A throttled track search must not be cached as "this track has no metadata".</summary>
+    [Fact]
+    public async Task EnrichTrackAsync_Throttled_NotCachedAndRecoversOnRetry()
+    {
+        const string track =
+            @"{""data"":[{""title"":""Golfa"",""duration"":359,
+               ""album"":{""id"":711108,""title"":""Canciones Prohibidas"",""cover_xl"":""https://cdn/xl.jpg""},
+               ""artist"":{""name"":""Extremoduro""}}]}";
+
+        var svc = BuildSequencedService(new()
+        {
+            ("/search?q=", new[] { QuotaEnvelope, track }),
+            ("/album/711108", new[] { AlbumDetailJson }),
+        }, out _);
+
+        Assert.Null(await svc.EnrichTrackAsync("Extremoduro", "Golfa"));
+
+        var second = await svc.EnrichTrackAsync("Extremoduro", "Golfa");
+        Assert.NotNull(second);
+        Assert.Equal("Canciones Prohibidas", second!.AlbumTitle);
     }
 }

--- a/octo.Tests/DeezerMetadataServiceTests.cs
+++ b/octo.Tests/DeezerMetadataServiceTests.cs
@@ -360,6 +360,30 @@ public class DeezerMetadataServiceTests
         Assert.Equal("711108", second[0].DeezerId);
     }
 
+    /// <summary>
+    /// Entries now expire on their own, but a definitive negative still sticks for its TTL.
+    /// ClearCaches is the lever that turns "wait for the TTL" into "fixed now", so it has
+    /// to actually drop cached answers.
+    /// </summary>
+    [Fact]
+    public async Task ClearCaches_ForcesARefetch()
+    {
+        var svc = BuildSequencedService(new()
+        {
+            ("/album/999/tracks", new[] { TracksJson(3) }),
+            ("/album/999", new[] { NoDataEnvelope, AlbumDetailJson }),
+        }, out var calls);
+
+        Assert.Null(await svc.GetAlbumDetailAsync("999"));
+        Assert.Null(await svc.GetAlbumDetailAsync("999"));
+        Assert.Equal(1, calls("/album/999"));
+
+        svc.ClearCaches();
+
+        Assert.NotNull(await svc.GetAlbumDetailAsync("999"));
+        Assert.Equal(2, calls("/album/999"));
+    }
+
     /// <summary>A throttled track search must not be cached as "this track has no metadata".</summary>
     [Fact]
     public async Task EnrichTrackAsync_Throttled_NotCachedAndRecoversOnRetry()

--- a/octo.Tests/DeezerRateLimitHandlerTests.cs
+++ b/octo.Tests/DeezerRateLimitHandlerTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Octo.Services.Metadata;
+using System.Net;
+using System.Threading.RateLimiting;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The existing Deezer harness stubs CreateClient(It.IsAny&lt;string&gt;()), so it builds the
+/// named client WITHOUT this handler. These drive the handler pipeline directly, because
+/// the traps here are all silent: a wrongly-metered CDN, a lane that steals another lane's
+/// budget, or a rejection that never surfaces.
+/// </summary>
+public class DeezerRateLimitHandlerTests
+{
+    /// <summary>Terminates the chain and records what actually reached the network.</summary>
+    private sealed class CountingInnerHandler : HttpMessageHandler
+    {
+        public int Calls;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref Calls);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private static (HttpClient Client, CountingInnerHandler Inner, DeezerRateLimiter Limiter) Build()
+    {
+        var limiter = new DeezerRateLimiter();
+        var inner = new CountingInnerHandler();
+        var handler = new DeezerRateLimitHandler(limiter, new Mock<ILogger<DeezerRateLimitHandler>>().Object)
+        {
+            InnerHandler = inner,
+        };
+        return (new HttpClient(handler), inner, limiter);
+    }
+
+    /// <summary>
+    /// The cover-art lookup fetches image bytes from the CDN through the SAME client it
+    /// uses for API calls. Metering those would spend an API permit per rendered row and
+    /// throttle a host that has no quota, so the budget must ignore them entirely.
+    /// </summary>
+    [Fact]
+    public async Task CdnRequestsAreNotMetered()
+    {
+        var (client, inner, limiter) = Build();
+        using var _ = limiter;
+
+        // Far more than the interactive permit count, so metering these would visibly
+        // throttle them.
+        for (var i = 0; i < 120; i++)
+        {
+            var resp = await client.GetAsync($"https://cdn-images.dzcdn.net/images/cover/{i}/1000x1000.jpg");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+        Assert.Equal(120, inner.Calls);
+
+        // Asserting they merely SUCCEEDED is not enough: a metered burst still succeeds,
+        // it just waits for permits. What proves they were unmetered is that the whole
+        // interactive window is still intact afterwards, with every permit available
+        // without waiting.
+        var leases = new List<RateLimitLease>();
+        try
+        {
+            for (var i = 0; i < 30; i++)
+            {
+                var pending = limiter.AcquireAsync(background: false, CancellationToken.None);
+                Assert.True(pending.IsCompleted, $"interactive permit {i} had to wait, so CDN traffic spent the API budget");
+                var lease = await pending;
+                Assert.True(lease.IsAcquired);
+                leases.Add(lease);
+            }
+        }
+        finally
+        {
+            foreach (var l in leases) l.Dispose();
+        }
+    }
+
+    /// <summary>Anything that is not the Deezer API is passed straight through.</summary>
+    [Fact]
+    public async Task UnrelatedHostsArePassedThrough()
+    {
+        var (client, inner, limiter) = Build();
+        using var _ = limiter;
+
+        var resp = await client.GetAsync("https://itunes.apple.com/search?term=x");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(1, inner.Calls);
+    }
+
+    /// <summary>
+    /// API calls really do spend the budget, and it is bounded. Note this is a sliding
+    /// WINDOW: permits come back with time, not when a lease is disposed, so an
+    /// over-budget caller waits rather than being refused outright.
+    /// </summary>
+    [Fact]
+    public async Task ApiRequestsConsumeTheInteractiveBudget()
+    {
+        var (client, inner, limiter) = Build();
+        using var _l = limiter;
+
+        for (var i = 0; i < 30; i++)
+        {
+            var resp = await client.GetAsync($"https://api.deezer.com/album/{i}");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+        Assert.Equal(30, inner.Calls);
+
+        // The window is spent, so the next acquire must queue rather than complete now.
+        var queued = limiter.AcquireAsync(background: false, CancellationToken.None).AsTask();
+        Assert.False(queued.IsCompleted);
+
+        // Drain it so the ValueTask is observed rather than abandoned.
+        using var lease = await queued.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(lease.IsAcquired);
+    }
+
+    /// <summary>
+    /// Background cache warming must not be able to starve a search the user is waiting
+    /// on. Two limiters whose permits summed above the ceiling would defeat the point, so
+    /// this pins that they are genuinely separate allowances.
+    /// </summary>
+    [Fact]
+    public async Task BackgroundLaneDoesNotConsumeInteractivePermits()
+    {
+        var (_, _, limiter) = Build();
+        using var _l = limiter;
+
+        var background = new List<IDisposable>();
+        for (var i = 0; i < 10; i++)
+        {
+            var lease = await limiter.AcquireAsync(background: true, CancellationToken.None);
+            Assert.True(lease.IsAcquired);
+            background.Add(lease);
+        }
+
+        // Background is spent; interactive must still be immediately available.
+        using var interactive = await limiter.AcquireAsync(background: false, CancellationToken.None);
+        Assert.True(interactive.IsAcquired);
+
+        foreach (var l in background) l.Dispose();
+    }
+}

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -34,6 +34,8 @@ public class AdminController : ControllerBase
     private readonly SubsonicProxyService _proxy;
     private readonly SubsonicDiscoveryService _discovery;
     private readonly Octo.Services.Local.DownloadHistoryService _history;
+    private readonly Octo.Services.Metadata.DeezerMetadataService _deezer;
+    private readonly Octo.Services.CoverArt.CoverArtAggregator _coverArt;
     private readonly IHttpClientFactory _httpFactory;
     private readonly IHostApplicationLifetime _lifetime;
     private readonly ILogger<AdminController> _logger;
@@ -48,10 +50,14 @@ public class AdminController : ControllerBase
         SubsonicProxyService proxy,
         SubsonicDiscoveryService discovery,
         Octo.Services.Local.DownloadHistoryService history,
+        Octo.Services.Metadata.DeezerMetadataService deezer,
+        Octo.Services.CoverArt.CoverArtAggregator coverArt,
         IHttpClientFactory httpFactory,
         IHostApplicationLifetime lifetime,
         ILogger<AdminController> logger)
     {
+        _deezer = deezer;
+        _coverArt = coverArt;
         _settings = settings;
         _subsonicOpts = subsonicOpts;
         _soulseekOpts = soulseekOpts;
@@ -510,4 +516,22 @@ public class AdminController : ControllerBase
             ?.Split('+')[0]
         ?? typeof(AdminController).Assembly.GetName().Version?.ToString()
         ?? "unknown";
+
+    /// <summary>
+    /// Drop every cached metadata answer and cover image.
+    ///
+    /// Cached entries now expire on their own, so this is a recovery lever rather than
+    /// routine maintenance: it turns "wait for the TTL" into "fixed now" when a run of
+    /// throttled upstream calls has left albums or covers looking wrong. Clearing every
+    /// instance matters, because a poisoned entry surviving in one of them would outlive
+    /// the very button meant to remove it.
+    /// </summary>
+    [HttpPost("clear-metadata-cache")]
+    public IActionResult ClearMetadataCache()
+    {
+        _deezer.ClearCaches();
+        _coverArt.ClearCache();
+        _logger.LogInformation("Metadata and cover-art caches cleared by admin request");
+        return Ok(new { cleared = true });
+    }
 }

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -78,6 +78,17 @@ builder.Services.AddSingleton<RadioQueueStore>();
 builder.Services.AddSingleton<Octo.Services.Subsonic.NavidromeIdentityService>();
 builder.Services.AddSingleton<Octo.Services.Subsonic.SubsonicDiscoveryService>();
 builder.Services.AddSingleton<Octo.Services.Metadata.DeezerMetadataService>();
+
+// Deezer's public API allows roughly 50 requests per 5 seconds and signals refusal with
+// HTTP 200 plus an error body, so going over budget corrupts metadata rather than merely
+// failing. The limiter is the singleton that holds the budget; the handler is transient
+// because IHttpClientFactory recycles handler chains. Every Deezer caller must resolve
+// the named client or it bypasses this entirely.
+builder.Services.AddSingleton<Octo.Services.Metadata.DeezerRateLimiter>();
+builder.Services.AddTransient<Octo.Services.Metadata.DeezerRateLimitHandler>();
+builder.Services.AddHttpClient(Octo.Services.Metadata.DeezerRateLimiter.ClientName)
+    .AddHttpMessageHandler<Octo.Services.Metadata.DeezerRateLimitHandler>();
+
 builder.Services.AddSingleton<IMusicMetadataService, SoulseekMetadataService>();
 builder.Services.AddSingleton<IDownloadService, SoulseekDownloadService>();
 

--- a/octo/Services/CoverArt/CoverArtAggregator.cs
+++ b/octo/Services/CoverArt/CoverArtAggregator.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+using Microsoft.Extensions.Caching.Memory;
 using Octo.Services.Soulseek;
 
 namespace Octo.Services.CoverArt;
@@ -14,13 +14,25 @@ namespace Octo.Services.CoverArt;
 /// Last.fm last because its track image often points to the same iTunes
 /// asset we'd have gotten one source earlier.
 /// </summary>
-public class CoverArtAggregator
+public class CoverArtAggregator : IDisposable
 {
     private readonly IReadOnlyList<ICoverArtSource> _sources;
     private readonly ILogger<CoverArtAggregator> _logger;
 
-    private readonly ConcurrentDictionary<string, byte[]?> _cache = new();
-    private const int MaxCacheEntries = 4000;
+    // Bounded in BYTES, and on its own instance rather than shared with the metadata
+    // caches: these entries are 1000x1000 JPEGs at 150-400KB each, so an entry count
+    // that suits small metadata records would be a meaningless bound here.
+    private const long MaxCacheBytes = 256L * 1024 * 1024;
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions { SizeLimit = MaxCacheBytes });
+
+    private static readonly TimeSpan HitTtl = TimeSpan.FromHours(12);
+
+    /// <summary>A miss can be caused by a source being throttled, so it must not be
+    /// remembered for long enough to blank a cover for the life of the process.</summary>
+    private static readonly TimeSpan MissTtl = TimeSpan.FromMinutes(5);
+
+    /// <summary>Wrapper so a cached miss is distinguishable from a cache miss.</summary>
+    private sealed record Entry(byte[]? Bytes);
 
     public CoverArtAggregator(IEnumerable<ICoverArtSource> sources, ILogger<CoverArtAggregator> logger)
     {
@@ -33,16 +45,7 @@ public class CoverArtAggregator
     public async Task<byte[]?> GetCoverAsync(SoulseekRouting routing, CancellationToken ct = default)
     {
         var cacheKey = MakeCacheKey(routing);
-        if (_cache.TryGetValue(cacheKey, out var cached)) return cached;
-
-        // Bounded LRU-ish trim: when we cross the cap, drop the first half by
-        // dictionary order. ConcurrentDictionary doesn't preserve insertion
-        // order strictly but it's close enough — cache misses just re-fetch.
-        if (_cache.Count > MaxCacheEntries)
-        {
-            foreach (var key in _cache.Keys.Take(_cache.Count / 2))
-                _cache.TryRemove(key, out _);
-        }
+        if (_cache.TryGetValue(cacheKey, out Entry? cached)) return cached!.Bytes;
 
         foreach (var source in _sources)
         {
@@ -59,15 +62,32 @@ public class CoverArtAggregator
             if (bytes is { Length: > 0 })
             {
                 _logger.LogDebug("cover {Source} hit for {Key} ({Bytes} bytes)", source.Name, cacheKey, bytes.Length);
-                _cache[cacheKey] = bytes;
+                Put(cacheKey, bytes, bytes.Length, HitTtl);
                 return bytes;
             }
         }
 
         _logger.LogDebug("cover all-miss for {Key}", cacheKey);
-        _cache[cacheKey] = null;
+        Put(cacheKey, null, 1, MissTtl);
         return null;
     }
+
+    private void Put(string key, byte[]? bytes, long size, TimeSpan ttl) =>
+        _cache.Set(key, new Entry(bytes), new MemoryCacheEntryOptions
+        {
+            Size = size,
+            AbsoluteExpirationRelativeToNow = ttl,
+        });
+
+    /// <summary>Drop every cached cover. Exposed so a run of throttled lookups can be
+    /// cleared without restarting the container.</summary>
+    public void ClearCache()
+    {
+        _cache.Clear();
+        _logger.LogInformation("cover art cache cleared");
+    }
+
+    public void Dispose() => _cache.Dispose();
 
     private static string MakeCacheKey(SoulseekRouting r)
     {

--- a/octo/Services/CoverArt/DeezerCoverArtLookup.cs
+++ b/octo/Services/CoverArt/DeezerCoverArtLookup.cs
@@ -25,7 +25,9 @@ public class DeezerCoverArtLookup : ICoverArtSource
 
     public DeezerCoverArtLookup(IHttpClientFactory httpClientFactory, ILogger<DeezerCoverArtLookup> logger)
     {
-        _http = httpClientFactory.CreateClient();
+        // Named so API calls go through the shared Deezer rate limiter. This same client
+        // also fetches the image bytes from the CDN, which the handler leaves unmetered.
+        _http = httpClientFactory.CreateClient(Octo.Services.Metadata.DeezerRateLimiter.ClientName);
         _http.Timeout = TimeSpan.FromSeconds(8);
         _logger = logger;
     }

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Octo.Services.Metadata;
 
@@ -12,7 +13,7 @@ namespace Octo.Services.Metadata;
 /// returns null, and callers fall back to a synthetic entity. Nothing on this
 /// path ever blocks or fails playback.
 /// </summary>
-public class DeezerMetadataService
+public class DeezerMetadataService : IDisposable
 {
     public record TrackMeta(string? AlbumTitle, string? AlbumCoverUrl, int? Year, int? Duration,
         string? ArtistName, string? ArtistImageUrl);
@@ -64,18 +65,56 @@ public class DeezerMetadataService
         public void Dispose() => Doc?.Dispose();
     }
 
+    /// <summary>Good answers are stable, so this only needs to be short enough that a
+    /// long-lived container eventually picks up catalog corrections.</summary>
+    private static readonly TimeSpan PositiveTtl = TimeSpan.FromHours(12);
+
+    /// <summary>"Deezer answered and this does not exist." Still expires, because the
+    /// catalog gains releases.</summary>
+    private static readonly TimeSpan NegativeTtl = TimeSpan.FromMinutes(5);
+
+    /// <summary>A tracklist we know is incomplete. Usable now, refetched soon.</summary>
+    private static readonly TimeSpan PartialTtl = TimeSpan.FromMinutes(10);
+
     private readonly IHttpClientFactory _httpFactory;
     private readonly ILogger<DeezerMetadataService> _logger;
-    private readonly ConcurrentDictionary<string, TrackMeta?> _trackCache = new();
-    private readonly ConcurrentDictionary<string, FullTrackMeta?> _fullCache = new();
-    private readonly ConcurrentDictionary<string, ArtistMeta?> _artistCache = new();
-    private readonly ConcurrentDictionary<long, int?> _albumYearCache = new();
-    private readonly ConcurrentDictionary<string, List<AlbumHit>> _albumSearchCache = new();
-    private readonly ConcurrentDictionary<string, string?> _albumIdCache = new();
-    private readonly ConcurrentDictionary<string, AlbumDetail?> _albumDetailCache = new();
+
+    // Owned rather than injected from DI: metadata records are tens of bytes and
+    // cover-art blobs are hundreds of kilobytes, so a single shared SizeLimit cannot
+    // be right for both. Every entry counts as 1, so the limit is an entry count.
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions { SizeLimit = MaxCache });
+
     // Single-flight the album-year fetch: many tracks in one search share an album
     // (a whole album's tracks), so concurrent lookups collapse onto one HTTP call.
     private readonly ConcurrentDictionary<long, Lazy<Task<(int? Year, bool Transient)>>> _albumYearTasks = new();
+
+    /// <summary>Wrapper so a cached null is distinguishable from a cache miss.</summary>
+    private sealed record Entry<T>(T Value);
+
+    private bool TryGetCached<T>(string key, out T? value)
+    {
+        if (_cache.TryGetValue(key, out Entry<T>? e)) { value = e!.Value; return true; }
+        value = default;
+        return false;
+    }
+
+    private void Put<T>(string key, T value, TimeSpan ttl) =>
+        _cache.Set(key, new Entry<T>(value), new MemoryCacheEntryOptions
+        {
+            Size = 1,
+            AbsoluteExpirationRelativeToNow = ttl,
+        });
+
+    /// <summary>Drop every cached answer. Exposed so a poisoned cache can be cleared
+    /// without restarting the container.</summary>
+    public void ClearCaches()
+    {
+        _cache.Clear();
+        _albumYearTasks.Clear();
+        _logger.LogInformation("deezer metadata caches cleared");
+    }
+
+    public void Dispose() => _cache.Dispose();
 
     public DeezerMetadataService(IHttpClientFactory httpFactory, ILogger<DeezerMetadataService> logger)
     {
@@ -96,8 +135,8 @@ public class DeezerMetadataService
     public async Task<TrackMeta?> EnrichTrackAsync(string? artist, string? title, bool includeYear = true, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(artist) && string.IsNullOrWhiteSpace(title)) return null;
-        var key = $"{artist}|{title}".ToLowerInvariant();
-        if (_trackCache.TryGetValue(key, out var cached)) return cached;
+        var key = $"t|{artist}|{title}".ToLowerInvariant();
+        if (TryGetCached<TrackMeta?>(key, out var cached)) return cached;
 
         TrackMeta? meta = null;
         try
@@ -140,7 +179,7 @@ public class DeezerMetadataService
             _logger.LogDebug("deezer enrich track '{A} - {T}' failed: {M}", artist, title, ex.Message);
         }
 
-        Cache(_trackCache, key, meta);
+        Put(key, meta, meta is null ? NegativeTtl : PositiveTtl);
         return meta;
     }
 
@@ -153,7 +192,7 @@ public class DeezerMetadataService
     {
         if (string.IsNullOrWhiteSpace(artist) && string.IsNullOrWhiteSpace(title)) return null;
         var key = $"full|{artist}|{title}".ToLowerInvariant();
-        if (_fullCache.TryGetValue(key, out var cached)) return cached;
+        if (TryGetCached<FullTrackMeta?>(key, out var cached)) return cached;
 
         FullTrackMeta? meta = null;
         try
@@ -204,7 +243,7 @@ public class DeezerMetadataService
             _logger.LogDebug("deezer full enrich '{A} - {T}' failed: {M}", artist, title, ex.Message);
         }
 
-        Cache(_fullCache, key, meta);
+        Put(key, meta, meta is null ? NegativeTtl : PositiveTtl);
         return meta;
     }
 
@@ -212,8 +251,8 @@ public class DeezerMetadataService
     public async Task<ArtistMeta?> EnrichArtistAsync(string? artist, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(artist)) return null;
-        var key = artist.ToLowerInvariant();
-        if (_artistCache.TryGetValue(key, out var cached)) return cached;
+        var key = $"a|{artist}".ToLowerInvariant();
+        if (TryGetCached<ArtistMeta?>(key, out var cached)) return cached;
 
         ArtistMeta? meta = null;
         try
@@ -229,7 +268,7 @@ public class DeezerMetadataService
             _logger.LogDebug("deezer enrich artist '{A}' failed: {M}", artist, ex.Message);
         }
 
-        Cache(_artistCache, key, meta);
+        Put(key, meta, meta is null ? NegativeTtl : PositiveTtl);
         return meta;
     }
 
@@ -238,8 +277,8 @@ public class DeezerMetadataService
     public async Task<List<AlbumHit>> SearchAlbumsAsync(string query, int limit, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query) || limit <= 0) return new List<AlbumHit>();
-        var key = $"{query}|{limit}".ToLowerInvariant();
-        if (_albumSearchCache.TryGetValue(key, out var cached)) return cached;
+        var key = $"as|{query}|{limit}".ToLowerInvariant();
+        if (TryGetCached<List<AlbumHit>>(key, out var cached)) return cached!;
 
         var hits = new List<AlbumHit>();
         try
@@ -279,7 +318,7 @@ public class DeezerMetadataService
             _logger.LogDebug("deezer album search '{Q}' failed: {M}", query, ex.Message);
         }
 
-        Cache(_albumSearchCache, key, hits);
+        Put(key, hits, hits.Count == 0 ? NegativeTtl : PositiveTtl);
         return hits;
     }
 
@@ -288,8 +327,8 @@ public class DeezerMetadataService
     public async Task<string?> FindAlbumIdAsync(string? artist, string? album, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(album)) return null;
-        var key = $"{artist}|{album}".ToLowerInvariant();
-        if (_albumIdCache.TryGetValue(key, out var cached)) return cached;
+        var key = $"ai|{artist}|{album}".ToLowerInvariant();
+        if (TryGetCached<string?>(key, out var cached)) return cached;
 
         string? id = null;
         try
@@ -309,7 +348,7 @@ public class DeezerMetadataService
             _logger.LogDebug("deezer album id lookup '{A} - {Al}' failed: {M}", artist, album, ex.Message);
         }
 
-        Cache(_albumIdCache, key, id);
+        Put(key, id, id is null ? NegativeTtl : PositiveTtl);
         return id;
     }
 
@@ -319,9 +358,13 @@ public class DeezerMetadataService
     public async Task<AlbumDetail?> GetAlbumDetailAsync(string deezerId, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(deezerId)) return null;
-        if (_albumDetailCache.TryGetValue(deezerId, out var cached)) return cached;
+        var cacheKey = $"ad|{deezerId}";
+        if (TryGetCached<AlbumDetail?>(cacheKey, out var cached)) return cached;
 
         AlbumDetail? detail = null;
+        // A tracklist we know is short gets a shorter life than a complete one, so a
+        // truncated or partly-skipped album repairs itself instead of sticking.
+        var partial = false;
         try
         {
             string title = "", artist = "", genre = "", label = "", cover = "";
@@ -353,7 +396,8 @@ public class DeezerMetadataService
                 }
             }
 
-            if (string.IsNullOrWhiteSpace(title)) { Cache(_albumDetailCache, deezerId, null); return null; }
+            // Deezer answered and there is no such album. Cacheable, but not forever.
+            if (string.IsNullOrWhiteSpace(title)) { Put(cacheKey, (AlbumDetail?)null, NegativeTtl); return null; }
 
             var tracks = new List<AlbumTrack>();
             using (var tr = await GetJsonAsync($"{Base}/album/{deezerId}/tracks?limit=300", ct))
@@ -379,9 +423,12 @@ public class DeezerMetadataService
 
                     var total = Int(tr.Doc.RootElement, "total");
                     if (total is int n && n > tracks.Count)
+                    {
+                        partial = true;
                         _logger.LogWarning(
                             "deezer album '{Title}' ({Id}) returned {Got} of {Total} tracks; tracklist is truncated",
                             title, deezerId, tracks.Count, n);
+                    }
                 }
             }
 
@@ -396,6 +443,9 @@ public class DeezerMetadataService
                     title, deezerId, nbTracks?.ToString() ?? "an unknown number of");
                 return null;
             }
+
+            // Fewer tracks than the album claims, e.g. entries skipped for a blank title.
+            if (nbTracks is int expected && tracks.Count < expected) partial = true;
 
             tracks = tracks
                 .OrderBy(t => t.DiscNumber ?? 1)
@@ -413,13 +463,13 @@ public class DeezerMetadataService
             _logger.LogDebug("deezer album detail {Id} failed: {M}", deezerId, ex.Message);
         }
 
-        Cache(_albumDetailCache, deezerId, detail);
+        Put(cacheKey, detail, detail is null ? NegativeTtl : partial ? PartialTtl : PositiveTtl);
         return detail;
     }
 
     private Task<(int? Year, bool Transient)> AlbumYearAsync(long albumId, CancellationToken ct)
     {
-        if (_albumYearCache.TryGetValue(albumId, out var y)) return Task.FromResult<(int?, bool)>((y, false));
+        if (TryGetCached<int?>($"y|{albumId}", out var y)) return Task.FromResult<(int?, bool)>((y, false));
         // Shared across concurrent callers for the same album id (single-flight).
         return _albumYearTasks.GetOrAdd(albumId,
             id => new Lazy<Task<(int? Year, bool Transient)>>(() => FetchAlbumYearAsync(id))).Value;
@@ -431,14 +481,14 @@ public class DeezerMetadataService
         using var r = await GetJsonAsync($"{Base}/album/{albumId}", CancellationToken.None);
         _albumYearTasks.TryRemove(albumId, out _);
 
-        // This write bypasses Cache() and is the one that used to make a throttled
-        // year lookup permanent.
+        // This used to be a raw indexer write after a bare catch, so it bypassed the
+        // cache helper entirely and a throttled year lookup stuck permanently.
         if (r.Transient) return (null, true);
 
         var rd = r.Doc is null ? null : Str(r.Doc.RootElement, "release_date");
         if (!string.IsNullOrEmpty(rd) && rd.Length >= 4 && int.TryParse(rd[..4], out var yr))
             year = yr;
-        _albumYearCache[albumId] = year;
+        Put($"y|{albumId}", year, year is null ? NegativeTtl : PositiveTtl);
         return (year, false);
     }
 
@@ -494,9 +544,4 @@ public class DeezerMetadataService
     private static int? Int(JsonElement e, string name)
         => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt32() : (int?)null;
 
-    private static void Cache<TK, TV>(ConcurrentDictionary<TK, TV> cache, TK key, TV val) where TK : notnull
-    {
-        cache[key] = val;
-        if (cache.Count > MaxCache) cache.Clear();  // crude bound; simple and safe
-    }
 }

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -124,7 +124,9 @@ public class DeezerMetadataService : IDisposable
 
     private HttpClient Client()
     {
-        var c = _httpFactory.CreateClient();
+        // Named so the rate-limiting handler is in the chain. Resolving the default
+        // client here would silently bypass Deezer's budget.
+        var c = _httpFactory.CreateClient(DeezerRateLimiter.ClientName);
         c.Timeout = TimeSpan.FromSeconds(8);
         return c;
     }
@@ -132,7 +134,8 @@ public class DeezerMetadataService : IDisposable
     /// <summary>Resolve "artist + title" to the real album + artist (name, art, year).
     /// Pass includeYear=false to skip the extra album-detail call (bulk enrichment
     /// wants duration + album fast; the year is fetched lazily by the album view).</summary>
-    public async Task<TrackMeta?> EnrichTrackAsync(string? artist, string? title, bool includeYear = true, CancellationToken ct = default)
+    public async Task<TrackMeta?> EnrichTrackAsync(string? artist, string? title, bool includeYear = true,
+        bool background = false, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(artist) && string.IsNullOrWhiteSpace(title)) return null;
         var key = $"t|{artist}|{title}".ToLowerInvariant();
@@ -142,7 +145,7 @@ public class DeezerMetadataService : IDisposable
         try
         {
             var q = Uri.EscapeDataString($"artist:\"{artist}\" track:\"{title}\"");
-            using var r = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct);
+            using var r = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct, background);
             if (r.Transient) return null;
             if (FirstData(r.Doc) is JsonElement t)
             {
@@ -492,12 +495,17 @@ public class DeezerMetadataService : IDisposable
         return (year, false);
     }
 
-    private async Task<DeezerResponse> GetJsonAsync(string url, CancellationToken ct)
+    private async Task<DeezerResponse> GetJsonAsync(string url, CancellationToken ct, bool background = false)
     {
         JsonDocument? doc = null;
         try
         {
-            using var resp = await Client().GetAsync(url, ct);
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            if (background) req.Options.Set(DeezerRateLimitHandler.BackgroundLane, true);
+
+            using var resp = await Client().SendAsync(req, ct);
+            // A 429 here is usually our OWN limiter shedding load rather than Deezer's,
+            // and either way it is transient, so nothing derived from it is cached.
             if (!resp.IsSuccessStatusCode) return new DeezerResponse { Transient = true };
 
             var s = await resp.Content.ReadAsStringAsync(ct);

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -40,6 +40,30 @@ public class DeezerMetadataService
     private const string Base = "https://api.deezer.com";
     private const int MaxCache = 4096;
 
+    /// <summary>
+    /// The only Deezer error code meaning "this genuinely does not exist". Everything
+    /// else, including quota (code 4) and any code we do not recognise, is treated as
+    /// transient. Caching an error we do not understand is exactly how one throttled
+    /// call turned into an album that reported zero tracks for the life of the process.
+    /// </summary>
+    private const int DefinitiveErrorCode = 800;
+
+    /// <summary>
+    /// Result of one Deezer call. Deezer answers HTTP 200 even when it is refusing the
+    /// request, so "we parsed a document" is not the same as "the call succeeded", and
+    /// callers must never cache anything derived from a transient failure.
+    /// </summary>
+    private sealed class DeezerResponse : IDisposable
+    {
+        public JsonDocument? Doc { get; init; }
+
+        /// <summary>Failed in a way that may succeed later. Nothing about this call
+        /// may be written to a cache.</summary>
+        public bool Transient { get; init; }
+
+        public void Dispose() => Doc?.Dispose();
+    }
+
     private readonly IHttpClientFactory _httpFactory;
     private readonly ILogger<DeezerMetadataService> _logger;
     private readonly ConcurrentDictionary<string, TrackMeta?> _trackCache = new();
@@ -51,7 +75,7 @@ public class DeezerMetadataService
     private readonly ConcurrentDictionary<string, AlbumDetail?> _albumDetailCache = new();
     // Single-flight the album-year fetch: many tracks in one search share an album
     // (a whole album's tracks), so concurrent lookups collapse onto one HTTP call.
-    private readonly ConcurrentDictionary<long, Lazy<Task<int?>>> _albumYearTasks = new();
+    private readonly ConcurrentDictionary<long, Lazy<Task<(int? Year, bool Transient)>>> _albumYearTasks = new();
 
     public DeezerMetadataService(IHttpClientFactory httpFactory, ILogger<DeezerMetadataService> logger)
     {
@@ -79,8 +103,9 @@ public class DeezerMetadataService
         try
         {
             var q = Uri.EscapeDataString($"artist:\"{artist}\" track:\"{title}\"");
-            using var doc = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct);
-            if (FirstData(doc) is JsonElement t)
+            using var r = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct);
+            if (r.Transient) return null;
+            if (FirstData(r.Doc) is JsonElement t)
             {
                 string? albTitle = null, cover = null, artName = null, artImg = null;
                 long albId = 0;
@@ -98,7 +123,15 @@ public class DeezerMetadataService
                 }
                 int? duration = t.TryGetProperty("duration", out var du) && du.ValueKind == JsonValueKind.Number
                     ? du.GetInt32() : null;
-                var year = includeYear && albId > 0 ? await AlbumYearAsync(albId, ct) : null;
+                int? year = null;
+                if (includeYear && albId > 0)
+                {
+                    var (y, yearTransient) = await AlbumYearAsync(albId, ct);
+                    // A throttled year lookup would otherwise be cached as "this track
+                    // has no year", permanently, on an otherwise good result.
+                    if (yearTransient) return null;
+                    year = y;
+                }
                 meta = new TrackMeta(albTitle, cover, year, duration, artName, artImg);
             }
         }
@@ -126,8 +159,9 @@ public class DeezerMetadataService
         try
         {
             var q = Uri.EscapeDataString($"artist:\"{artist}\" track:\"{title}\"");
-            using var doc = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct);
-            if (FirstData(doc) is JsonElement t)
+            using var r = await GetJsonAsync($"{Base}/search?q={q}&limit=1", ct);
+            if (r.Transient) return null;
+            if (FirstData(r.Doc) is JsonElement t)
             {
                 string? albTitle = null, cover = null, artName = null;
                 var isrc = Str(t, "isrc");
@@ -145,10 +179,11 @@ public class DeezerMetadataService
                 string? genre = null, label = null, releaseDate = null;
                 if (albId > 0)
                 {
-                    using var adoc = await GetJsonAsync($"{Base}/album/{albId}", ct);
-                    if (adoc != null)
+                    using var ar = await GetJsonAsync($"{Base}/album/{albId}", ct);
+                    if (ar.Transient) return null;
+                    if (ar.Doc != null)
                     {
-                        var root = adoc.RootElement;
+                        var root = ar.Doc.RootElement;
                         releaseDate = Str(root, "release_date");
                         if (!string.IsNullOrEmpty(releaseDate) && releaseDate.Length >= 4 && int.TryParse(releaseDate[..4], out var yr))
                             year = yr;
@@ -184,8 +219,9 @@ public class DeezerMetadataService
         try
         {
             var q = Uri.EscapeDataString(artist);
-            using var doc = await GetJsonAsync($"{Base}/search/artist?q={q}&limit=1", ct);
-            if (FirstData(doc) is JsonElement a)
+            using var r = await GetJsonAsync($"{Base}/search/artist?q={q}&limit=1", ct);
+            if (r.Transient) return null;
+            if (FirstData(r.Doc) is JsonElement a)
                 meta = new ArtistMeta(Str(a, "name"), Str(a, "picture_xl") ?? Str(a, "picture_medium"));
         }
         catch (Exception ex)
@@ -209,9 +245,12 @@ public class DeezerMetadataService
         try
         {
             var q = Uri.EscapeDataString(query);
-            using var doc = await GetJsonAsync($"{Base}/search/album?q={q}&limit={limit}", ct);
-            if (doc is not null
-                && doc.RootElement.TryGetProperty("data", out var data)
+            using var r = await GetJsonAsync($"{Base}/search/album?q={q}&limit={limit}", ct);
+            // Caching an empty list here is what would make external albums silently
+            // vanish from search3 for the rest of the process.
+            if (r.Transient) return new List<AlbumHit>();
+            if (r.Doc is not null
+                && r.Doc.RootElement.TryGetProperty("data", out var data)
                 && data.ValueKind == JsonValueKind.Array)
             {
                 // Materialize everything before the JsonDocument is disposed.
@@ -257,8 +296,9 @@ public class DeezerMetadataService
         {
             var q = Uri.EscapeDataString(
                 string.IsNullOrWhiteSpace(artist) ? $"album:\"{album}\"" : $"artist:\"{artist}\" album:\"{album}\"");
-            using var doc = await GetJsonAsync($"{Base}/search/album?q={q}&limit=1", ct);
-            if (FirstData(doc) is JsonElement a
+            using var r = await GetJsonAsync($"{Base}/search/album?q={q}&limit=1", ct);
+            if (r.Transient) return null;
+            if (FirstData(r.Doc) is JsonElement a
                 && a.TryGetProperty("id", out var aid) && aid.ValueKind == JsonValueKind.Number)
             {
                 id = aid.GetInt64().ToString();
@@ -286,12 +326,18 @@ public class DeezerMetadataService
         {
             string title = "", artist = "", genre = "", label = "", cover = "";
             int? year = null;
+            // Declared out here on purpose: the document below is disposed before the
+            // tracklist call, and this is what tells an empty tracklist apart from an
+            // album that genuinely has no tracks.
+            int? nbTracks = null;
 
-            using (var doc = await GetJsonAsync($"{Base}/album/{deezerId}", ct))
+            using (var r = await GetJsonAsync($"{Base}/album/{deezerId}", ct))
             {
-                if (doc is not null)
+                if (r.Transient) return null;
+                if (r.Doc is not null)
                 {
-                    var root = doc.RootElement;
+                    var root = r.Doc.RootElement;
+                    nbTracks = Int(root, "nb_tracks");
                     title = Str(root, "title") ?? "";
                     cover = Str(root, "cover_xl") ?? Str(root, "cover_medium") ?? "";
                     label = Str(root, "label") ?? "";
@@ -310,10 +356,15 @@ public class DeezerMetadataService
             if (string.IsNullOrWhiteSpace(title)) { Cache(_albumDetailCache, deezerId, null); return null; }
 
             var tracks = new List<AlbumTrack>();
-            using (var doc = await GetJsonAsync($"{Base}/album/{deezerId}/tracks?limit=300", ct))
+            using (var tr = await GetJsonAsync($"{Base}/album/{deezerId}/tracks?limit=300", ct))
             {
-                if (doc is not null
-                    && doc.RootElement.TryGetProperty("data", out var data)
+                // The album call can succeed while the tracklist call is throttled. That
+                // built a perfectly valid AlbumDetail carrying title, year and genre with
+                // an empty tracklist, cached it permanently, and is why getAlbum reported
+                // songCount 0 forever while still showing real metadata.
+                if (tr.Transient) return null;
+                if (tr.Doc is not null
+                    && tr.Doc.RootElement.TryGetProperty("data", out var data)
                     && data.ValueKind == JsonValueKind.Array)
                 {
                     foreach (var t in data.EnumerateArray())
@@ -326,12 +377,24 @@ public class DeezerMetadataService
                             Int(t, "track_position"), Int(t, "disk_number"), Str(t, "isrc")));
                     }
 
-                    var total = Int(doc.RootElement, "total");
+                    var total = Int(tr.Doc.RootElement, "total");
                     if (total is int n && n > tracks.Count)
                         _logger.LogWarning(
                             "deezer album '{Title}' ({Id}) returned {Got} of {Total} tracks; tracklist is truncated",
                             title, deezerId, tracks.Count, n);
                 }
+            }
+
+            // An empty tracklist on an album Deezer says HAS tracks is a failure, not an
+            // answer. Note the null check is load-bearing: Int() returns int?, and a lifted
+            // `nbTracks > 0` is FALSE when nb_tracks is absent, so testing that alone would
+            // let the empty result through and cache it exactly as before.
+            if (tracks.Count == 0 && (nbTracks is null || nbTracks > 0))
+            {
+                _logger.LogWarning(
+                    "deezer album '{Title}' ({Id}) reports {Expected} track(s) but returned none; not caching",
+                    title, deezerId, nbTracks?.ToString() ?? "an unknown number of");
+                return null;
             }
 
             tracks = tracks
@@ -354,36 +417,67 @@ public class DeezerMetadataService
         return detail;
     }
 
-    private Task<int?> AlbumYearAsync(long albumId, CancellationToken ct)
+    private Task<(int? Year, bool Transient)> AlbumYearAsync(long albumId, CancellationToken ct)
     {
-        if (_albumYearCache.TryGetValue(albumId, out var y)) return Task.FromResult(y);
+        if (_albumYearCache.TryGetValue(albumId, out var y)) return Task.FromResult<(int?, bool)>((y, false));
         // Shared across concurrent callers for the same album id (single-flight).
         return _albumYearTasks.GetOrAdd(albumId,
-            id => new Lazy<Task<int?>>(() => FetchAlbumYearAsync(id))).Value;
+            id => new Lazy<Task<(int? Year, bool Transient)>>(() => FetchAlbumYearAsync(id))).Value;
     }
 
-    private async Task<int?> FetchAlbumYearAsync(long albumId)
+    private async Task<(int? Year, bool Transient)> FetchAlbumYearAsync(long albumId)
     {
         int? year = null;
-        try
-        {
-            using var doc = await GetJsonAsync($"{Base}/album/{albumId}", CancellationToken.None);
-            var rd = doc is null ? null : Str(doc.RootElement, "release_date");
-            if (!string.IsNullOrEmpty(rd) && rd.Length >= 4 && int.TryParse(rd[..4], out var yr))
-                year = yr;
-        }
-        catch { /* best-effort */ }
-        _albumYearCache[albumId] = year;
+        using var r = await GetJsonAsync($"{Base}/album/{albumId}", CancellationToken.None);
         _albumYearTasks.TryRemove(albumId, out _);
-        return year;
+
+        // This write bypasses Cache() and is the one that used to make a throttled
+        // year lookup permanent.
+        if (r.Transient) return (null, true);
+
+        var rd = r.Doc is null ? null : Str(r.Doc.RootElement, "release_date");
+        if (!string.IsNullOrEmpty(rd) && rd.Length >= 4 && int.TryParse(rd[..4], out var yr))
+            year = yr;
+        _albumYearCache[albumId] = year;
+        return (year, false);
     }
 
-    private async Task<JsonDocument?> GetJsonAsync(string url, CancellationToken ct)
+    private async Task<DeezerResponse> GetJsonAsync(string url, CancellationToken ct)
     {
-        using var resp = await Client().GetAsync(url, ct);
-        if (!resp.IsSuccessStatusCode) return null;
-        var s = await resp.Content.ReadAsStringAsync(ct);
-        return JsonDocument.Parse(s);
+        JsonDocument? doc = null;
+        try
+        {
+            using var resp = await Client().GetAsync(url, ct);
+            if (!resp.IsSuccessStatusCode) return new DeezerResponse { Transient = true };
+
+            var s = await resp.Content.ReadAsStringAsync(ct);
+            doc = JsonDocument.Parse(s);
+
+            // Deezer reports throttling as 200 + {"error":{"code":4,...}}, which parses
+            // perfectly and then reads as "the album has no tracks". Catching it here is
+            // what stops a quota blip becoming permanent cached state.
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("error", out var err)
+                && err.ValueKind == JsonValueKind.Object)
+            {
+                var code = Int(err, "code");
+                var definitive = code == DefinitiveErrorCode;
+                _logger.LogWarning("deezer refused {Url}: {Type} \"{Msg}\" (code {Code}, treated as {Kind})",
+                    url, Str(err, "type"), Str(err, "message"), code, definitive ? "definitive" : "transient");
+                doc.Dispose();
+                return new DeezerResponse { Transient = !definitive };
+            }
+
+            var ok = new DeezerResponse { Doc = doc };
+            doc = null;
+            return ok;
+        }
+        catch (Exception ex)
+        {
+            doc?.Dispose();
+            _logger.LogDebug("deezer request {Url} failed: {M}", url, ex.Message);
+            return new DeezerResponse { Transient = true };
+        }
     }
 
     private static JsonElement? FirstData(JsonDocument? doc)

--- a/octo/Services/Metadata/DeezerRateLimitHandler.cs
+++ b/octo/Services/Metadata/DeezerRateLimitHandler.cs
@@ -1,0 +1,51 @@
+using System.Net;
+
+namespace Octo.Services.Metadata;
+
+/// <summary>
+/// Spends a <see cref="DeezerRateLimiter"/> permit before each Deezer API call.
+/// Transient by design: IHttpClientFactory recycles handler chains, so the limiter
+/// itself is the singleton and this is just the seam that consults it.
+/// </summary>
+public sealed class DeezerRateLimitHandler : DelegatingHandler
+{
+    /// <summary>Marks a request as background work, so cache warming yields to anything
+    /// a user is actually waiting on.</summary>
+    public static readonly HttpRequestOptionsKey<bool> BackgroundLane = new("octo.deezer.background");
+
+    private const string ApiHost = "api.deezer.com";
+
+    private readonly DeezerRateLimiter _limiter;
+    private readonly ILogger<DeezerRateLimitHandler> _logger;
+
+    public DeezerRateLimitHandler(DeezerRateLimiter limiter, ILogger<DeezerRateLimitHandler> logger)
+    {
+        _limiter = limiter;
+        _logger = logger;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+    {
+        // Only the API is metered. The cover-art lookup pulls actual image bytes from
+        // cdn-images.dzcdn.net through this same client, and that host has no quota:
+        // metering it would spend an API permit per rendered row and throttle a CDN for
+        // nothing.
+        if (!string.Equals(request.RequestUri?.Host, ApiHost, StringComparison.OrdinalIgnoreCase))
+            return await base.SendAsync(request, ct);
+
+        var background = request.Options.TryGetValue(BackgroundLane, out var bg) && bg;
+
+        using var lease = await _limiter.AcquireAsync(background, ct);
+        if (!lease.IsAcquired)
+        {
+            // The queue is full. Answering 429 rather than throwing means callers take
+            // their existing "Deezer refused this" path, which never caches the result —
+            // so back-pressure can slow us down but can never poison the cache.
+            _logger.LogWarning("deezer rate limiter rejected a {Lane} request to {Url}",
+                background ? "background" : "interactive", request.RequestUri);
+            return new HttpResponseMessage(HttpStatusCode.TooManyRequests) { RequestMessage = request };
+        }
+
+        return await base.SendAsync(request, ct);
+    }
+}

--- a/octo/Services/Metadata/DeezerRateLimiter.cs
+++ b/octo/Services/Metadata/DeezerRateLimiter.cs
@@ -1,0 +1,60 @@
+using System.Threading.RateLimiting;
+
+namespace Octo.Services.Metadata;
+
+/// <summary>
+/// Keeps Octo inside Deezer's public-API budget of roughly 50 requests per 5 seconds.
+///
+/// Exceeding it does not produce a 429. Deezer answers HTTP 200 with an error envelope,
+/// which used to parse as a valid-but-empty payload and get cached, so going over budget
+/// was silently destructive rather than merely slow (issue #8).
+///
+/// Two lanes, one budget. Interactive work (a search the user is waiting on, cover art a
+/// client is rendering) must not queue behind background cache warming. The permit counts
+/// are chosen to SUM below the ceiling: separate limiters each get their own window, so
+/// two generous lanes would admit their total rather than capping it.
+/// </summary>
+public sealed class DeezerRateLimiter : IDisposable
+{
+    /// <summary>Named HttpClient that carries the limiting handler. Both the metadata
+    /// service and the cover-art lookup must resolve this name or they bypass the budget.</summary>
+    public const string ClientName = "deezer";
+
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(5);
+
+    // 30 + 10 = 40 of Deezer's ~50, leaving headroom for retries elsewhere and for the
+    // fact that the ceiling is approximate rather than published as a contract.
+    private const int InteractivePermits = 30;
+    private const int BackgroundPermits = 10;
+
+    // Queue depths are bounded by the 8s HttpClient timeout, which now covers waiting for
+    // a permit as well as the call itself. Interactive drains at 6/s, so 32 queued is a
+    // ~5s worst case and stays inside it; a deeper queue would just manufacture timeouts.
+    private readonly SlidingWindowRateLimiter _interactive = Build(InteractivePermits, queueLimit: 32);
+    private readonly SlidingWindowRateLimiter _background = Build(BackgroundPermits, queueLimit: 32);
+
+    private static SlidingWindowRateLimiter Build(int permits, int queueLimit) =>
+        new(new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = permits,
+            Window = Window,
+            // One-second granularity, so permits free up smoothly instead of all at once
+            // at the end of each window.
+            SegmentsPerWindow = 5,
+            // Must be set explicitly: it defaults to 0, which makes AcquireAsync return a
+            // NON-acquired lease immediately instead of waiting. Every over-budget call
+            // would then be dropped rather than delayed.
+            QueueLimit = queueLimit,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = true,
+        });
+
+    public ValueTask<RateLimitLease> AcquireAsync(bool background, CancellationToken ct) =>
+        (background ? _background : _interactive).AcquireAsync(1, ct);
+
+    public void Dispose()
+    {
+        _interactive.Dispose();
+        _background.Dispose();
+    }
+}

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -155,7 +155,7 @@ public class SoulseekMetadataService : IMusicMetadataService
             {
                 // Sequential on purpose: this has no deadline, and fanning out here is
                 // what would eat the quota the awaited set needs.
-                try { await _deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: false); }
+                try { await _deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: false, background: true); }
                 catch { /* best-effort */ }
             }
         });

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -336,18 +336,35 @@ public class SoulseekMetadataService : IMusicMetadataService
             ExternalId = externalId,
         };
 
-        if (string.IsNullOrEmpty(deezerAlbumId)) return album;
+        if (string.IsNullOrEmpty(deezerAlbumId))
+        {
+            // Logged rather than silent: this is what a user sees as an album that opens
+            // with no tracks, and without a line here there is nothing to diagnose from.
+            _logger.LogWarning(
+                "getAlbum '{Artist} - {Album}' ({Id}): no Deezer album id resolved; returning album without a tracklist",
+                routing.Artist, placeholder, externalId);
+            return album;
+        }
 
         var detail = await _deezer.GetAlbumDetailAsync(deezerAlbumId);
         // An album with no resolvable tracklist must still render, so fall through with
         // whatever we already have rather than failing the request.
-        if (detail is null) return album;
+        if (detail is null)
+        {
+            _logger.LogWarning(
+                "getAlbum '{Artist} - {Album}' ({Id}): Deezer album {DeezerId} returned no usable detail "
+                + "(see the deezer warning above for why); returning album without a tracklist",
+                routing.Artist, placeholder, externalId, deezerAlbumId);
+            return album;
+        }
 
         album.Title = detail.Title;
         album.Year = detail.Year ?? album.Year;
         album.Genre = detail.Genre;
         album.CoverArtUrl = detail.CoverUrl ?? album.CoverArtUrl;
-        album.SongCount = detail.Tracks.Count;
+        // Defence in depth: the Deezer layer no longer returns a tracklist-less album,
+        // but if one ever gets through, reporting zero is worse than saying nothing.
+        if (detail.Tracks.Count > 0) album.SongCount = detail.Tracks.Count;
         if (!string.IsNullOrWhiteSpace(detail.Artist)) album.Artist = detail.Artist;
 
         foreach (var track in detail.Tracks)

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -89,16 +89,27 @@ public class SoulseekMetadataService : IMusicMetadataService
         });
     }
 
-    // Cap Deezer calls per search so a big result set (Feishin requests up to 200)
-    // does not add seconds of latency or trip Deezer's rate limit. The visible top
-    // of the list gets real data; the rest keep the 180s fallback. Cached, so a
-    // repeat search fills in more instantly.
-    private const int SearchEnrichLimit = 60;
+    // Deezer's real ceiling is ~50 requests per 5 seconds, and this runs on search3's
+    // critical path, so the AWAITED set has to stay small. 60 rows at 8-way concurrency
+    // was roughly 65 requests/second on its own, which is what exhausted the quota and
+    // poisoned the metadata caches (issue #8).
+    //
+    // 12 is the same "first page" figure PrewarmYouTubeIdsAsync already uses. It must
+    // stay above TopDurationResolveLimit, or the rows that get a YouTube length hint
+    // would be reading a duration nobody resolved.
+    private const int SearchEnrichLimit = 12;
+
+    // Rows past the first page are warmed off the critical path, so per-row detail
+    // calls (getSong, the native song endpoint) hit a populated cache instead of
+    // paying for the lookup while a user waits.
+    private const int BackgroundEnrichLimit = 60;
 
     public async Task EnrichExternalSongsAsync(List<Song> songs, CancellationToken ct = default)
     {
+        var external = songs.Where(s => !s.IsLocal).ToList();
+
         var sem = new SemaphoreSlim(8);
-        var tasks = songs.Where(s => !s.IsLocal).Take(SearchEnrichLimit).Select(async song =>
+        var tasks = external.Take(SearchEnrichLimit).Select(async song =>
         {
             await sem.WaitAsync(ct);
             try
@@ -121,6 +132,33 @@ public class SoulseekMetadataService : IMusicMetadataService
             finally { sem.Release(); }
         });
         await Task.WhenAll(tasks);
+
+        WarmRemainingInBackground(external.Skip(SearchEnrichLimit).Take(BackgroundEnrichLimit - SearchEnrichLimit).ToList());
+    }
+
+    /// <summary>
+    /// Populate the Deezer cache for rows below the first page.
+    ///
+    /// These deliberately do NOT write back to the Song or its routing. Those objects
+    /// are being serialised into the response as this runs, and Song.Duration is an
+    /// int? whose non-atomic write can be read back as 0 — which is precisely the value
+    /// that stops a client drawing a scrub bar. Writing Album mid-loop would also split
+    /// one album across two synthetic ids. Cache only.
+    /// </summary>
+    private void WarmRemainingInBackground(List<Song> songs)
+    {
+        if (songs.Count == 0) return;
+
+        _ = Task.Run(async () =>
+        {
+            foreach (var song in songs)
+            {
+                // Sequential on purpose: this has no deadline, and fanning out here is
+                // what would eat the quota the awaited set needs.
+                try { await _deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: false); }
+                catch { /* best-effort */ }
+            }
+        });
     }
 
     // Resolve the ACTUAL YouTube video for the top of the list at search time and


### PR DESCRIPTION
Fixes the cause of #8.

Deezer answers HTTP 200 with an `{"error":...}` body rather than a 4xx, so a refusal parsed cleanly and every reader treated it as valid-but-empty data. Nothing in the metadata caches had a TTL, so one throttled call became permanent state for the life of the process.

Reproduced against the live API: 80 concurrent requests in 5.9s returned 10 of those envelopes, and one `search3` was firing up to 121 requests against a documented ceiling of 50 per 5 seconds.

Two ways it surfaced, and the one matching the report is not the obvious one. When the album call succeeds and only the tracklist call is refused, the code built a fully valid album record carrying real title, year and genre with an empty tracklist and cached it **positively, forever**, which is why the reporter saw correct metadata alongside `songCount: 0`, sub-millisecond, with no outbound request.

**What changed**

- `GetJsonAsync` inspects the body and classifies. Only `code 800` counts as definitive; quota and anything unrecognised are transient and never cached. All twelve call sites branch on it, including three that poisoned silently: the album search (which cached an empty list, so external albums would stop appearing at all), the album-id lookup, and the year fetch, whose raw indexer write bypassed the cache helper entirely.
- An empty tracklist on an album Deezer says has tracks is treated as a failure. The null check there is load-bearing: `Int()` returns `int?`, and a lifted `nbTracks > 0` is false when the field is absent.
- Caches moved to `MemoryCache` with TTLs (good answers hours, definitive negatives 5 minutes, partial tracklists 10). No new dependency.
- Enrichment fan-out cut from 60 awaited rows to 12, with the rest warmed in the background.
- A shared rate limiter behind a `DelegatingHandler`. It meters `api.deezer.com` only, since the cover-art lookup pulls image bytes from the CDN through the same client.
- `POST /api/admin/clear-metadata-cache` as a recovery lever.

**Verified**

Live against Deezer: the reporter's exact query returns their exact album id, and `getAlbum` on it now gives `songCount: 10` with all 10 tracks in 560ms. Five broad searches produced zero refusals and zero limiter rejections.

120 tests, up from 108. Five of the new ones fail against the previous code, and the CDN test fails if the limiter's host check is removed.
