### PR TITLE
Bounded lossless wait with preview fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,11 @@ DOWNLOAD_ALBUM_ON_STAR=true
 # clients will give up on. Restart required, since it also changes what searches
 # advertise for external tracks.
 WAIT_FOR_LOSSLESS_ON_PLAY=false
+# With the wait on: 0 waits as long as the fetch needs; above 0, playback falls back
+# to the streaming preview after this many seconds while the download finishes in
+# the background. The fallback serves lossy audio under a track advertised lossless,
+# which strict clients can refuse to start.
+LOSSLESS_WAIT_TIMEOUT_SECONDS=0
 # Flat = "Artist - Title.flac", Organized = "Artist/Album/Track.flac"
 FOLDER_STRUCTURE=Flat
 # Set true when DOWNLOAD_PATH is a cloud/FUSE mount (rclone, pCloud)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       Subsonic__DownloadOnStar: ${DOWNLOAD_ON_STAR:-true}
       Subsonic__DownloadAlbumOnStar: ${DOWNLOAD_ALBUM_ON_STAR:-true}
       Subsonic__WaitForLosslessOnPlay: ${WAIT_FOR_LOSSLESS_ON_PLAY:-false}
+      Subsonic__LosslessWaitTimeoutSeconds: ${LOSSLESS_WAIT_TIMEOUT_SECONDS:-0}
       Subsonic__FolderStructure: ${FOLDER_STRUCTURE:-Flat}
       Subsonic__DownloadSource: ${DOWNLOAD_SOURCE:-Soulseek}
       Subsonic__UseLocalStaging: ${USE_LOCAL_STAGING:-false}

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -139,6 +139,7 @@ public class AdminController : ControllerBase
                 ["DownloadOnStar"] = subsonic.DownloadOnStar,
                 ["DownloadAlbumOnStar"] = subsonic.DownloadAlbumOnStar,
                 ["WaitForLosslessOnPlay"] = subsonic.WaitForLosslessOnPlay,
+                ["LosslessWaitTimeoutSeconds"] = subsonic.LosslessWaitTimeoutSeconds,
                 // These two are rendered by the dashboard but were missing here, so their
                 // fields never pre-filled with the saved value.
                 ["DownloadSource"] = subsonic.DownloadSource.ToString(),
@@ -260,6 +261,7 @@ public class AdminController : ControllerBase
                 ["DownloadOnStar"] = subsonic.DownloadOnStar,
                 ["DownloadAlbumOnStar"] = subsonic.DownloadAlbumOnStar,
                 ["WaitForLosslessOnPlay"] = subsonic.WaitForLosslessOnPlay,
+                ["LosslessWaitTimeoutSeconds"] = subsonic.LosslessWaitTimeoutSeconds,
                 ["DownloadSource"] = subsonic.DownloadSource.ToString(),
                 ["AutoDetectDownloadPath"] = subsonic.AutoDetectDownloadPath,
                 ["FolderStructure"] = subsonic.FolderStructure.ToString(),
@@ -362,7 +364,7 @@ public class AdminController : ControllerBase
         {
             "Subsonic:Url", "Subsonic:StorageMode", "Subsonic:DownloadMode",
             "Subsonic:DownloadOnStar", "Subsonic:DownloadAlbumOnStar",
-            "Subsonic:WaitForLosslessOnPlay",
+            "Subsonic:WaitForLosslessOnPlay", "Subsonic:LosslessWaitTimeoutSeconds",
             "Subsonic:DownloadSource", "Subsonic:AutoDetectDownloadPath",
             "Subsonic:FolderStructure",
             "Subsonic:UseLocalStaging", "Subsonic:ExplicitFilter",

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -566,7 +566,8 @@ public class SubsonicController : ControllerBase
 
             if (acquisition is not null && _subsonicSettings.WaitForLosslessOnPlay)
             {
-                return await ServeAcquiredAsync(acquisition, id, format);
+                return await ServeAcquiredAsync(acquisition, provider!, externalId!, id, format,
+                    allowPreviewFallback: true);
             }
 
             // Cache mode is deliberately left on its original path. It skips library
@@ -585,7 +586,10 @@ public class SubsonicController : ControllerBase
 
             // No YouTube match. Wait on the SAME queued acquisition rather than starting a
             // second one; without a lossless copy on the way there is nothing to serve.
-            if (acquisition is not null) return await ServeAcquiredAsync(acquisition, id, format);
+            // The preview already failed above, so a timeout fallback has nothing to serve.
+            if (acquisition is not null)
+                return await ServeAcquiredAsync(acquisition, provider!, externalId!, id, format,
+                    allowPreviewFallback: false);
 
             return _responseBuilder.CreateError(format, 70, "No playable source found for this track");
         }
@@ -608,22 +612,45 @@ public class SubsonicController : ControllerBase
     /// WaitAsync is what makes this safe: abandoning the WAIT leaves the transfer running,
     /// so a client that gives up costs it nothing.
     /// </summary>
-    private async Task<IActionResult> ServeAcquiredAsync(Task<string> acquisition, string id, string format)
+    private async Task<IActionResult> ServeAcquiredAsync(
+        Task<string> acquisition, string provider, string externalId, string id, string format,
+        bool allowPreviewFallback)
     {
+        // Above 0, the wait is bounded and the preview stands in while the fetch keeps
+        // running in the background; the next play of this id serves the landed file.
+        var timeout = Math.Max(0, _subsonicSettings.LosslessWaitTimeoutSeconds);
+        var fallback = allowPreviewFallback && timeout > 0;
+
         string path;
         try
         {
-            path = await acquisition.WaitAsync(HttpContext.RequestAborted);
+            path = fallback
+                ? await acquisition.WaitAsync(TimeSpan.FromSeconds(timeout), HttpContext.RequestAborted)
+                : await acquisition.WaitAsync(HttpContext.RequestAborted);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
         {
             return new EmptyResult();
         }
         catch (Exception ex)
         {
-            // Never fall back to the lossy stream here. This session declared the id
-            // lossless, so lossy bytes would be the same contract violation in reverse.
-            _logger.LogWarning(ex, "Lossless acquisition failed for {Id}", id);
+            if (fallback)
+            {
+                // The user opted into a bounded wait, trading the declared-lossless
+                // contract for playback that starts. Strict clients may refuse the
+                // lossy bytes; timeout 0 keeps the contract exact.
+                _logger.LogInformation(
+                    "Lossless wait ended early for {Id} ({Reason}); serving the preview while the fetch continues",
+                    id, ex is TimeoutException ? $"timeout {timeout}s" : ex.Message);
+                var preview = await TryDirectStreamAsync(provider, externalId, id);
+                if (preview is not null) return preview;
+            }
+            else
+            {
+                // Never fall back to the lossy stream here. This session declared the id
+                // lossless, so lossy bytes would be the same contract violation in reverse.
+                _logger.LogWarning(ex, "Lossless acquisition failed for {Id}", id);
+            }
             return _responseBuilder.CreateError(format, 70, $"Could not fetch a lossless copy: {ex.Message}");
         }
 

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -206,6 +206,18 @@ public class SubsonicSettings
     public bool WaitForLosslessOnPlay { get; set; } = false;
 
     /// <summary>
+    /// With WaitForLosslessOnPlay on, give up waiting after this many seconds and fall
+    /// back to the lossy preview while the fetch finishes in the background (default: 0,
+    /// wait as long as the fetch needs).
+    /// Environment variable: LOSSLESS_WAIT_TIMEOUT_SECONDS
+    ///
+    /// A fallback serves lossy bytes under an id this session declared lossless, which
+    /// strict clients can refuse to start. That trade is why it is opt-in and 0 keeps
+    /// the declared contract exact.
+    /// </summary>
+    public int LosslessWaitTimeoutSeconds { get; set; } = 0;
+
+    /// <summary>
     /// Folder structure for downloaded tracks (default: Flat)
     /// Environment variable: FOLDER_STRUCTURE
     /// Values: "Organized" (Artist/Album/Track.flac), "Flat" (Artist - Title.flac)

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -341,6 +341,13 @@
               </div>
               <label class="switch"><input type="checkbox" id="f-wait-for-lossless-on-play" name="Subsonic.WaitForLosslessOnPlay" data-restart="true" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
             </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Lossless wait timeout <span class="set-opt">seconds</span></div>
+                <div class="set-info-d">Only with the wait on. 0 waits as long as the fetch needs. Above 0, playback falls back to the streaming preview after this many seconds while the download finishes in the background; some players refuse the preview on a track advertised lossless.</div>
+              </div>
+              <input class="set-input" id="f-lossless-wait-timeout" name="Subsonic.LosslessWaitTimeoutSeconds" type="number" min="0" data-restart="true" />
+            </div>
           </form>
         </div>
       </section>


### PR DESCRIPTION
WaitForLosslessOnPlay makes the first play block for however long the Soulseek fetch takes, which most clients give up on — the trade #9 ran into.

New setting `LosslessWaitTimeoutSeconds` (default 0):

- **0** — current behavior exactly: the play waits as long as the fetch needs, and a failed fetch returns a Subsonic error rather than lossy bytes under a lossless declaration.
- **Above 0** — the request waits that many seconds, then falls back to the streaming preview (also on acquisition failure) while the fetch finishes in the background. The next play of the same track serves the landed FLAC from disk. The setting copy and .env.example both note that strict clients can refuse lossy bytes on a track advertised lossless, which is why this is opt-in.

Also in this change:

- A cancellation thrown by the acquisition itself (an slskd HTTP timeout is a `TaskCanceledException`, indistinguishable by type from a client abort) now counts as a failure instead of returning a silent empty response; only a genuine client disconnect returns one.
- `GetSettings` returns the new key, the dashboard gets a restart-required number field under the wait toggle, and compose/.env.example expose `LOSSLESS_WAIT_TIMEOUT_SECONDS`.

Verified live against a local run: a hanging slskd trips the 5s timeout and serves the preview (`audio/mp4`, logged `timeout 5s`); a failed acquisition falls back with its real error logged; timeout 0 returns the code-70 error unchanged. 137 tests green on `octo.sln`.

Ref #9