### PR TITLE
Detect finished Soulseek transfers immediately

### DIFF
--- a/octo.Tests/SoulseekTransferPollTests.cs
+++ b/octo.Tests/SoulseekTransferPollTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Octo.Services.Soulseek;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The completion poll reads slskd's downloads endpoint, and the response shape decides
+/// whether a finished transfer is ever noticed. The per-user endpoint returns a single
+/// {username, directories} object; the all-users endpoint returns an array of them.
+/// The poll used to accept only the array, so against the per-user endpoint every
+/// completed transfer went unseen and the wait always ran the full per-attempt timer:
+/// a 3-second download surfaced as playable only after 60 seconds.
+///
+/// The object fixture below is the real response captured from slskd 0.26.0.
+/// </summary>
+public class SoulseekTransferPollTests
+{
+    private const string RemoteFilename =
+        @"music\Daft Punk\1997 - Homework [CD]\01 - Daftendirekt.flac";
+
+    // Shape of GET /api/v0/transfers/downloads/{username}: one user group object.
+    private const string PerUserObjectJson = """
+        {
+          "username": "blixquoy",
+          "directories": [
+            {
+              "directory": "music\\Daft Punk\\1997 - Homework [CD]",
+              "fileCount": 1,
+              "files": [
+                {
+                  "filename": "music\\Daft Punk\\1997 - Homework [CD]\\01 - Daftendirekt.flac",
+                  "state": "Completed, Succeeded",
+                  "size": 17361963
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static string ArrayWrapped => "[" + PerUserObjectJson + "]";
+
+    private static string? Find(string json, string filename)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return SoulseekClient.FindTransferState(doc.RootElement, filename);
+    }
+
+    [Fact]
+    public void PerUserObjectResponse_FindsCompletedTransfer()
+    {
+        var state = Find(PerUserObjectJson, RemoteFilename);
+        Assert.Equal("Completed, Succeeded", state);
+    }
+
+    [Fact]
+    public void AllUsersArrayResponse_FindsCompletedTransfer()
+    {
+        var state = Find(ArrayWrapped, RemoteFilename);
+        Assert.Equal("Completed, Succeeded", state);
+    }
+
+    [Fact]
+    public void FileNotInResponse_ReturnsNull()
+    {
+        Assert.Null(Find(PerUserObjectJson, @"music\Other\file.flac"));
+        Assert.Null(Find(ArrayWrapped, @"music\Other\file.flac"));
+    }
+
+    [Fact]
+    public void ErroredState_IsReturnedVerbatim()
+    {
+        var json = PerUserObjectJson.Replace("Completed, Succeeded", "Completed, Errored");
+        Assert.Equal("Completed, Errored", Find(json, RemoteFilename));
+    }
+
+    [Fact]
+    public void MalformedRoots_ReturnNull()
+    {
+        Assert.Null(Find("\"just a string\"", RemoteFilename));
+        Assert.Null(Find("{\"username\":\"x\"}", RemoteFilename));
+        Assert.Null(Find("[{\"directories\":\"not-an-array\"}]", RemoteFilename));
+    }
+}

--- a/octo/Services/Soulseek/SoulseekClient.cs
+++ b/octo/Services/Soulseek/SoulseekClient.cs
@@ -324,45 +324,25 @@ public class SoulseekClient
 
                 var json = await resp.Content.ReadAsStringAsync(ct);
                 using var doc = JsonDocument.Parse(json);
-                if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                var state = FindTransferState(doc.RootElement, filename);
+                bool foundThisPoll = state is not null;
+                if (foundThisPoll)
                 {
-                    if (seenAtLeastOnce) consecutiveMisses++;
-                    if (consecutiveMisses >= MaxConsecutiveMissesAfterSeen) return SoulseekTransferState.Errored;
-                    continue;
-                }
+                    seenAtLeastOnce = true;
+                    consecutiveMisses = 0;
 
-                // Walk the user/directory/file tree looking for our file.
-                bool foundThisPoll = false;
-                foreach (var userGroup in doc.RootElement.EnumerateArray())
-                {
-                    if (!userGroup.TryGetProperty("directories", out var dirs)) continue;
-                    foreach (var dir in dirs.EnumerateArray())
+                    if (state!.Contains("Completed", StringComparison.OrdinalIgnoreCase) &&
+                        state.Contains("Succeeded", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (!dir.TryGetProperty("files", out var files)) continue;
-                        foreach (var file in files.EnumerateArray())
-                        {
-                            var fn = file.TryGetProperty("filename", out var fnEl) ? fnEl.GetString() : null;
-                            if (fn != filename) continue;
-                            foundThisPoll = true;
-                            seenAtLeastOnce = true;
-                            consecutiveMisses = 0;
-
-                            var state = file.TryGetProperty("state", out var stEl) ? stEl.GetString() ?? "" : "";
-
-                            if (state.Contains("Completed", StringComparison.OrdinalIgnoreCase) &&
-                                state.Contains("Succeeded", StringComparison.OrdinalIgnoreCase))
-                            {
-                                return SoulseekTransferState.Succeeded;
-                            }
-                            if (state.Contains("Errored", StringComparison.OrdinalIgnoreCase) ||
-                                state.Contains("Cancelled", StringComparison.OrdinalIgnoreCase) ||
-                                state.Contains("Rejected", StringComparison.OrdinalIgnoreCase) ||
-                                state.Contains("TimedOut", StringComparison.OrdinalIgnoreCase))
-                            {
-                                _logger.LogDebug("slskd transfer ended in state: {State}", state);
-                                return SoulseekTransferState.Errored;
-                            }
-                        }
+                        return SoulseekTransferState.Succeeded;
+                    }
+                    if (state.Contains("Errored", StringComparison.OrdinalIgnoreCase) ||
+                        state.Contains("Cancelled", StringComparison.OrdinalIgnoreCase) ||
+                        state.Contains("Rejected", StringComparison.OrdinalIgnoreCase) ||
+                        state.Contains("TimedOut", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogDebug("slskd transfer ended in state: {State}", state);
+                        return SoulseekTransferState.Errored;
                     }
                 }
 
@@ -384,6 +364,43 @@ public class SoulseekClient
 
         _logger.LogWarning("slskd transfer timed out after {Sec}s: {File}", timeoutSec, filename);
         return SoulseekTransferState.Errored;
+    }
+
+    /// <summary>
+    /// Finds a transfer's state in an slskd downloads response, or null when the
+    /// file is not present. The per-user endpoint returns a single
+    /// {username, directories} object, while the all-users endpoint returns an
+    /// array of them; both shapes are accepted. Reading the wrong shape is what
+    /// made every completed transfer look like a timeout: the poll loop rejected
+    /// the object response wholesale and rode the per-attempt timer to the end.
+    /// </summary>
+    internal static string? FindTransferState(JsonElement root, string filename)
+    {
+        IEnumerable<JsonElement> userGroups = root.ValueKind switch
+        {
+            JsonValueKind.Array => root.EnumerateArray(),
+            JsonValueKind.Object => new[] { root },
+            _ => Array.Empty<JsonElement>(),
+        };
+
+        foreach (var userGroup in userGroups)
+        {
+            if (userGroup.ValueKind != JsonValueKind.Object) continue;
+            if (!userGroup.TryGetProperty("directories", out var dirs)) continue;
+            if (dirs.ValueKind != JsonValueKind.Array) continue;
+            foreach (var dir in dirs.EnumerateArray())
+            {
+                if (!dir.TryGetProperty("files", out var files)) continue;
+                if (files.ValueKind != JsonValueKind.Array) continue;
+                foreach (var file in files.EnumerateArray())
+                {
+                    var fn = file.TryGetProperty("filename", out var fnEl) ? fnEl.GetString() : null;
+                    if (fn != filename) continue;
+                    return file.TryGetProperty("state", out var stEl) ? stEl.GetString() ?? "" : "";
+                }
+            }
+        }
+        return null;
     }
 }
 


### PR DESCRIPTION
While measuring star-to-playable time, the whole minute turned out to be one bug: the completion poll only accepted an **array** response from slskd's downloads endpoint, but the per-user endpoint (`/api/v0/transfers/downloads/{username}`) returns a single `{username, directories}` **object**. Every poll discarded the response wholesale, so a transfer that finished in 3 seconds was never noticed — the wait rode the full 60s per-attempt timer, and only then did the filesystem check rescue the file.

This is also the true story behind the long-standing "slskd reports Errored while the file is complete on disk" behavior: slskd was reporting `Completed, Succeeded` all along, in a shape the poll threw away. The "Errored" was our own timeout mapping.

The walk now lives in `FindTransferState`, accepts both shapes (object fixture captured from a live slskd 0.26.0), and is unit-tested (5 new tests, 142 total green).

Measured live against the real Soulseek network, same peer class:

- Before: star → playable **62.7s** (transfer done at ~3s, then 60s of timer)
- After: star → playable **6.8s**

Failed peers also now advance in seconds instead of burning 60s each, which shrinks the worst-case 5-peer failure from ~5 minutes to under a minute.

Ref #9