### PR TITLE
Fix discovery at the default song count, and the search paths around it

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,31 @@ The installer asks for your Navidrome URL (and, optionally, Last.fm and Soulseek
 
 ## Compatible apps
 
-| Works | App |
-|---|---|
-| ✅ | [Feishin](https://github.com/jeffvli/feishin) (desktop) |
-| ✅ | [Arpeggi](https://www.reddit.com/r/arpeggiApp/) (iOS) |
-| ✅ | [Narjo](https://www.reddit.com/r/NarjoApp/) (iOS) |
-| ✅ | Tempus (Android) |
-| ✅ | most other Subsonic apps |
-| ❌ | Symfonium — offline-first, doesn't query the server for searches |
+| Works | App | Platform |
+|---|---|---|
+| ✅ | [Feishin](https://github.com/jeffvli/feishin) | desktop |
+| ✅ | [Supersonic](https://github.com/dweymouth/supersonic) | desktop |
+| ✅ | [Sublime Music](https://github.com/sublime-music/sublime-music) | Linux |
+| ✅ | [Arpeggi](https://www.reddit.com/r/arpeggiApp/) | iOS |
+| ✅ | [Narjo](https://www.reddit.com/r/NarjoApp/) | iOS |
+| ✅ | [Amperfy](https://github.com/BLeeEZ/amperfy) | iOS |
+| ✅ | [DSub](https://github.com/daneren2005/Subsonic) | Android |
+| ✅ | [Ultrasonic](https://gitlab.com/ultrasonic/ultrasonic) | Android |
+| ✅ | [Tempo](https://github.com/CappielloAntonio/tempo) | Android |
+| ✅ | [Audinaut](https://github.com/nvllsvm/Audinaut) | Android |
+| ✅ | [SubTracks](https://github.com/austinried/subtracks) | Android / iOS |
+| ✅ | Tempus | Android |
+| ✅ | most other Subsonic apps | |
+| ❌ | Symfonium | searches its own offline copy, so it never asks the server |
+
+Symfonium is the one that genuinely cannot work. It syncs your library to the device and
+searches locally, so a search never reaches Octo and there is nothing to add results to.
+
+**Both search generations are supported.** Subsonic has two search endpoints, `search2` and
+`search3`, and Octo answers either. This matters more than it sounds: DSub and Ultrasonic
+choose between them based on whether *you* browse by tags or by folders, not on the server
+version, so a folder-browsing user talks `search2`. Both formats are supported too — some
+clients speak JSON, some (DSub) only XML.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The installer asks for your Navidrome URL (and, optionally, Last.fm and Soulseek
 | ✅ | [Feishin](https://github.com/jeffvli/feishin) (desktop) |
 | ✅ | [Arpeggi](https://www.reddit.com/r/arpeggiApp/) (iOS) |
 | ✅ | [Narjo](https://www.reddit.com/r/NarjoApp/) (iOS) |
+| ✅ | Tempus (Android) |
 | ✅ | most other Subsonic apps |
 | ❌ | Symfonium — offline-first, doesn't query the server for searches |
 

--- a/octo.Tests/FailedRelayDetectionTests.cs
+++ b/octo.Tests/FailedRelayDetectionTests.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using Octo.Controllers;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// Subsonic reports its own errors inside an HTTP 200, so a rejected login and an empty
+/// library look identical to a status-code check. That mattered little while search
+/// returned whatever the library gave it, but the discovery top-up reads "no local
+/// matches" as an invitation to fill the page, which would dress a broken connection up
+/// as a healthy search.
+/// </summary>
+public class FailedRelayDetectionTests
+{
+    private static byte[] B(string s) => Encoding.UTF8.GetBytes(s);
+
+    [Fact]
+    public void JsonErrorEnvelopeIsDetected()
+    {
+        var body = B(@"{""subsonic-response"":{""status"":""failed"",""version"":""1.16.1"",
+                       ""error"":{""code"":40,""message"":""Wrong username or password""}}}");
+
+        Assert.True(SubsonicController.IsFailedSubsonicBody(body, "application/json"));
+    }
+
+    [Fact]
+    public void XmlErrorEnvelopeIsDetected()
+    {
+        var body = B(@"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <subsonic-response xmlns=""http://subsonic.org/restapi"" status=""failed"" version=""1.16.1"">
+              <error code=""40"" message=""Wrong username or password""/>
+            </subsonic-response>");
+
+        Assert.True(SubsonicController.IsFailedSubsonicBody(body, "application/xml"));
+    }
+
+    [Fact]
+    public void AnEmptyButSuccessfulResultIsNotAFailure()
+    {
+        // The case that must keep working: a real search that genuinely matched nothing.
+        var json = B(@"{""subsonic-response"":{""status"":""ok"",""version"":""1.16.1"",""searchResult3"":{}}}");
+        var xml = B(@"<subsonic-response xmlns=""http://subsonic.org/restapi"" status=""ok"" version=""1.16.1"">
+                        <searchResult3/></subsonic-response>");
+
+        Assert.False(SubsonicController.IsFailedSubsonicBody(json, "application/json"));
+        Assert.False(SubsonicController.IsFailedSubsonicBody(xml, "application/xml"));
+    }
+
+    [Fact]
+    public void UnreadableOrEmptyBodiesAreNotTreatedAsFailures()
+    {
+        // Unparseable is not the same as failed; the normal path should still handle it.
+        Assert.False(SubsonicController.IsFailedSubsonicBody(null, "application/json"));
+        Assert.False(SubsonicController.IsFailedSubsonicBody(Array.Empty<byte>(), "application/json"));
+        Assert.False(SubsonicController.IsFailedSubsonicBody(B("not json at all"), "application/json"));
+        Assert.False(SubsonicController.IsFailedSubsonicBody(B("<broken"), "application/xml"));
+    }
+}

--- a/octo.Tests/LastFmServiceTests.cs
+++ b/octo.Tests/LastFmServiceTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Octo.Models.Settings;
+using Octo.Services.LastFm;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// "Can Last.fm answer at all" and "is the radio feature switched on" are different
+/// questions. They used to be one property, so turning radio off also emptied the search
+/// bar of discovery results — a setting doing something its name does not say.
+/// </summary>
+public class LastFmServiceTests
+{
+    private static LastFmService With(string apiKey, bool enableRadio) =>
+        new(new HttpClient(),
+            Options.Create(new LastFmSettings { ApiKey = apiKey, EnableRadio = enableRadio }),
+            new Mock<ILogger<LastFmService>>().Object);
+
+    [Theory]
+    [InlineData("", true, false)]
+    [InlineData("", false, false)]
+    [InlineData("abc123", true, true)]
+    [InlineData("abc123", false, true)]
+    public void HasApiKey_DependsOnlyOnTheKey(string key, bool radio, bool expected)
+    {
+        // Search discovery gates on this, so EnableRadio must not appear in it.
+        Assert.Equal(expected, With(key, radio).HasApiKey);
+    }
+
+    [Theory]
+    [InlineData("abc123", true, true)]
+    [InlineData("abc123", false, false)]
+    [InlineData("", true, false)]
+    public void IsRadioEnabled_NeedsBothTheKeyAndTheSwitch(string key, bool radio, bool expected)
+    {
+        Assert.Equal(expected, With(key, radio).IsRadioEnabled);
+    }
+
+    [Fact]
+    public void RadioOffStillLeavesSearchDiscoveryAvailable()
+    {
+        // The regression this pair exists to prevent.
+        var svc = With("abc123", enableRadio: false);
+
+        Assert.True(svc.HasApiKey);
+        Assert.False(svc.IsRadioEnabled);
+    }
+}

--- a/octo.Tests/SearchBudgetTests.cs
+++ b/octo.Tests/SearchBudgetTests.cs
@@ -33,10 +33,12 @@ public class SearchBudgetTests
     [InlineData(40, 12, 28)]
     [InlineData(60, 15, 45)]
     [InlineData(79, 19, 60)]
-    // From here up the quarter rule dominates and nothing changes at all.
+    // From here up the quarter rule dominates, so the local side stops changing. The
+    // external side is held at the ceiling, which is the number of rows a query actually
+    // builds; past it the rows would be unenriched placeholders.
     [InlineData(80, 20, 60)]
-    [InlineData(200, 50, 150)]
-    [InlineData(1000, 250, 150)]
+    [InlineData(200, 50, 60)]
+    [InlineData(1000, 250, 60)]
     public void Compute_SplitsAsSpecified(int requested, int expectedLocal, int expectedExternal)
     {
         var (local, external) = SearchBudget.Compute(requested);
@@ -46,28 +48,31 @@ public class SearchBudgetTests
     }
 
     [Fact]
-    public void Compute_IsUnchangedFromTheLegacySplitForLargeRequests()
+    public void Compute_LeavesTheLocalTargetUnchangedForLargeRequests()
     {
-        // At 80 and above, requested/4 is at least 20, so the old flat floor was never
-        // the binding term and the new capped floor resolves to the same number. This is
-        // the whole reviewability argument for the change: radio-style clients and
-        // anything else sending a large songCount see byte-identical behaviour.
+        // At 80 and above, requested/4 is at least 20, so the old flat floor was never the
+        // binding term and the new capped floor resolves to the same number. Radio-style
+        // clients and anything else sending a large songCount see the same local target
+        // they saw before.
         for (var n = 80; n <= 5000; n++)
         {
-            Assert.Equal(Legacy(n), SearchBudget.Compute(n));
+            Assert.Equal(Legacy(n).Local, SearchBudget.Compute(n).Local);
         }
     }
 
     [Fact]
-    public void Compute_NeverReturnsFewerExternalsThanTheLegacySplit()
+    public void Compute_OnlyEverLosesExternalsToTheCeiling()
     {
-        // Min(floor, n) can only be smaller than the old flat 20, so the local target
-        // never grows, so the external target never shrinks. No client anywhere loses
-        // discovery rows as a result of this change.
+        // Min(floor, n) can only be smaller than the old flat 20, so the local target never
+        // grows and the external target never shrinks on account of the split itself. The
+        // one place the count can fall is the ceiling, which was lowered to the number of
+        // rows a query actually builds — beyond that the old code was emitting placeholders
+        // that no enrichment pass ever reached.
         for (var n = 0; n <= 5000; n++)
         {
-            Assert.True(SearchBudget.Compute(n).External >= Legacy(n).External,
-                $"songCount={n} lost external rows");
+            var expected = Math.Min(SearchBudget.ExternalCeiling, Legacy(n).External);
+            Assert.True(SearchBudget.Compute(n).External >= expected,
+                $"songCount={n} lost external rows beyond the ceiling");
         }
     }
 

--- a/octo.Tests/SearchBudgetTests.cs
+++ b/octo.Tests/SearchBudgetTests.cs
@@ -1,0 +1,104 @@
+using Octo.Services.Subsonic;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The local/external split for search3. These pin issue #14: the old local floor was a
+/// flat 20, which is also the Subsonic spec default for songCount, so a client that sent
+/// the default (or sent nothing) had its whole budget consumed by local results and never
+/// received a single discovery row. Search looked like it only ever returned albums.
+/// </summary>
+public class SearchBudgetTests
+{
+    /// <summary>
+    /// The split exactly as it behaved before the fix. Kept here so the "nothing changes
+    /// for large requests" guarantee is checked by CI on every run rather than by a
+    /// one-off manual diff against a running server.
+    /// </summary>
+    private static (int Local, int External) Legacy(int requestedSongs)
+    {
+        var local = Math.Max(20, requestedSongs / 4);
+        var external = Math.Min(150, Math.Max(0, requestedSongs - local));
+        return (local, external);
+    }
+
+    [Theory]
+    // Below the floor: local-only, and we stop asking Navidrome for more than the
+    // client wanted. No discovery means no Last.fm fan-out on a type-ahead keystroke.
+    [InlineData(0, 0, 0)]
+    [InlineData(5, 5, 0)]
+    [InlineData(12, 12, 0)]
+    // The reported bug. The spec default used to yield zero external rows.
+    [InlineData(20, 12, 8)]
+    [InlineData(40, 12, 28)]
+    [InlineData(60, 15, 45)]
+    [InlineData(79, 19, 60)]
+    // From here up the quarter rule dominates and nothing changes at all.
+    [InlineData(80, 20, 60)]
+    [InlineData(200, 50, 150)]
+    [InlineData(1000, 250, 150)]
+    public void Compute_SplitsAsSpecified(int requested, int expectedLocal, int expectedExternal)
+    {
+        var (local, external) = SearchBudget.Compute(requested);
+
+        Assert.Equal(expectedLocal, local);
+        Assert.Equal(expectedExternal, external);
+    }
+
+    [Fact]
+    public void Compute_IsUnchangedFromTheLegacySplitForLargeRequests()
+    {
+        // At 80 and above, requested/4 is at least 20, so the old flat floor was never
+        // the binding term and the new capped floor resolves to the same number. This is
+        // the whole reviewability argument for the change: radio-style clients and
+        // anything else sending a large songCount see byte-identical behaviour.
+        for (var n = 80; n <= 5000; n++)
+        {
+            Assert.Equal(Legacy(n), SearchBudget.Compute(n));
+        }
+    }
+
+    [Fact]
+    public void Compute_NeverReturnsFewerExternalsThanTheLegacySplit()
+    {
+        // Min(floor, n) can only be smaller than the old flat 20, so the local target
+        // never grows, so the external target never shrinks. No client anywhere loses
+        // discovery rows as a result of this change.
+        for (var n = 0; n <= 5000; n++)
+        {
+            Assert.True(SearchBudget.Compute(n).External >= Legacy(n).External,
+                $"songCount={n} lost external rows");
+        }
+    }
+
+    [Fact]
+    public void Compute_KeepsBothTargetsInsideTheRequestedCount()
+    {
+        // The merge appends externals after locals with no total cap, so a client that
+        // renders only the count it asked for would never see an external row if the two
+        // targets summed past it.
+        for (var n = 0; n <= 5000; n++)
+        {
+            var (local, external) = SearchBudget.Compute(n);
+            Assert.True(local + external <= n, $"songCount={n} produced {local}+{external}");
+        }
+    }
+
+    [Fact]
+    public void Compute_TreatsNegativeCountsAsZero()
+    {
+        // The old expression sanitised these only by accident, via its flat floor. A
+        // negative target would otherwise be relayed to Navidrome verbatim.
+        Assert.Equal((0, 0), SearchBudget.Compute(-1));
+        Assert.Equal((0, 0), SearchBudget.Compute(int.MinValue));
+    }
+
+    [Fact]
+    public void Compute_DoesNotOverflowOnAbsurdCounts()
+    {
+        var (local, external) = SearchBudget.Compute(int.MaxValue);
+
+        Assert.Equal(int.MaxValue / 4, local);
+        Assert.Equal(SearchBudget.ExternalCeiling, external);
+    }
+}

--- a/octo.Tests/SerializerSymmetryTests.cs
+++ b/octo.Tests/SerializerSymmetryTests.cs
@@ -1,0 +1,121 @@
+using System.Collections;
+using System.Xml.Linq;
+using Microsoft.Extensions.Options;
+using Octo.Models.Domain;
+using Octo.Models.Settings;
+using Octo.Services.Soulseek;
+using Octo.Services.Subsonic;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The XML and JSON serializers must describe the same thing. They were written out by
+/// hand separately and drifted: a song carried nine attributes in XML against twenty-seven
+/// fields in JSON, so an XML-only client (DSub is one, and it never requests JSON) received
+/// external tracks with no suffix, contentType or bitRate — precisely the fields a client
+/// reads to choose a decoder, and the ones this codebase already warns must match the bytes
+/// that will actually arrive.
+/// </summary>
+public class SerializerSymmetryTests
+{
+    private static readonly XNamespace Ns = XNamespace.Get("http://subsonic.org/restapi");
+
+    private static SubsonicResponseBuilder Builder(bool waitForLossless = false) =>
+        new(new ExternalIdRegistry(),
+            Options.Create(new SubsonicSettings { WaitForLosslessOnPlay = waitForLossless }));
+
+    private static Song ExternalSong() => new()
+    {
+        Id = "abc123",
+        Title = "Karma Police",
+        Artist = "Radiohead",
+        Album = "OK Computer",
+        Duration = 261,
+        Year = 1997,
+        IsLocal = false,
+    };
+
+    /// <summary>Keys the XML form is expected to carry: everything except collections.</summary>
+    private static IEnumerable<string> ScalarKeys(IDictionary<string, object> fields) =>
+        fields.Where(kv => kv.Value is not null
+                        && (kv.Value is string || kv.Value is not IEnumerable))
+              .Select(kv => kv.Key)
+              .OrderBy(k => k);
+
+    [Fact]
+    public void SongCarriesTheSameFieldsInBothFormats()
+    {
+        var b = Builder();
+        var song = ExternalSong();
+
+        var json = b.ConvertSongToJson(song);
+        var xml = b.ConvertSongToXml(song, Ns);
+
+        Assert.Equal(ScalarKeys(json), xml.Attributes().Select(a => a.Name.LocalName).OrderBy(n => n));
+    }
+
+    [Fact]
+    public void AlbumAndArtistCarryTheSameFieldsInBothFormats()
+    {
+        var b = Builder();
+        var album = new Album { Id = "al1", Title = "In Rainbows", Artist = "Radiohead", Year = 2007, SongCount = 10 };
+        var artist = new Artist { Id = "ar1", Name = "Radiohead", AlbumCount = 2 };
+
+        var albumJson = (IDictionary<string, object>)b.ConvertAlbumToJson(album);
+        var artistJson = (IDictionary<string, object>)b.ConvertArtistToJson(artist);
+
+        Assert.Equal(ScalarKeys(albumJson),
+            b.ConvertAlbumToXml(album, Ns).Attributes().Select(a => a.Name.LocalName).OrderBy(n => n));
+        Assert.Equal(ScalarKeys(artistJson),
+            b.ConvertArtistToXml(artist, Ns).Attributes().Select(a => a.Name.LocalName).OrderBy(n => n));
+    }
+
+    [Fact]
+    public void XmlSongDeclaresHowToPlayIt()
+    {
+        // The specific regression. Without these a client cannot choose a decoder, and the
+        // entry either fails to play or is dropped from the queue outright.
+        var xml = Builder().ConvertSongToXml(ExternalSong(), Ns);
+
+        Assert.Equal("m4a", xml.Attribute("suffix")?.Value);
+        Assert.Equal("audio/mp4", xml.Attribute("contentType")?.Value);
+        Assert.Equal("128", xml.Attribute("bitRate")?.Value);
+    }
+
+    [Fact]
+    public void XmlSongFollowsTheLosslessSettingJustAsJsonDoes()
+    {
+        // The declaration has to track what /rest/stream will actually serve, in both
+        // formats. Getting this wrong in one of them is the bug this file exists to stop.
+        var xml = Builder(waitForLossless: true).ConvertSongToXml(ExternalSong(), Ns);
+
+        Assert.Equal("flac", xml.Attribute("suffix")?.Value);
+        Assert.Equal("audio/flac", xml.Attribute("contentType")?.Value);
+    }
+
+    [Fact]
+    public void XmlAlbumLooksLikeADirectoryToAFolderBrowsingClient()
+    {
+        // search2 clients browse by folder and read these three. Injected albums used to
+        // carry none of them, so they looked unlike anything the upstream server returns.
+        var xml = Builder().ConvertAlbumToXml(
+            new Album { Id = "al1", Title = "In Rainbows", Artist = "Radiohead" }, Ns);
+
+        Assert.Equal("true", xml.Attribute("isDir")?.Value);
+        Assert.Equal("In Rainbows", xml.Attribute("title")?.Value);
+        Assert.False(string.IsNullOrEmpty(xml.Attribute("parent")?.Value));
+    }
+
+    [Fact]
+    public void ValuesRenderInvariantlyRegardlessOfLocale()
+    {
+        // A comma decimal separator under a European locale would produce numbers no
+        // Subsonic client can parse. CI runs on Linux where the ambient culture differs
+        // from the workstation's, so assert the rendering rather than trust the default.
+        var xml = Builder().ConvertSongToXml(ExternalSong(), Ns);
+
+        Assert.Equal("261", xml.Attribute("duration")?.Value);
+        Assert.Equal("1997", xml.Attribute("year")?.Value);
+        Assert.DoesNotContain(",", xml.Attribute("size")?.Value ?? "");
+    }
+}

--- a/octo.Tests/SerializerSymmetryTests.cs
+++ b/octo.Tests/SerializerSymmetryTests.cs
@@ -107,6 +107,37 @@ public class SerializerSymmetryTests
     }
 
     [Fact]
+    public void AnUnknownYearIsOmittedRatherThanInvented()
+    {
+        // It used to fall back to the current year, which is not a plausible default but a
+        // wrong one: a 1995 track was published to the client as this year's release, and
+        // that is something the user sees and sorts by.
+        var b = Builder();
+        var song = ExternalSong();
+        song.Year = null;
+
+        Assert.DoesNotContain("year", b.ConvertSongToJson(song).Keys);
+        Assert.Null(b.ConvertSongToXml(song, Ns).Attribute("year"));
+
+        // Deezer's album search payload carries no release date at all, so this is the
+        // normal case for an injected album row rather than an edge case.
+        var album = new Album { Id = "al1", Title = "In Rainbows", Artist = "Radiohead", Year = null };
+        Assert.DoesNotContain("year", ((IDictionary<string, object>)b.ConvertAlbumToJson(album)).Keys);
+        Assert.Null(b.ConvertAlbumToXml(album, Ns).Attribute("year"));
+    }
+
+    [Fact]
+    public void AKnownYearIsStillReported()
+    {
+        var b = Builder();
+
+        Assert.Equal(1997, b.ConvertSongToJson(ExternalSong())["year"]);
+        Assert.Equal("2007", b.ConvertAlbumToXml(
+            new Album { Id = "al1", Title = "In Rainbows", Artist = "Radiohead", Year = 2007 }, Ns)
+            .Attribute("year")?.Value);
+    }
+
+    [Fact]
     public void ValuesRenderInvariantlyRegardlessOfLocale()
     {
         // A comma decimal separator under a European locale would produce numbers no

--- a/octo.Tests/SingleFlightTests.cs
+++ b/octo.Tests/SingleFlightTests.cs
@@ -1,0 +1,142 @@
+using Octo.Services.Common;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// Single-flight is what stops one typed query from running the discovery pipeline several
+/// times over. The dangerous part is not the happy path but what a failure leaves behind:
+/// a keyed dictionary of tasks that outlives its usefulness becomes a user-triggerable
+/// leak, and a retained faulted task turns one bad moment into a permanently broken query.
+/// </summary>
+public class SingleFlightTests
+{
+    private static readonly TimeSpan Generous = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task ConcurrentCallersForOneKeyShareASingleExecution()
+    {
+        var flight = new SingleFlight<string, int>();
+        var runs = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<int> Factory(CancellationToken ct)
+        {
+            Interlocked.Increment(ref runs);
+            started.TrySetResult();
+            await release.Task;
+            return 42;
+        }
+
+        // Hold the first call open so the others cannot miss it by finishing too early.
+        var first = flight.RunAsync("q", Factory, Generous);
+        await started.Task;
+
+        var joiners = Enumerable.Range(0, 8)
+            .Select(_ => flight.RunAsync("q", Factory, Generous))
+            .ToArray();
+
+        release.SetResult();
+        var results = await Task.WhenAll(joiners.Prepend(first));
+
+        Assert.Equal(1, runs);
+        Assert.All(results, r => Assert.Equal(42, r));
+    }
+
+    [Fact]
+    public async Task DifferentKeysDoNotShareAnExecution()
+    {
+        var flight = new SingleFlight<string, string>();
+
+        var results = await Task.WhenAll(
+            flight.RunAsync("a", _ => Task.FromResult("a"), Generous),
+            flight.RunAsync("b", _ => Task.FromResult("b"), Generous));
+
+        Assert.Equal(new[] { "a", "b" }, results);
+    }
+
+    [Fact]
+    public async Task AFailedExecutionReachesEveryJoinerAndIsNotRetained()
+    {
+        var flight = new SingleFlight<string, int>();
+        var runs = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<int> Failing(CancellationToken ct)
+        {
+            Interlocked.Increment(ref runs);
+            started.TrySetResult();
+            await release.Task;
+            throw new InvalidOperationException("upstream is down");
+        }
+
+        var first = flight.RunAsync("q", Failing, Generous);
+        await started.Task;
+        var joiner = flight.RunAsync("q", Failing, Generous);
+
+        release.SetResult();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => first);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => joiner);
+        Assert.Equal(1, runs);
+
+        // The entry must be gone, or one transient outage would poison this key for the
+        // life of the process.
+        Assert.Equal(0, flight.InFlightCount);
+        Assert.Equal(7, await flight.RunAsync("q", _ => Task.FromResult(7), Generous));
+    }
+
+    [Fact]
+    public async Task ASynchronouslyThrowingFactoryIsAlsoNotRetained()
+    {
+        var flight = new SingleFlight<string, int>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => flight.RunAsync("q", _ => throw new InvalidOperationException("boom"), Generous));
+
+        Assert.Equal(0, flight.InFlightCount);
+        Assert.Equal(1, await flight.RunAsync("q", _ => Task.FromResult(1), Generous));
+    }
+
+    [Fact]
+    public async Task ACompletedKeyRunsAgainOnTheNextCall()
+    {
+        var flight = new SingleFlight<string, int>();
+        var runs = 0;
+
+        for (var i = 0; i < 3; i++)
+        {
+            await flight.RunAsync("q", _ => Task.FromResult(Interlocked.Increment(ref runs)), Generous);
+        }
+
+        // Nothing is cached, so results stay fresh and no eviction policy is needed.
+        Assert.Equal(3, runs);
+        Assert.Equal(0, flight.InFlightCount);
+    }
+
+    [Fact]
+    public async Task TheFactoryTokenIsCancelledByTheDeadline()
+    {
+        var flight = new SingleFlight<string, bool>();
+
+        // A hung dependency must not pin the key. The token the factory receives belongs to
+        // the execution, never to a caller: joined callers share it, so one client
+        // disconnecting cannot take the others down with it.
+        var cancelled = await flight.RunAsync("q", async ct =>
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30), ct);
+                return false;
+            }
+            catch (OperationCanceledException)
+            {
+                return true;
+            }
+        }, TimeSpan.FromMilliseconds(150));
+
+        Assert.True(cancelled);
+        Assert.Equal(0, flight.InFlightCount);
+    }
+}

--- a/octo.Tests/SubsonicModelMapperTests.cs
+++ b/octo.Tests/SubsonicModelMapperTests.cs
@@ -24,6 +24,50 @@ public class SubsonicModelMapperTests
     }
 
     [Fact]
+    public void ParseSearchResponse_JsonSearchResult2_ParsesLocalRows()
+    {
+        // Search3() also serves rest/search2 and relays there, so the upstream answers
+        // under searchResult2. Reading only searchResult3 dropped every local row and the
+        // response then carried nothing but discovery results.
+        var jsonResponse = @"{
+            ""subsonic-response"": {
+                ""status"": ""ok"",
+                ""version"": ""1.16.1"",
+                ""searchResult2"": {
+                    ""song"": [ { ""id"": ""song1"", ""title"": ""Test Song"" } ],
+                    ""album"": [ { ""id"": ""alb1"", ""name"": ""Test Album"" } ],
+                    ""artist"": [ { ""id"": ""art1"", ""name"": ""Test Artist"" } ]
+                }
+            }
+        }";
+
+        var (songs, albums, artists) = _mapper.ParseSearchResponse(
+            Encoding.UTF8.GetBytes(jsonResponse), "application/json");
+
+        Assert.Single(songs);
+        Assert.Single(albums);
+        Assert.Single(artists);
+    }
+
+    [Fact]
+    public void ParseSearchResponse_XmlSearchResult2_ParsesLocalRows()
+    {
+        var xmlResponse = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <subsonic-response xmlns=""http://subsonic.org/restapi"" status=""ok"" version=""1.16.1"">
+                <searchResult2>
+                    <song id=""song1"" title=""Test Song"" />
+                    <album id=""alb1"" name=""Test Album"" />
+                </searchResult2>
+            </subsonic-response>";
+
+        var (songs, albums, _) = _mapper.ParseSearchResponse(
+            Encoding.UTF8.GetBytes(xmlResponse), "application/xml");
+
+        Assert.Single(songs);
+        Assert.Single(albums);
+    }
+
+    [Fact]
     public void ParseSearchResponse_JsonWithSongs_ParsesCorrectly()
     {
         // Arrange

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -325,17 +325,12 @@ public class SubsonicController : ControllerBase
         // source and locals would crowd out external recommendations. Now
         // radio goes through getSimilarSongs2 (where we do local-first
         // resolution), so search3 is "search" again — locals belong here.
-        // Generous local target so a search for "Drake" surfaces all your
-        // owned Drake songs alongside the YouTube discoveries; Navidrome
-        // returns at most what it actually has anyway.
-        var localSongTarget = Math.Max(20, requestedSongs / 4);
-
-        // Cap external generation. For songCount=2000 we used to fan out to
-        // ~1800 Last.fm tracks per call — fast at filling the registry's 10k
-        // LRU and ratelimits Last.fm. ~150 is plenty for any reasonable queue
-        // and the registry survives across many sessions before recycling.
-        const int MaxExternalPerQuery = 150;
-        var externalTarget = Math.Min(MaxExternalPerQuery, Math.Max(0, requestedSongs - localSongTarget));
+        //
+        // The split itself lives in SearchBudget so it can be unit-tested; the
+        // local floor used to be a flat 20, which is also the spec default for
+        // songCount, so the most common search in the wild left nothing for
+        // discovery at all (#14).
+        var (localSongTarget, externalTarget) = SearchBudget.Compute(requestedSongs);
 
         // External: Last.fm fan-out. We try track.search first (fuzzy matches
         // anywhere in the query), then top up with the canonical artist's top

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -302,19 +302,25 @@ public class SubsonicController : ControllerBase
 
         var cleanQuery = query.Trim().Trim('"');
 
+        // search2 and search3 are the same hijack with different envelopes. Decide once:
+        // the relay target, the envelope we answer with, and the empty-query passthrough
+        // all have to agree, and they used to be decided in three separate places with the
+        // response side hardcoded to searchResult3.
+        var isSearch2 = (Request.Path.Value ?? "").Contains("search2", StringComparison.OrdinalIgnoreCase);
+        var searchEndpoint = isSearch2 ? "rest/search2" : "rest/search3";
+        var envelope = isSearch2 ? "searchResult2" : "searchResult3";
+
         if (string.IsNullOrWhiteSpace(cleanQuery))
         {
             try
             {
-                var endpoint = (Request.Path.Value ?? "").Contains("search2", StringComparison.OrdinalIgnoreCase)
-                    ? "rest/search2" : "rest/search3";
-                var result = await _proxyService.RelayAsync(endpoint, parameters);
+                var result = await _proxyService.RelayAsync(searchEndpoint, parameters);
                 var contentType = result.ContentType ?? $"application/{format}";
                 return File(result.Body, contentType);
             }
             catch
             {
-                return _responseBuilder.CreateResponse(format, "searchResult3", new { });
+                return _responseBuilder.CreateResponse(format, envelope, new { });
             }
         }
 
@@ -354,15 +360,13 @@ public class SubsonicController : ControllerBase
 
         // Local pass-through. Albums/artists always get the full requested counts;
         // song-side gets the local target.
-        var localProxyEndpoint = (Request.Path.Value ?? "").Contains("search2", StringComparison.OrdinalIgnoreCase)
-            ? "rest/search2" : "rest/search3";
         var localParams = new Dictionary<string, string>(parameters)
         {
             ["songCount"]   = localSongTarget.ToString(),
             ["albumCount"]  = requestedAlbums.ToString(),
             ["artistCount"] = requestedArtists.ToString(),
         };
-        var localResult = await _proxyService.RelaySafeAsync(localProxyEndpoint, localParams);
+        var localResult = await _proxyService.RelaySafeAsync(searchEndpoint, localParams);
 
         // Parsed here rather than inside the merge so the count that sizes the discovery
         // slice below is taken from the very list the response will render. Deriving it
@@ -410,7 +414,7 @@ public class SubsonicController : ControllerBase
         var localSongIds = ExtractLocalSongIds(localResult.Body, localResult.ContentType);
         _radioQueueStore.Register(localSongIds.Concat(externalSongs.Select(s => s.Id)));
 
-        return MergeSearchResults(localParsed, localResult.ContentType, externalResult, playlistTask, format);
+        return MergeSearchResults(localParsed, localResult.ContentType, externalResult, playlistTask, format, envelope);
     }
 
     /// <summary>
@@ -1177,56 +1181,60 @@ public class SubsonicController : ControllerBase
         string? localContentType,
         SearchResult externalResult,
         List<ExternalPlaylist> playlistResult,
-        string format)
+        string format,
+        string envelope)
     {
         var (localSongs, localAlbums, localArtists) = local;
 
         var isJson = format == "json" || localContentType?.Contains("json") == true;
         var (mergedSongs, mergedAlbums, mergedArtists) = _modelMapper.MergeSearchResults(
-            localSongs, 
-            localAlbums, 
-            localArtists, 
+            localSongs,
+            localAlbums,
+            localArtists,
             externalResult,
             playlistResult,
             isJson);
 
         if (isJson)
         {
-            return _responseBuilder.CreateJsonResponse(new
+            // Dictionary rather than an anonymous type because the envelope name is
+            // decided by the request: search2 answered under searchResult3 is a shape the
+            // client never asked for, and a strict one drops the whole payload.
+            return _responseBuilder.CreateJsonResponse(new Dictionary<string, object>
             {
-                status = "ok",
-                version = "1.16.1",
-                searchResult3 = new
+                ["status"] = "ok",
+                ["version"] = "1.16.1",
+                [envelope] = new Dictionary<string, object>
                 {
-                    song = mergedSongs,
-                    album = mergedAlbums,
-                    artist = mergedArtists
-                }
+                    ["song"] = mergedSongs,
+                    ["album"] = mergedAlbums,
+                    ["artist"] = mergedArtists,
+                },
             });
         }
         else
         {
             var ns = XNamespace.Get("http://subsonic.org/restapi");
-            var searchResult3 = new XElement(ns + "searchResult3");
-            
+            var searchResult = new XElement(ns + envelope);
+
             foreach (var artist in mergedArtists.Cast<XElement>())
             {
-                searchResult3.Add(artist);
+                searchResult.Add(artist);
             }
             foreach (var album in mergedAlbums.Cast<XElement>())
             {
-                searchResult3.Add(album);
+                searchResult.Add(album);
             }
             foreach (var song in mergedSongs.Cast<XElement>())
             {
-                searchResult3.Add(song);
+                searchResult.Add(song);
             }
 
             var doc = new XDocument(
                 new XElement(ns + "subsonic-response",
                     new XAttribute("status", "ok"),
                     new XAttribute("version", "1.16.1"),
-                    searchResult3
+                    searchResult
                 )
             );
 

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -38,6 +38,7 @@ public class SubsonicController : ControllerBase
     private readonly CoverArtAggregator? _coverArtAggregator;
     private readonly ExternalIdRegistry _idRegistry;
     private readonly Octo.Services.Common.TrackAcquisitionQueue _acquisitions;
+    private readonly Octo.Services.Common.ExternalSearchService _externalSearch;
     private readonly RadioQueueStore _radioQueueStore;
     private readonly NavidromeIdentityService _navIdentity;
     private readonly ILogger<SubsonicController> _logger;
@@ -53,6 +54,7 @@ public class SubsonicController : ControllerBase
         SubsonicProxyService proxyService,
         ExternalIdRegistry idRegistry,
         Octo.Services.Common.TrackAcquisitionQueue acquisitions,
+        Octo.Services.Common.ExternalSearchService externalSearch,
         RadioQueueStore radioQueueStore,
         NavidromeIdentityService navIdentity,
         ILogger<SubsonicController> logger,
@@ -72,6 +74,7 @@ public class SubsonicController : ControllerBase
         _proxyService = proxyService;
         _idRegistry = idRegistry;
         _acquisitions = acquisitions;
+        _externalSearch = externalSearch;
         _radioQueueStore = radioQueueStore;
         _navIdentity = navIdentity;
         _playlistSyncService = playlistSyncService;
@@ -332,24 +335,20 @@ public class SubsonicController : ControllerBase
         // discovery at all (#14).
         var (localSongTarget, externalTarget) = SearchBudget.Compute(requestedSongs);
 
-        // External: Last.fm fan-out. We try track.search first (fuzzy matches
-        // anywhere in the query), then top up with the canonical artist's top
-        // tracks if we're short. Each Last.fm hit becomes an instant placeholder
-        // song via SoulseekMetadataService — no yt-dlp call until /rest/stream.
-        // Album discovery runs concurrently with the Last.fm song fan-out so it costs no
+        // Album discovery runs concurrently with the song fan-out below so it costs no
         // serial latency. It needs no Last.fm key (Deezer's catalog is keyless), so albums
         // still appear for a user who has not set one up.
         var albumTask = requestedAlbums > 0
             ? _metadataService.SearchAlbumsAsync(cleanQuery, Math.Min(requestedAlbums, 20))
             : Task.FromResult(new List<Album>());
 
-        var externalSongs = await BuildExternalSearchResultsAsync(cleanQuery, externalTarget);
-
-        // Album/art/year from Deezer (fast), then the ACCURATE duration for the top
-        // of the list from the real YouTube video (so the scrub bar matches the
-        // audio and the client advances correctly). Bounded + cached.
-        await _metadataService.EnrichExternalSongsAsync(externalSongs);
-        await _metadataService.ResolveTopDurationsAsync(externalSongs);
+        // One build per query, shared by every caller. Clients routinely fire several
+        // search calls for a single typed query, and those calls resolve to the same
+        // routing objects, so without this each one would re-run the whole enrichment
+        // pipeline over them concurrently.
+        var externalSongs = externalTarget > 0
+            ? (await _externalSearch.GetAsync(cleanQuery)).Take(externalTarget).ToList()
+            : new List<Song>();
 
         // Local pass-through. Albums/artists always get the full requested counts;
         // song-side gets the local target.
@@ -436,63 +435,6 @@ public class SubsonicController : ControllerBase
         }
         catch { /* malformed upstream response — return whatever we got */ }
         return ids;
-    }
-
-    /// <summary>
-    /// Fans out a free-form query to Last.fm and returns up to <paramref name="target"/>
-    /// instant-placeholder external songs. Order:
-    ///   1. track.search hits (best fuzzy matches for the query as typed)
-    ///   2. canonical artist's top tracks (in case (1) was thin — common for
-    ///      single-word artist queries)
-    /// We dedupe by artist+title to avoid the same track appearing twice.
-    /// </summary>
-    private async Task<List<Song>> BuildExternalSearchResultsAsync(string query, int target)
-    {
-        if (target <= 0 || _lastFmService is null || !_lastFmService.IsConfigured)
-            return new List<Song>();
-
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var collected = new List<(string Artist, string Title)>();
-
-        var tracks = await _lastFmService.SearchTracksAsync(query, Math.Min(50, target * 2));
-        foreach (var t in tracks)
-        {
-            var key = $"{t.Artist}|{t.Title}".ToLowerInvariant();
-            if (seen.Add(key)) collected.Add((t.Artist, t.Title));
-            if (collected.Count >= target) break;
-        }
-
-        if (collected.Count < target)
-        {
-            // Use the first track-search hit's artist as the canonical anchor
-            // for top-tracks padding. Falls back to the raw query string when
-            // track.search came back empty.
-            var anchor = tracks.Count > 0 ? tracks[0].Artist : query;
-            var topTracks = await _lastFmService.GetArtistTopTracksAsync(anchor, target * 2);
-            foreach (var t in topTracks)
-            {
-                var key = $"{t.Artist}|{t.Title}".ToLowerInvariant();
-                if (seen.Add(key)) collected.Add((t.Artist, t.Title));
-                if (collected.Count >= target) break;
-            }
-        }
-
-        var songs = new List<Song>(collected.Count);
-        foreach (var (artist, title) in collected)
-        {
-            var hits = await _metadataService.SearchSongsByArtistTitleAsync(artist, title, 1);
-            if (hits.Count > 0) songs.Add(hits[0]);
-        }
-        _logger.LogInformation("External search '{Q}' -> {N} placeholder songs", query, songs.Count);
-
-        // Fire-and-forget: pre-resolve YouTube videoIds for the top hits so the
-        // first /rest/stream click doesn't pay the cold yt-dlp double-call cost
-        // (ytsearch1: + -g, 6-16s combined). Arpeggi cancels at ~10s and falls
-        // back to a local song; without this, external playback is unreachable
-        // from that client. 12 ≈ what fits on the first page of search results.
-        _ = _metadataService.PrewarmYouTubeIdsAsync(songs, topN: 12);
-
-        return songs;
     }
 
     /// <summary>
@@ -2107,11 +2049,10 @@ public class SubsonicController : ControllerBase
         if (target <= 0) return null;
 
         // Same discovery core as Subsonic search3: Last.fm fan-out, Deezer enrich,
-        // accurate YouTube durations for the top of the list.
-        var externalSongs = await BuildExternalSearchResultsAsync(term, target);
+        // accurate YouTube durations for the top of the list. Shared with search3, so a
+        // client that searches both ways for one query only pays for it once.
+        var externalSongs = (await _externalSearch.GetAsync(term)).Take(target).ToList();
         if (externalSongs.Count == 0) return null;
-        await _metadataService.EnrichExternalSongsAsync(externalSongs);
-        await _metadataService.ResolveTopDurationsAsync(externalSongs);
 
         foreach (var s in externalSongs)
             realArr.Add(BuildNativeSongObject(s));

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -345,10 +345,12 @@ public class SubsonicController : ControllerBase
         // One build per query, shared by every caller. Clients routinely fire several
         // search calls for a single typed query, and those calls resolve to the same
         // routing objects, so without this each one would re-run the whole enrichment
-        // pipeline over them concurrently.
-        var externalSongs = externalTarget > 0
-            ? (await _externalSearch.GetAsync(cleanQuery)).Take(externalTarget).ToList()
-            : new List<Song>();
+        // pipeline over them concurrently. Started here rather than awaited, so it
+        // overlaps the local relay below; how many of its rows we actually use depends
+        // on what that relay comes back with.
+        var externalTask = externalTarget > 0
+            ? _externalSearch.GetAsync(cleanQuery)
+            : Task.FromResult<IReadOnlyList<Song>>(Array.Empty<Song>());
 
         // Local pass-through. Albums/artists always get the full requested counts;
         // song-side gets the local target.
@@ -361,6 +363,25 @@ public class SubsonicController : ControllerBase
             ["artistCount"] = requestedArtists.ToString(),
         };
         var localResult = await _proxyService.RelaySafeAsync(localProxyEndpoint, localParams);
+
+        // Parsed here rather than inside the merge so the count that sizes the discovery
+        // slice below is taken from the very list the response will render. Deriving it
+        // from a second, differently-written parse of the same bytes is how you end up
+        // topping up against a local count the client never sees.
+        var localParsed = localResult.Success && localResult.Body != null
+            ? _modelMapper.ParseSearchResponse(localResult.Body, localResult.ContentType)
+            : (Songs: new List<object>(), Albums: new List<object>(), Artists: new List<object>());
+
+        // Hand the slots the library did not fill to discovery. A query the user owns
+        // nothing for is the one most worth answering with suggestions, and the local
+        // target is a reservation rather than a promise: Navidrome returns what it has.
+        // If the relay failed outright the count is zero, and filling the page with
+        // discovery is the right answer there too, since the merge will show no locals.
+        var built = await externalTask;
+        var externalSlice = Math.Min(
+            built.Count,
+            externalTarget + Math.Max(0, localSongTarget - localParsed.Songs.Count));
+        var externalSongs = built.Take(externalSlice).ToList();
 
         var playlistTask = _subsonicSettings.EnableExternalPlaylists
             ? await _metadataService.SearchPlaylistsAsync(cleanQuery, requestedAlbums)
@@ -389,7 +410,7 @@ public class SubsonicController : ControllerBase
         var localSongIds = ExtractLocalSongIds(localResult.Body, localResult.ContentType);
         _radioQueueStore.Register(localSongIds.Concat(externalSongs.Select(s => s.Id)));
 
-        return MergeSearchResults(localResult, externalResult, playlistTask, format);
+        return MergeSearchResults(localParsed, localResult.ContentType, externalResult, playlistTask, format);
     }
 
     /// <summary>
@@ -1152,16 +1173,15 @@ public class SubsonicController : ControllerBase
     #region Helper Methods
 
     private IActionResult MergeSearchResults(
-        (byte[]? Body, string? ContentType, bool Success) subsonicResult,
+        (List<object> Songs, List<object> Albums, List<object> Artists) local,
+        string? localContentType,
         SearchResult externalResult,
         List<ExternalPlaylist> playlistResult,
         string format)
     {
-        var (localSongs, localAlbums, localArtists) = subsonicResult.Success && subsonicResult.Body != null
-            ? _modelMapper.ParseSearchResponse(subsonicResult.Body, subsonicResult.ContentType)
-            : (new List<object>(), new List<object>(), new List<object>());
+        var (localSongs, localAlbums, localArtists) = local;
 
-        var isJson = format == "json" || subsonicResult.ContentType?.Contains("json") == true;
+        var isJson = format == "json" || localContentType?.Contains("json") == true;
         var (mergedSongs, mergedAlbums, mergedArtists) = _modelMapper.MergeSearchResults(
             localSongs, 
             localAlbums, 

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1403,7 +1403,7 @@ public class SubsonicController : ControllerBase
         }
 
         // Check if Last.fm radio is configured and enabled
-        if (_lastFmService == null || !_lastFmService.IsConfigured)
+        if (_lastFmService == null || !_lastFmService.IsRadioEnabled)
         {
             _logger.LogDebug("Last.fm radio not configured, relaying to upstream server");
             try

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -310,7 +310,14 @@ public class SubsonicController : ControllerBase
         var searchEndpoint = isSearch2 ? "rest/search2" : "rest/search3";
         var envelope = isSearch2 ? "searchResult2" : "searchResult3";
 
-        if (string.IsNullOrWhiteSpace(cleanQuery))
+        // Discovery belongs on the first page only. Injected rows are regenerated per
+        // request rather than held in a server-side result set, so appending them to page
+        // two hands the client the same suggestions it already scrolled past. The native
+        // search path refuses later pages for exactly this reason; do the same here and
+        // let the library page normally underneath.
+        var songOffset = int.TryParse(parameters.GetValueOrDefault("songOffset", "0"), out var so) ? so : 0;
+
+        if (string.IsNullOrWhiteSpace(cleanQuery) || songOffset > 0)
         {
             try
             {
@@ -341,10 +348,17 @@ public class SubsonicController : ControllerBase
         // discovery at all (#14).
         var (localSongTarget, externalTarget) = SearchBudget.Compute(requestedSongs);
 
+        // A client that asked for a handful of songs is searching as the user types. The
+        // song side already costs nothing there (the budget leaves no room for discovery),
+        // but external album search was still firing a Deezer query per keystroke. Judged
+        // from the song count only when the client actually asked for songs, so a genuine
+        // album-only search still gets album discovery.
+        var isTypeAheadProbe = requestedSongs > 0 && externalTarget == 0;
+
         // Album discovery runs concurrently with the song fan-out below so it costs no
         // serial latency. It needs no Last.fm key (Deezer's catalog is keyless), so albums
         // still appear for a user who has not set one up.
-        var albumTask = requestedAlbums > 0
+        var albumTask = requestedAlbums > 0 && !isTypeAheadProbe
             ? _metadataService.SearchAlbumsAsync(cleanQuery, Math.Min(requestedAlbums, 20))
             : Task.FromResult(new List<Album>());
 
@@ -367,6 +381,16 @@ public class SubsonicController : ControllerBase
             ["artistCount"] = requestedArtists.ToString(),
         };
         var localResult = await _proxyService.RelaySafeAsync(searchEndpoint, localParams);
+
+        // Subsonic reports its own errors inside an HTTP 200, so a rejected login and an
+        // empty library are the same thing to every check above this line. Left alone,
+        // the discovery top-up would read "no local matches", fill the page with
+        // suggestions, and present a broken connection as a healthy search.
+        if (IsFailedSubsonicBody(localResult.Body, localResult.ContentType))
+        {
+            _logger.LogDebug("upstream rejected the search for '{Q}'; passing its error through", cleanQuery);
+            return File(localResult.Body!, localResult.ContentType ?? $"application/{format}");
+        }
 
         // Parsed here rather than inside the merge so the count that sizes the discovery
         // slice below is taken from the very list the response will render. Deriving it
@@ -415,6 +439,36 @@ public class SubsonicController : ControllerBase
         _radioQueueStore.Register(localSongIds.Concat(externalSongs.Select(s => s.Id)));
 
         return MergeSearchResults(localParsed, localResult.ContentType, externalResult, playlistTask, format, envelope);
+    }
+
+    /// <summary>
+    /// True when a relayed body is a Subsonic error envelope. These arrive as HTTP 200
+    /// with <c>status="failed"</c> inside, so the status code alone cannot tell a rejected
+    /// request from an empty result set.
+    /// </summary>
+    internal static bool IsFailedSubsonicBody(byte[]? body, string? contentType)
+    {
+        if (body == null || body.Length == 0) return false;
+        try
+        {
+            if (contentType?.Contains("json") == true)
+            {
+                using var doc = JsonDocument.Parse(body);
+                return doc.RootElement.TryGetProperty("subsonic-response", out var resp)
+                    && resp.TryGetProperty("status", out var st)
+                    && st.ValueKind == JsonValueKind.String
+                    && string.Equals(st.GetString(), "failed", StringComparison.OrdinalIgnoreCase);
+            }
+
+            var xml = XDocument.Load(new System.IO.MemoryStream(body));
+            return string.Equals(xml.Root?.Attribute("status")?.Value, "failed",
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Unparseable is not the same as failed. Let the normal path handle it.
+            return false;
+        }
     }
 
     /// <summary>

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -92,6 +92,11 @@ builder.Services.AddHttpClient(Octo.Services.Metadata.DeezerRateLimiter.ClientNa
 builder.Services.AddSingleton<IMusicMetadataService, SoulseekMetadataService>();
 builder.Services.AddSingleton<IDownloadService, SoulseekDownloadService>();
 
+// Discovery results are built once per query and shared. Clients fire several search
+// calls for one typed query, and they all resolve to the same routing objects, so without
+// this each call re-runs the enrichment pipeline over them concurrently.
+builder.Services.AddSingleton<Octo.Services.Common.ExternalSearchService>();
+
 // Permanent-copy fetches run here, never inside the request that asked for one. A client
 // giving up on a slow play must not cancel a transfer slskd is going to finish anyway.
 builder.Services.AddSingleton<Octo.Services.Common.TrackAcquisitionQueue>();

--- a/octo/Services/Common/ExternalSearchService.cs
+++ b/octo/Services/Common/ExternalSearchService.cs
@@ -1,0 +1,150 @@
+using Octo.Models.Domain;
+using Octo.Services.LastFm;
+
+namespace Octo.Services.Common;
+
+/// <summary>
+/// Builds the external (discovery) half of a search, once per query.
+///
+/// Every caller for the same query joins one execution and receives the same list. That
+/// is not an optimisation, it is what keeps the search3 fix from re-creating issue #8.
+/// Clients routinely fire several search calls for one typed query, and registry ids are
+/// deterministic, so those calls resolve to the *same* SoulseekRouting objects and would
+/// each run the enrichment pipeline over them concurrently — three writers to a shared
+/// int? duration, and three times the Deezer fan-out against a budget that is already the
+/// tightest thing in the system.
+///
+/// The returned list is FROZEN. Nothing may mutate a Song after the build completes;
+/// callers slice it and serialise it, concurrently, without copying. Both Subsonic
+/// serialisers and the native one only read, and the star/download paths rebuild a Song
+/// from the registry rather than from a search result. Any future "top up the enrichment
+/// because this caller wanted more rows" belongs inside the build, not after it.
+/// </summary>
+public sealed class ExternalSearchService
+{
+    /// <summary>
+    /// Rows built per query, regardless of how many the caller wants.
+    ///
+    /// It has to be a constant rather than the caller's target, or single-flight is
+    /// unsound: a client asking for 8 rows could win the race and hand 8 rows to a caller
+    /// that asked for 150. 60 is the number because that is where enrichment stops
+    /// (BackgroundEnrichLimit), so rows past it would ship as bare placeholders carrying a
+    /// fallback duration, and because the Navidrome-native search path already caps here.
+    /// </summary>
+    public const int BuildSize = 60;
+
+    /// <summary>
+    /// Deadline for one build. Last.fm has no configured HTTP timeout of its own, so
+    /// without this a single hung call would pin the query for every joined caller.
+    /// </summary>
+    private static readonly TimeSpan BuildTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly SingleFlight<string, List<Song>> _flight = new();
+    private readonly IMusicMetadataService _metadata;
+    private readonly LastFmService? _lastFm;
+    private readonly ILogger<ExternalSearchService> _logger;
+
+    public ExternalSearchService(
+        IMusicMetadataService metadata,
+        ILogger<ExternalSearchService> logger,
+        LastFmService? lastFm = null)
+    {
+        _metadata = metadata;
+        _logger = logger;
+        _lastFm = lastFm;
+    }
+
+    /// <summary>
+    /// Up to <see cref="BuildSize"/> enriched external songs for this query. Callers take
+    /// the prefix they need; the list is shared and must not be mutated.
+    /// </summary>
+    public async Task<IReadOnlyList<Song>> GetAsync(string query, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return Array.Empty<Song>();
+        if (_lastFm is null || !_lastFm.IsConfigured) return Array.Empty<Song>();
+
+        // Key on the query alone. The build size is constant, so two callers wanting
+        // different row counts still want the same work done.
+        var key = query.Trim().ToLowerInvariant();
+
+        try
+        {
+            return await _flight.RunAsync(key, token => BuildAsync(query, token), BuildTimeout);
+        }
+        catch (Exception ex)
+        {
+            // Discovery is an addition to search, never a precondition for it. The steps
+            // inside the build are individually best-effort, but the deadline is not: the
+            // enrichment fan-out waits on its semaphore outside its own try, so a timeout
+            // there would otherwise escape and take the user's local results down with it.
+            _logger.LogDebug("external search '{Q}' failed: {M}", query, ex.Message);
+            return Array.Empty<Song>();
+        }
+    }
+
+    /// <summary>
+    /// Fans out to Last.fm, then fills in the metadata a client needs to render and play
+    /// the rows. Order:
+    ///   1. track.search hits (best fuzzy matches for the query as typed)
+    ///   2. canonical artist's top tracks (in case (1) was thin — common for
+    ///      single-word artist queries)
+    /// Deduped by artist+title so the same track cannot appear twice.
+    /// </summary>
+    private async Task<List<Song>> BuildAsync(string query, CancellationToken ct)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var collected = new List<(string Artist, string Title)>();
+
+        var tracks = await _lastFm!.SearchTracksAsync(query, Math.Min(50, BuildSize * 2));
+        foreach (var t in tracks)
+        {
+            var key = $"{t.Artist}|{t.Title}".ToLowerInvariant();
+            if (seen.Add(key)) collected.Add((t.Artist, t.Title));
+            if (collected.Count >= BuildSize) break;
+        }
+
+        if (collected.Count < BuildSize)
+        {
+            // Use the first track-search hit's artist as the canonical anchor
+            // for top-tracks padding. Falls back to the raw query string when
+            // track.search came back empty.
+            var anchor = tracks.Count > 0 ? tracks[0].Artist : query;
+            var topTracks = await _lastFm.GetArtistTopTracksAsync(anchor, BuildSize * 2);
+            foreach (var t in topTracks)
+            {
+                var key = $"{t.Artist}|{t.Title}".ToLowerInvariant();
+                if (seen.Add(key)) collected.Add((t.Artist, t.Title));
+                if (collected.Count >= BuildSize) break;
+            }
+        }
+
+        var songs = new List<Song>(collected.Count);
+        foreach (var (artist, title) in collected)
+        {
+            var hits = await _metadata.SearchSongsByArtistTitleAsync(artist, title, 1);
+            if (hits.Count > 0) songs.Add(hits[0]);
+        }
+        _logger.LogInformation("External search '{Q}' -> {N} placeholder songs", query, songs.Count);
+
+        // Album/art/year from Deezer (fast), then the ACCURATE duration for the top of the
+        // list from the real YouTube video (so the scrub bar matches the audio and the
+        // client advances correctly). Bounded + cached.
+        await _metadata.EnrichExternalSongsAsync(songs, ct);
+        await _metadata.ResolveTopDurationsAsync(songs, ct);
+
+        // Fire-and-forget: pre-resolve YouTube videoIds for the top hits so the first
+        // /rest/stream click doesn't pay the cold yt-dlp double-call cost (ytsearch1: + -g,
+        // 6-16s combined). Arpeggi cancels at ~10s and falls back to a local song; without
+        // this, external playback is unreachable from that client. 12 is about what fits on
+        // the first page of search results.
+        //
+        // It runs LAST on purpose. It used to run before enrichment, where it wrote a
+        // videoId chosen with no duration hint while ResolveTopDurationsAsync was choosing
+        // a different one using the Deezer duration — so for the top rows the two raced and
+        // the loser could leave a song advertising the length of a video that would not be
+        // the one played.
+        _ = _metadata.PrewarmYouTubeIdsAsync(songs, topN: 12);
+
+        return songs;
+    }
+}

--- a/octo/Services/Common/ExternalSearchService.cs
+++ b/octo/Services/Common/ExternalSearchService.cs
@@ -61,7 +61,10 @@ public sealed class ExternalSearchService
     public async Task<IReadOnlyList<Song>> GetAsync(string query, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query)) return Array.Empty<Song>();
-        if (_lastFm is null || !_lastFm.IsConfigured) return Array.Empty<Song>();
+        // Only the key, not the radio switch. Discovery in the search bar is a different
+        // feature from radio, and gating it on EnableRadio made turning radio off empty
+        // the search results too.
+        if (_lastFm is null || !_lastFm.HasApiKey) return Array.Empty<Song>();
 
         // Key on the query alone. The build size is constant, so two callers wanting
         // different row counts still want the same work done.

--- a/octo/Services/Common/SingleFlight.cs
+++ b/octo/Services/Common/SingleFlight.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+
+namespace Octo.Services.Common;
+
+/// <summary>
+/// Collapses concurrent identical work onto one execution. Callers arriving while a key
+/// is already running join the running task instead of starting their own.
+///
+/// This holds no results. Once the work finishes the entry is gone, so there is no
+/// staleness policy, no negative-caching rule, and nothing for a poisoned entry to
+/// survive in. That is deliberate: the failure mode we are avoiding is a keyed dictionary
+/// of tasks that outlives its usefulness, which on arbitrary user input becomes a
+/// user-triggerable leak.
+/// </summary>
+public sealed class SingleFlight<TKey, TValue> where TKey : notnull
+{
+    private readonly ConcurrentDictionary<TKey, TaskCompletionSource<TValue>> _inFlight = new();
+
+    /// <summary>Number of executions currently running. Exposed for tests and logging.</summary>
+    public int InFlightCount => _inFlight.Count;
+
+    /// <summary>
+    /// Run <paramref name="factory"/> for <paramref name="key"/>, or join the execution
+    /// already running for it.
+    /// </summary>
+    /// <param name="timeout">
+    /// Deadline for the work itself. The factory never sees a caller's cancellation token:
+    /// joined callers share one execution, so letting the first one to disconnect cancel it
+    /// would take everyone else down with it. A deadline is what stops a hung dependency
+    /// pinning the key instead.
+    /// </param>
+    public async Task<TValue> RunAsync(
+        TKey key,
+        Func<CancellationToken, Task<TValue>> factory,
+        TimeSpan timeout)
+    {
+        // RunContinuationsAsynchronously is required. Without it, completing this source
+        // runs every joined request's continuation — response headers, body writes, the
+        // whole serialisation — inline on whichever thread finished the work.
+        var mine = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var existing = _inFlight.GetOrAdd(key, mine);
+        if (!ReferenceEquals(existing, mine))
+        {
+            // Someone else owns this key. Join them rather than doing the work twice.
+            return await existing.Task;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            mine.SetResult(await factory(cts.Token));
+        }
+        catch (Exception ex)
+        {
+            // Every joiner sees the failure, and the finally below removes the entry, so
+            // the next caller retries rather than inheriting a permanently faulted task.
+            mine.SetException(ex);
+        }
+        finally
+        {
+            // After the result is set, not before: a caller arriving in between joins a
+            // completed task and gets the answer, where the reverse order would have it
+            // start a redundant execution.
+            _inFlight.TryRemove(key, out _);
+        }
+
+        return await mine.Task;
+    }
+}

--- a/octo/Services/LastFm/LastFmService.cs
+++ b/octo/Services/LastFm/LastFmService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Octo.Models.Settings;
@@ -11,8 +12,11 @@ public class LastFmService
     private readonly ILogger<LastFmService> _logger;
     private const string BaseUrl = "https://ws.audioscrobbler.com/2.0/";
     
-    // Simple in-memory cache
-    private readonly Dictionary<string, (DateTime Expiry, List<SimilarTrack> Tracks)> _cache = new();
+    // Concurrent because radio requests arrive on request threads and this is written on
+    // every miss. A plain Dictionary written from two threads at once does not merely lose
+    // an entry: a resize racing with an insert can corrupt the bucket chain and leave a
+    // later read spinning forever inside the lookup.
+    private readonly ConcurrentDictionary<string, (DateTime Expiry, List<SimilarTrack> Tracks)> _cache = new();
 
     public LastFmService(
         HttpClient httpClient,
@@ -193,7 +197,18 @@ public class LastFmService
         }
     }
 
-    public bool IsConfigured => !string.IsNullOrEmpty(_settings.ApiKey) && _settings.EnableRadio;
+    /// <summary>
+    /// Last.fm can answer at all. Search discovery needs only this: an API key.
+    /// </summary>
+    public bool HasApiKey => !string.IsNullOrEmpty(_settings.ApiKey);
+
+    /// <summary>
+    /// Radio specifically is available. EnableRadio is a switch for the radio feature, so
+    /// it belongs here and not on <see cref="HasApiKey"/> — the two used to be one property,
+    /// which meant turning radio off also silently emptied the search bar of discovery
+    /// results, a setting doing something its name does not say.
+    /// </summary>
+    public bool IsRadioEnabled => HasApiKey && _settings.EnableRadio;
 
     /// <summary>
     /// Free-form track search. Used by Search3 hijack so the search bar

--- a/octo/Services/Subsonic/SearchBudget.cs
+++ b/octo/Services/Subsonic/SearchBudget.cs
@@ -1,0 +1,61 @@
+namespace Octo.Services.Subsonic;
+
+/// <summary>
+/// Splits a client's requested song count between local library results and external
+/// discovery results for search3 / search2.
+///
+/// This exists because the split used to be a flat local floor of 20 that could consume
+/// the entire budget. Since 20 is also the Subsonic spec default for songCount (and this
+/// server's own fallback when the parameter is absent), the most common search in the
+/// wild reserved every slot for local results and generated no discovery at all, which
+/// is what made search look like it only ever returned albums.
+///
+/// The rule that replaced it caps the floor at what the client actually asked for, so
+/// the two targets always fit inside the requested count. That matters because the merge
+/// concatenates local songs first and appends externals with no total cap: an external
+/// past the client's songCount is the same as no external at all for any client that
+/// renders only what it requested.
+/// </summary>
+public static class SearchBudget
+{
+    /// <summary>
+    /// How many local rows to reserve before discovery gets a share. Capped at the
+    /// requested count, so a client asking for fewer than this gets local-only results
+    /// and no fan-out. That is what keeps per-keystroke type-ahead cheap: a search for
+    /// five rows costs one relay, where generating discovery for it would cost a Last.fm
+    /// fan-out plus a dozen Deezer enrichment rows and eight yt-dlp lookups.
+    /// </summary>
+    public const int LocalSongFloor = 12;
+
+    /// <summary>
+    /// Ceiling on generated discovery rows per query. Beyond this the rows are not worth
+    /// producing: enrichment stops at BackgroundEnrichLimit, so anything past it ships as
+    /// a bare placeholder carrying a fallback duration.
+    /// </summary>
+    public const int ExternalCeiling = 150;
+
+    /// <summary>
+    /// Split <paramref name="requestedSongs"/> into a local target and an external target.
+    /// Both are returned together so the two can never drift apart at a call site.
+    /// </summary>
+    /// <param name="requestedSongs">
+    /// The client's songCount. Negative values are treated as zero; the previous
+    /// expression sanitised those only by accident, through its flat floor.
+    /// </param>
+    /// <returns>
+    /// Local and external targets. Their sum never exceeds <paramref name="requestedSongs"/>.
+    /// </returns>
+    public static (int Local, int External) Compute(int requestedSongs)
+    {
+        var requested = Math.Max(0, requestedSongs);
+
+        // Locals still scale with big requests through the quarter rule, which is what
+        // keeps behaviour identical for the large counts radio-style clients send. The
+        // floor only decides small requests, and capping it at the request is the fix.
+        var local = Math.Max(Math.Min(LocalSongFloor, requested), requested / 4);
+
+        var external = Math.Min(ExternalCeiling, Math.Max(0, requested - local));
+
+        return (local, external);
+    }
+}

--- a/octo/Services/Subsonic/SearchBudget.cs
+++ b/octo/Services/Subsonic/SearchBudget.cs
@@ -28,11 +28,12 @@ public static class SearchBudget
     public const int LocalSongFloor = 12;
 
     /// <summary>
-    /// Ceiling on generated discovery rows per query. Beyond this the rows are not worth
-    /// producing: enrichment stops at BackgroundEnrichLimit, so anything past it ships as
-    /// a bare placeholder carrying a fallback duration.
+    /// Ceiling on discovery rows handed to one response. Tied to the number actually built
+    /// per query so a caller can never be promised more rows than exist: the build size is
+    /// a constant precisely so concurrent callers wanting different amounts can share one
+    /// execution.
     /// </summary>
-    public const int ExternalCeiling = 150;
+    public const int ExternalCeiling = Common.ExternalSearchService.BuildSize;
 
     /// <summary>
     /// Split <paramref name="requestedSongs"/> into a local target and an external target.

--- a/octo/Services/Subsonic/SubsonicModelMapper.cs
+++ b/octo/Services/Subsonic/SubsonicModelMapper.cs
@@ -40,8 +40,12 @@ public class SubsonicModelMapper
             if (contentType?.Contains("json") == true)
             {
                 var jsonDoc = JsonDocument.Parse(content);
+                // Both envelopes: search2 and search3 are the same hijack, and a search2
+                // relay answers under searchResult2. Reading only searchResult3 silently
+                // dropped every local row for search2 clients.
                 if (jsonDoc.RootElement.TryGetProperty("subsonic-response", out var response) &&
-                    response.TryGetProperty("searchResult3", out var searchResult))
+                    (response.TryGetProperty("searchResult3", out var searchResult) ||
+                     response.TryGetProperty("searchResult2", out searchResult)))
                 {
                     if (searchResult.TryGetProperty("song", out var songElements))
                     {
@@ -70,7 +74,8 @@ public class SubsonicModelMapper
             {
                 var xmlDoc = XDocument.Parse(content);
                 var ns = xmlDoc.Root?.GetDefaultNamespace() ?? XNamespace.None;
-                var searchResult = xmlDoc.Descendants(ns + "searchResult3").FirstOrDefault();
+                var searchResult = xmlDoc.Descendants(ns + "searchResult3").FirstOrDefault()
+                                   ?? xmlDoc.Descendants(ns + "searchResult2").FirstOrDefault();
                 
                 if (searchResult != null)
                 {

--- a/octo/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -315,7 +315,13 @@ public class SubsonicResponseBuilder
     /// <summary>
     /// Converts a Song domain model to Subsonic JSON format.
     /// </summary>
-    public Dictionary<string, object> ConvertSongToJson(Song song)
+    public Dictionary<string, object> ConvertSongToJson(Song song) => ConvertSongFields(song);
+
+    /// <summary>
+    /// The song shape both serializers render. See <see cref="Attributes"/> for why there
+    /// is only one of these.
+    /// </summary>
+    private Dictionary<string, object> ConvertSongFields(Song song)
     {
         // External (Soulseek/YouTube) songs are presented as ordinary streamable
         // tracks. Setting isExternal=true causes some Subsonic clients (Arpeggio,
@@ -430,83 +436,111 @@ public class SubsonicResponseBuilder
     /// <summary>
     /// Converts an Album domain model to Subsonic JSON format.
     /// </summary>
-    public object ConvertAlbumToJson(Album album)
+    public object ConvertAlbumToJson(Album album) => BuildAlbumFields(album);
+
+    /// <summary>
+    /// The album shape both serializers render. A client browsing by folder rather than by
+    /// tags reads <c>title</c>, <c>isDir</c> and <c>parent</c>; emitting only <c>name</c>
+    /// left injected albums looking unlike anything the upstream server returns.
+    /// </summary>
+    private Dictionary<string, object> BuildAlbumFields(Album album)
     {
-        return new
+        var artistId = album.ArtistId ?? _idRegistry.Register(new SoulseekRouting
         {
-            id = album.Id,
-            name = album.Title,
-            artist = album.Artist,
-            artistId = album.ArtistId,
-            songCount = album.SongCount ?? 0,
-            year = album.Year ?? 0,
-            coverArt = album.Id,
-            isExternal = !album.IsLocal
+            Kind = RoutingKind.Artist,
+            Artist = album.Artist,
+        });
+
+        return new Dictionary<string, object>
+        {
+            ["id"] = album.Id,
+            ["parent"] = artistId,
+            ["isDir"] = true,
+            ["title"] = album.Title,
+            ["name"] = album.Title,
+            ["album"] = album.Title,
+            ["artist"] = album.Artist ?? "",
+            ["artistId"] = artistId,
+            ["songCount"] = album.SongCount ?? 0,
+            ["year"] = album.Year ?? 0,
+            ["genre"] = album.Genre ?? "",
+            ["coverArt"] = album.Id,
+            ["created"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+            ["mediaType"] = "album",
+            ["displayArtist"] = album.Artist ?? "",
+            ["sortName"] = (album.Title ?? "").ToLowerInvariant(),
+            ["isExternal"] = !album.IsLocal,
         };
     }
 
     /// <summary>
     /// Converts an Artist domain model to Subsonic JSON format.
     /// </summary>
-    public object ConvertArtistToJson(Artist artist)
-    {
-        return new
+    public object ConvertArtistToJson(Artist artist) => BuildArtistFields(artist);
+
+    private static Dictionary<string, object> BuildArtistFields(Artist artist) =>
+        new()
         {
-            id = artist.Id,
-            name = artist.Name,
-            albumCount = artist.AlbumCount ?? 0,
-            coverArt = artist.Id,
-            isExternal = !artist.IsLocal
+            ["id"] = artist.Id,
+            ["name"] = artist.Name,
+            ["albumCount"] = artist.AlbumCount ?? 0,
+            ["coverArt"] = artist.Id,
+            ["isExternal"] = !artist.IsLocal,
         };
-    }
 
     /// <summary>
     /// Converts a Song domain model to Subsonic XML format.
     /// </summary>
     public XElement ConvertSongToXml(Song song, XNamespace ns)
-    {
-        return new XElement(ns + "song",
-            new XAttribute("id", song.Id),
-            new XAttribute("title", song.Title),
-            new XAttribute("album", song.Album ?? ""),
-            new XAttribute("artist", song.Artist ?? ""),
-            new XAttribute("duration", song.Duration ?? 0),
-            new XAttribute("track", song.Track ?? 0),
-            new XAttribute("year", song.Year ?? 0),
-            new XAttribute("coverArt", song.Id),
-            new XAttribute("isExternal", (!song.IsLocal).ToString().ToLower())
-        );
-    }
+        => new(ns + "song", Attributes(ConvertSongFields(song)));
 
     /// <summary>
     /// Converts an Album domain model to Subsonic XML format.
     /// </summary>
     public XElement ConvertAlbumToXml(Album album, XNamespace ns)
-    {
-        return new XElement(ns + "album",
-            new XAttribute("id", album.Id),
-            new XAttribute("name", album.Title),
-            new XAttribute("artist", album.Artist ?? ""),
-            new XAttribute("songCount", album.SongCount ?? 0),
-            new XAttribute("year", album.Year ?? 0),
-            new XAttribute("coverArt", album.Id),
-            new XAttribute("isExternal", (!album.IsLocal).ToString().ToLower())
-        );
-    }
+        => new(ns + "album", Attributes(BuildAlbumFields(album)));
 
     /// <summary>
     /// Converts an Artist domain model to Subsonic XML format.
     /// </summary>
     public XElement ConvertArtistToXml(Artist artist, XNamespace ns)
+        => new(ns + "artist", Attributes(BuildArtistFields(artist)));
+
+    /// <summary>
+    /// Renders the shared field set as XML attributes.
+    ///
+    /// The two serializers used to be written out by hand, separately, and drifted badly:
+    /// XML emitted nine attributes for a song where JSON emitted twenty-seven, so an
+    /// XML-only client received external tracks with no <c>suffix</c>, <c>contentType</c>
+    /// or <c>bitRate</c> at all — the fields a client picks its decoder from, and the ones
+    /// this file already warns must describe the bytes that will actually arrive. Deriving
+    /// one from the other is what stops that happening again.
+    /// </summary>
+    private static IEnumerable<XAttribute> Attributes(IEnumerable<KeyValuePair<string, object>> fields)
     {
-        return new XElement(ns + "artist",
-            new XAttribute("id", artist.Id),
-            new XAttribute("name", artist.Name),
-            new XAttribute("albumCount", artist.AlbumCount ?? 0),
-            new XAttribute("coverArt", artist.Id),
-            new XAttribute("isExternal", (!artist.IsLocal).ToString().ToLower())
-        );
+        foreach (var (name, value) in fields)
+        {
+            if (value is null) continue;
+
+            // Subsonic carries collections as child elements, not attributes. Every
+            // collection in the shared shape is emitted empty, so skipping them keeps the
+            // two formats equivalent rather than merely similar.
+            if (value is not string && value is System.Collections.IEnumerable) continue;
+
+            yield return new XAttribute(name, Scalar(value));
+        }
     }
+
+    /// <summary>
+    /// Invariant rendering. A comma decimal separator under a European locale would produce
+    /// numbers no Subsonic client can parse.
+    /// </summary>
+    private static string Scalar(object value) => value switch
+    {
+        bool b => b ? "true" : "false",
+        IFormattable f => f.ToString(null, System.Globalization.CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? "",
+    };
 
     /// <summary>
     /// Converts a Subsonic JSON element to a dictionary.

--- a/octo/Services/Subsonic/SubsonicResponseBuilder.cs
+++ b/octo/Services/Subsonic/SubsonicResponseBuilder.cs
@@ -141,43 +141,41 @@ public class SubsonicResponseBuilder
     /// </summary>
     public IActionResult CreateAlbumResponse(string format, Album album)
     {
-        var totalDuration = album.Songs.Sum(s => s.Duration ?? 0);
-        
+        var fields = new Dictionary<string, object>
+        {
+            ["id"] = album.Id,
+            ["name"] = album.Title,
+            ["artist"] = album.Artist ?? "",
+            ["coverArt"] = album.Id,
+            ["songCount"] = album.Songs.Count > 0 ? album.Songs.Count : (album.SongCount ?? 0),
+            ["duration"] = album.Songs.Sum(s => s.Duration ?? 0),
+            ["genre"] = album.Genre ?? "",
+            ["isCompilation"] = false,
+        };
+        if (album.ArtistId is not null) fields["artistId"] = album.ArtistId;
+        if (album.Year is int albumYear) fields["year"] = albumYear;
+
         if (format == "json")
         {
-            return CreateJsonResponse(new 
-            { 
-                status = "ok", 
-                version = SubsonicVersion,
-                album = new
-                {
-                    id = album.Id,
-                    name = album.Title,
-                    artist = album.Artist,
-                    artistId = album.ArtistId,
-                    coverArt = album.Id,
-                    songCount = album.Songs.Count > 0 ? album.Songs.Count : (album.SongCount ?? 0),
-                    duration = totalDuration,
-                    year = album.Year ?? 0,
-                    genre = album.Genre ?? "",
-                    isCompilation = false,
-                    song = album.Songs.Select(s => ConvertSongToJson(s)).ToList()
-                }
+            var body = new Dictionary<string, object>(fields)
+            {
+                ["song"] = album.Songs.Select(ConvertSongToJson).ToList(),
+            };
+            return CreateJsonResponse(new Dictionary<string, object>
+            {
+                ["status"] = "ok",
+                ["version"] = SubsonicVersion,
+                ["album"] = body,
             });
         }
-        
+
         var ns = XNamespace.Get(SubsonicNamespace);
         var doc = new XDocument(
             new XElement(ns + "subsonic-response",
                 new XAttribute("status", "ok"),
                 new XAttribute("version", SubsonicVersion),
                 new XElement(ns + "album",
-                    new XAttribute("id", album.Id),
-                    new XAttribute("name", album.Title),
-                    new XAttribute("artist", album.Artist ?? ""),
-                    new XAttribute("songCount", album.Songs.Count > 0 ? album.Songs.Count : (album.SongCount ?? 0)),
-                    new XAttribute("year", album.Year ?? 0),
-                    new XAttribute("coverArt", album.Id),
+                    Attributes(fields),
                     album.Songs.Select(s => ConvertSongToXml(s, ns))
                 )
             )
@@ -385,13 +383,20 @@ public class SubsonicResponseBuilder
         var albumArtistList = artistList;
 
         // Plausible defaults so external entries don't read as "obviously fake"
-        // to client metadata heuristics. bitDepth/samplingRate/track/year of 0
-        // were the giveaways the old version emitted.
-        var year = song.Year ?? DateTime.UtcNow.Year;
+        // to client metadata heuristics. bitDepth/samplingRate/track of 0 were the
+        // giveaways the old version emitted.
+        //
+        // Year is the exception and is omitted entirely when unknown, rather than
+        // defaulted. It used to fall back to the current year, which is not a plausible
+        // default but a wrong one: a 1995 track was published to the client as this year's
+        // release, and unlike a missing field that is something the user can see and
+        // sort by. Every real library is full of untagged files, so a client that rejected
+        // entries without a year would already be broken against the server it is pointed
+        // at.
         var track = song.Track ?? 1;
         var bitDepth = song.IsLocal ? 16 : 16;
 
-        return new Dictionary<string, object>
+        var fields = new Dictionary<string, object>
         {
             ["id"] = song.Id,
             ["parent"] = albumId,
@@ -400,7 +405,6 @@ public class SubsonicResponseBuilder
             ["album"] = albumName,
             ["artist"] = song.Artist ?? "",
             ["track"] = track,
-            ["year"] = year,
             ["genre"] = song.Genre ?? "",
             ["coverArt"] = song.Id,
             ["size"] = estSize,
@@ -431,6 +435,10 @@ public class SubsonicResponseBuilder
             ["sortName"] = (song.Title ?? "").ToLowerInvariant(),
             ["isExternal"] = false
         };
+
+        if (song.Year is int knownYear) fields["year"] = knownYear;
+
+        return fields;
     }
 
     /// <summary>
@@ -451,7 +459,7 @@ public class SubsonicResponseBuilder
             Artist = album.Artist,
         });
 
-        return new Dictionary<string, object>
+        var fields = new Dictionary<string, object>
         {
             ["id"] = album.Id,
             ["parent"] = artistId,
@@ -462,7 +470,6 @@ public class SubsonicResponseBuilder
             ["artist"] = album.Artist ?? "",
             ["artistId"] = artistId,
             ["songCount"] = album.SongCount ?? 0,
-            ["year"] = album.Year ?? 0,
             ["genre"] = album.Genre ?? "",
             ["coverArt"] = album.Id,
             ["created"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
@@ -471,6 +478,14 @@ public class SubsonicResponseBuilder
             ["sortName"] = (album.Title ?? "").ToLowerInvariant(),
             ["isExternal"] = !album.IsLocal,
         };
+
+        // Deezer's album search payload carries no release date; only the per-album detail
+        // call does, and fetching that for every search row would be twenty extra requests
+        // against a budget this project has already been burned by. So the year is genuinely
+        // unknown here and is left out rather than reported as zero.
+        if (album.Year is int knownYear) fields["year"] = knownYear;
+
+        return fields;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #14.

`austempest` reported that search only ever returned albums, never songs. His diagnosis was right, and the root cause is narrower than it first looks.

## The reported bug

The local floor was a constant that could exceed the whole budget:

```csharp
var localSongTarget = Math.Max(20, requestedSongs / 4);
var externalTarget  = Math.Min(150, Math.Max(0, requestedSongs - localSongTarget));
```

At `songCount=20` the floor takes all 20 and the subtraction leaves nothing. Since 20 is both the Subsonic spec default for `search3` and this server's own fallback when the parameter is absent, the most common search in the wild was the broken one. Capping the floor at the requested count fixes it: `songCount=20` now splits 12 local / 8 external.

Two properties are pinned by tests rather than argued in review, with the old formula kept in the test file so CI checks them every run:

- nothing changes at all for `songCount >= 80`
- the external count never decreases on account of the split at any count

Type-ahead needs no special case. At `songCount <= 12` the floor takes the budget and discovery is zero, exactly as before, so a per-keystroke search still costs one relay.

## Why the rest is in the same PR

Fixing the floor **creates** a concurrency bug. Clients fire several search calls for one typed query; until now the two small ones exited before touching Last.fm, so nothing was duplicated. Once they all run, they resolve to the same routing objects (ids are deterministic) and each writes the same nullable int duration — three writers on the field the enrichment code already carries a warning comment about, plus three times a fixed Deezer fan-out against the budget that caused #8.

So the build now runs once per query behind a single-flight, with nothing retained afterwards. No results cache: that would need a staleness policy, a rule for not caching failures, and clear-cache wiring, which is the state #8 was about. Repeat searches are already covered by Deezer's positive TTL and the stored video id.

The remaining commits fix defects found while tracing that path, several of which the change would otherwise have made worse:

- **`search2` was broken end to end.** The handler serves and relays it, so the upstream answers under `searchResult2`, but the parser read only `searchResult3` (dropping every local row) and the merge emitted `searchResult3` regardless (so a client looking for `searchResult2` found nothing). The two cancelled into silence.
- **`songOffset` was never read**, so page two re-appended the same suggestions the user had just scrolled past.
- **A Subsonic error arrives as HTTP 200** with `status="failed"` in the body, so a rejected login and an empty library were indistinguishable. Harmless before; with the page now filling from discovery when the library is thin, a wrong password returned a full page of suggestions and looked healthy.
- **The Last.fm cache was a plain `Dictionary`** written from concurrent request threads, where an insert racing a resize corrupts it rather than merely losing an entry.
- **`IsConfigured` meant "has a key *and* radio is on"** while search discovery gated on it, so turning radio off silently emptied the search bar too.
- **External album search fired on every keystroke**, spending a Deezer query per character.

## Verification

177 tests green. Everything below was measured against a real Navidrome 0.63.2 with a yt-dlp shim, on a library sized so one query matches fully (30 tracks) and another matches thinly (2 tracks):

| songCount | full library | thin library |
|---|---|---|
| 5 | 5 local / 0 external | 2 / 0 |
| 12 | 12 / 0 | 2 / 0 |
| **20** | **12 / 8** | **2 / 18** |
| 40 | 12 / 28 | 2 / 38 |
| 80 | 20 / 60 | 2 / 60 |

The total never exceeds the requested count, which is what lets discovery survive a client that renders only what it asked for. `search2` and `search3` now return identical results. Three concurrent calls for one query produce a single fan-out where sequential calls produce one each, so nothing is retained. Fourteen type-ahead keystrokes produce no fan-out and no rate-limiter rejections. Page two repeats zero discovery rows. A wrong password returns error 40 rather than a page of suggestions. An external track still plays end to end, 206 with a correct content range.
