### PR TITLE
Point the size tiebreak the right way, and pin the new ranking rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,8 @@ SLSKD_PASSWORD=slskd
 SLSKD_SEARCH_WAIT_SECONDS=6
 SLSKD_MIN_FILE_SIZE_BYTES=5242880
 SLSKD_PREFERRED_EXTENSION=flac
+# Per PEER attempt, not per track. Octo walks up to five candidates and can spend
+# this on each, so a track nobody can serve takes five times this to give up.
 SLSKD_DOWNLOAD_TIMEOUT_SECONDS=180
 
 # Your Soulseek (Soulseek-network) account. Required for slskd to actually

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ octo/downloads/
 # Local runtime state
 octo-config/
 slskd-state/
+# The compose default for DOWNLOAD_PATH, so a default install creates it here.
+/downloads/

--- a/octo.Tests/SoulseekCandidateMatchingTests.cs
+++ b/octo.Tests/SoulseekCandidateMatchingTests.cs
@@ -177,4 +177,140 @@ public class SoulseekCandidateMatchingTests
         Assert.Equal(0, SoulseekDownloadService.VariantPenalty(
             "Oliver Nelson - Stolen Moments.flac", "Stolen Moments"));
     }
+
+    // ---- roman numerals -------------------------------------------------------
+
+    /// <summary>
+    /// The >=3 char token rule deleted the only thing separating these two titles, so
+    /// either file satisfied a request for the other and a two-part suite arrived as two
+    /// copies of the same part.
+    /// </summary>
+    [Fact]
+    public void RomanNumeralPartsAreNotInterchangeable()
+    {
+        Assert.False(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "02 - Trilogy II.flac", "Trilogy I"));
+        Assert.False(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "01 - Trilogy I.flac", "Trilogy II"));
+        Assert.True(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "01 - Trilogy I.flac", "Trilogy I"));
+    }
+
+    /// <summary>
+    /// Word boundaries in both directions: "I" must not find itself inside "II", and "V"
+    /// must not find itself inside "IV".
+    /// </summary>
+    [Fact]
+    public void RomanNumeralsMatchWholeWordsOnly()
+    {
+        Assert.False(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "Trilogy IV.flac", "Trilogy V"));
+        Assert.True(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "Trilogy IV.flac", "Trilogy IV"));
+    }
+
+    /// <summary>
+    /// The guard is anchored to the end of the title, so ordinary titles carrying a
+    /// stray "I" or a trailing letter are untouched by it.
+    /// </summary>
+    [Fact]
+    public void OrdinaryTitlesAreUnaffectedByTheRomanGuard()
+    {
+        Assert.True(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "Kendrick Lamar - DNA..flac", "DNA."));
+        Assert.True(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "anything at all.flac", "M.I.A."));
+        Assert.True(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            @"music\Massive Attack\Mezzanine (1998)\09 - Mezzanine.flac", "Mezzanine"));
+        Assert.True(SoulseekDownloadService.FilenamePlausiblyMatchesTitle(
+            "10 - Group Four.flac", "Group Four"));
+    }
+
+    // ---- quality ranking ------------------------------------------------------
+
+    private static SoulseekFileHit Hit(int? bitDepth, int? sampleRate) =>
+        new() { BitDepth = bitDepth, SampleRate = sampleRate };
+
+    /// <summary>
+    /// A 24/96 transfer of a CD-era master carries no more music than the 16/44.1 one,
+    /// at several times the bytes and the transfer time. Ranked down, never rejected.
+    /// </summary>
+    [Fact]
+    public void CdQualityOutranksHiRes()
+    {
+        var cd = SoulseekDownloadService.QualityPenalty(Hit(16, 44100));
+        var cd48 = SoulseekDownloadService.QualityPenalty(Hit(16, 48000));
+        var hiRes = SoulseekDownloadService.QualityPenalty(Hit(24, 96000));
+
+        Assert.True(cd < cd48, "16/44.1 is the target, 16/48 is the runner-up");
+        Assert.True(cd48 < hiRes, "hi-res sorts last");
+    }
+
+    /// <summary>
+    /// Most peers report neither field. Treating unknown as hi-res would bury the
+    /// majority of a normal search; treating it as CD would let an unlabelled 24/96
+    /// outrank a labelled 16/44.1. It sits between the two on purpose.
+    /// </summary>
+    [Fact]
+    public void UnknownQualitySitsBetweenCdAndHiRes()
+    {
+        var unknown = SoulseekDownloadService.QualityPenalty(Hit(null, null));
+
+        Assert.True(SoulseekDownloadService.QualityPenalty(Hit(16, 48000)) < unknown);
+        Assert.True(unknown < SoulseekDownloadService.QualityPenalty(Hit(24, 96000)));
+    }
+
+    /// <summary>
+    /// Size is the last signal left and it ties often, because slskd reports queue length
+    /// and upload speed per response rather than per file. Pointing it the wrong way for
+    /// a lossy library walks every track down to the worst copy on the shelf.
+    /// </summary>
+    [Fact]
+    public void SizeTiebreakPointsTowardsCdRipsButAwayFromLowBitrates()
+    {
+        Assert.True(
+            SoulseekDownloadService.SizeSortKey(30_000_000, "flac")
+            > SoulseekDownloadService.SizeSortKey(25_000_000, "flac"),
+            "chasing lossless, the smaller of two equals is the CD rip");
+
+        Assert.True(
+            SoulseekDownloadService.SizeSortKey(10_000_000, "mp3")
+            < SoulseekDownloadService.SizeSortKey(4_000_000, "mp3"),
+            "chasing lossy, the bigger file is simply the higher bitrate");
+    }
+
+    /// <summary>A configured extension is normalized the same way a hit's is.</summary>
+    [Fact]
+    public void SizeTiebreakReadsAConfiguredExtensionInAnyShape()
+    {
+        var smallerFirst = SoulseekDownloadService.SizeSortKey(9, "flac");
+        Assert.Equal(smallerFirst, SoulseekDownloadService.SizeSortKey(9, ".flac"));
+        Assert.Equal(smallerFirst, SoulseekDownloadService.SizeSortKey(9, "FLAC"));
+    }
+
+    // ---- extension normalization ----------------------------------------------
+
+    /// <summary>
+    /// Ranking accepts a hit by comparing its extension against the configured one, and
+    /// slskd does not report a consistent shape. An unnormalized ".flac" matched no
+    /// configured "flac", which surfaced as "this track is not on Soulseek" rather than
+    /// as a parsing mismatch, and took every FLAC on the network with it.
+    /// </summary>
+    [Fact]
+    public void EveryShapeSlskdReportsReducesToTheSameExtension()
+    {
+        Assert.Equal("flac", SoulseekClient.NormalizeExtension(".flac", "x.flac"));
+        Assert.Equal("flac", SoulseekClient.NormalizeExtension("flac", "x.flac"));
+        Assert.Equal("flac", SoulseekClient.NormalizeExtension("FLAC", "x.flac"));
+        Assert.Equal("flac", SoulseekClient.NormalizeExtension("  .FLAC ", "x.flac"));
+    }
+
+    /// <summary>Field absent or blank: fall back to the filename it came with.</summary>
+    [Fact]
+    public void AMissingExtensionFallsBackToTheFilename()
+    {
+        Assert.Equal("flac", SoulseekClient.NormalizeExtension(null, @"share\Artist\01 - Track.flac"));
+        Assert.Equal("flac", SoulseekClient.NormalizeExtension("", @"share\Artist\01 - Track.flac"));
+        Assert.Equal("", SoulseekClient.NormalizeExtension(null, "no extension at all"));
+    }
 }

--- a/octo/Models/Settings/SoulseekSettings.cs
+++ b/octo/Models/Settings/SoulseekSettings.cs
@@ -40,7 +40,10 @@ public class SoulseekSettings
     public string PreferredExtension { get; set; } = "flac";
 
     /// <summary>
-    /// Max time to wait (seconds) for a download to complete before giving up.
+    /// Max time to wait (seconds) for a download to complete before giving up on that
+    /// peer and trying the next one. Per attempt, not per track: a track that has to
+    /// walk all five candidates can spend this five times over. A peer that rejects
+    /// outright is detected in seconds and does not wait this out.
     /// </summary>
     public int DownloadTimeoutSeconds { get; set; } = 180;
 }

--- a/octo/Services/Soulseek/SoulseekClient.cs
+++ b/octo/Services/Soulseek/SoulseekClient.cs
@@ -274,18 +274,7 @@ public class SoulseekClient
                     int? length = file.TryGetProperty("length", out var lenEl) && lenEl.ValueKind == JsonValueKind.Number
                         ? lenEl.GetInt32()
                         : null;
-                    var ext = file.TryGetProperty("extension", out var exEl)
-                        ? exEl.GetString()
-                        : null;
-
-                    var normalizedExt = string.IsNullOrWhiteSpace(ext)
-                        ? Path.GetExtension(filename)
-                        : ext;
-
-                        normalizedExt = normalizedExt
-                        .Trim()
-                        .TrimStart('.')
-                        .ToLowerInvariant();
+                    var ext = file.TryGetProperty("extension", out var exEl) ? exEl.GetString() : null;
 
                     hits.Add(new SoulseekFileHit
                     {
@@ -296,7 +285,7 @@ public class SoulseekClient
                         SampleRate = sampleRate,
                         BitDepth = bitDepth,
                         Length = length,
-                        Extension = normalizedExt,
+                        Extension = NormalizeExtension(ext, filename),
                         UploadSpeed = uploadSpeed,
                         QueueLength = queueLength
                     });
@@ -308,6 +297,23 @@ public class SoulseekClient
             _logger.LogWarning("Failed to parse Soulseek responses: {Msg}", ex.Message);
         }
         return hits;
+    }
+
+    /// <summary>
+    /// Reduce a file extension to the bare lowercase form ("flac").
+    ///
+    /// Candidate ranking accepts a hit by comparing this against the configured
+    /// PreferredExtension, so the two have to agree on shape. slskd does not
+    /// guarantee one: some builds report "flac", some report ".flac", and some
+    /// omit the field entirely and leave only the filename to go on. An
+    /// unnormalized leading dot compared against a bare "flac" matches nothing,
+    /// which reads downstream as "this track is not on Soulseek" rather than as
+    /// a parsing mismatch. Both sides of the comparison run through here.
+    /// </summary>
+    internal static string NormalizeExtension(string? extension, string filename)
+    {
+        var raw = string.IsNullOrWhiteSpace(extension) ? Path.GetExtension(filename) : extension;
+        return (raw ?? "").Trim().TrimStart('.').ToLowerInvariant();
     }
 
     /// <summary>

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -144,6 +144,9 @@ public class SoulseekDownloadService : BaseDownloadService
     // Search Soulseek, walk the top-N peers in quality order, first successful
     // transfer wins. ~30-50% of Soulseek peer requests are rejected (queue
     // full / overwhelmed / banned), so trying just the top hit fails too often.
+    //
+    // Each attempt is bounded by Soulseek:DownloadTimeoutSeconds, so that setting is
+    // per peer and a full walk can spend it MaxPeerAttempts times over.
     // =========================================================================
     private const int MaxPeerAttempts = 5;
 
@@ -541,27 +544,65 @@ public class SoulseekDownloadService : BaseDownloadService
         "version", "demo", "session", "karaoke", "cover", "reprise",
     };
 
-    private List<SoulseekFileHit> RankCandidates(
-        List<SoulseekFileHit> hits,
-        string title,
-        int? expectedDuration)
-    => hits
-    .Where(h => string.Equals(
-        h.Extension,
-        _settings.PreferredExtension,
-        StringComparison.OrdinalIgnoreCase))
-    .Where(h => h.Size >= _settings.MinFileSizeBytes)
-    .Where(h => FilenamePlausiblyMatchesTitle(h.Filename, title))
-    .Where(h => DurationPlausible(h.Length, expectedDuration))
-    .OrderBy(h => VariantPenalty(h.Filename, title))
-    .ThenBy(h => QualityPenalty(h))
-    .ThenBy(h => h.QueueLength ?? int.MaxValue)
-    .ThenByDescending(h => h.UploadSpeed ?? 0)
-    .ThenBy(h => h.Size)
-    .Take(MaxPeerAttempts)
-    .ToList();
+    private List<SoulseekFileHit> RankCandidates(List<SoulseekFileHit> hits, string title, int? expectedDuration)
+    {
+        var wanted = SoulseekClient.NormalizeExtension(_settings.PreferredExtension, "");
+        return hits
+            .Where(h => string.Equals(h.Extension, wanted, StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.Size >= _settings.MinFileSizeBytes)
+            .Where(h => FilenamePlausiblyMatchesTitle(h.Filename, title))
+            .Where(h => DurationPlausible(h.Length, expectedDuration))
+            // Variant mixes sort last rather than being dropped: sometimes a remix really
+            // is what was asked for, and sometimes it is all a peer has.
+            .OrderBy(h => VariantPenalty(h.Filename, title))
+            .ThenBy(h => QualityPenalty(h))
+            .ThenBy(h => h.QueueLength ?? int.MaxValue)
+            .ThenByDescending(h => h.UploadSpeed ?? 0)
+            .ThenBy(h => SizeSortKey(h.Size, wanted))
+            .Take(MaxPeerAttempts)
+            .ToList();
+    }
 
-    private static int QualityPenalty(SoulseekFileHit h)
+    /// <summary>
+    /// Extensions where a bigger file means a longer or higher-resolution recording
+    /// rather than a better one. Used to decide which way the size tiebreak points.
+    /// </summary>
+    private static readonly string[] LosslessExtensions =
+    {
+        "flac", "wav", "alac", "ape", "aiff", "aif", "wv",
+    };
+
+    /// <summary>
+    /// The last signal left when everything above it ties, and it ties often: slskd
+    /// reports queue length and upload speed per RESPONSE, not per file, so every file
+    /// one peer offers carries identical values and size is what actually separates them.
+    ///
+    /// Which direction helps depends on what is being chased. Chasing lossless, the
+    /// smaller of two otherwise-equal candidates is the CD rip rather than the hi-res
+    /// transfer, which is the same preference QualityPenalty encodes and the only way to
+    /// express it when a peer reports no bit depth at all. Chasing a lossy format, the
+    /// bigger file is simply the higher bitrate, and preferring the smaller one would
+    /// walk an mp3 library down to its worst copy of every track.
+    /// </summary>
+    internal static long SizeSortKey(long size, string? preferredExtension)
+        => LosslessExtensions.Contains(SoulseekClient.NormalizeExtension(preferredExtension, ""))
+            ? size
+            : -size;
+
+    /// <summary>
+    /// How far a candidate sits from ordinary CD quality, 16-bit/44.1kHz.
+    ///
+    /// CD is the target because it is what the master almost always was: a 24/96 transfer
+    /// of a 1998 pop record carries no more music than the 16/44.1 one, at several times
+    /// the bytes on a disk the user is paying for and a transfer that takes proportionally
+    /// longer over Soulseek. Hi-res is ranked down rather than rejected, because sometimes
+    /// it is the only copy a peer has.
+    ///
+    /// Unknown sits deliberately between the two. Most peers report neither field, so
+    /// treating unknown as hi-res would bury the majority of a normal search, and treating
+    /// it as CD would let an unlabelled 24/96 outrank a labelled 16/44.1.
+    /// </summary>
+    internal static int QualityPenalty(SoulseekFileHit h)
     {
         var bitDepthPenalty = h.BitDepth switch
         {
@@ -590,18 +631,29 @@ public class SoulseekDownloadService : BaseDownloadService
     }
 
     private static string LeafOf(string path) =>
-    path.Replace('\\', '/')
-    .Split('/', StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } s
-    ? s[^1]
-    : path;
+        path.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } s
+            ? s[^1] : path;
 
     private static List<string> TitleTokens(string title) =>
-    title.ToLowerInvariant()
-    .Split(
-        new[] { ' ', '-', '(', ')', '[', ']', '_', '.', ',', '\'', '"' },
-           StringSplitOptions.RemoveEmptyEntries)
-    .Where(t => t.Length >= 3)
-    .ToList();
+        title.ToLowerInvariant()
+            .Split(new[] { ' ', '-', '(', ')', '[', ']', '_', '.', ',', '\'', '"' },
+                   StringSplitOptions.RemoveEmptyEntries)
+            .Where(t => t.Length >= 3)
+            .ToList();
+
+    /// <summary>
+    /// A roman numeral on the end of a title, which TitleTokens cannot see.
+    ///
+    /// Tokens shorter than 3 characters are dropped so that "DNA." and "M.I.A." are not
+    /// over-filtered, and that quietly deletes the entire difference between "Trilogy I"
+    /// and "Trilogy II": both reduce to the single token "trilogy", so either file
+    /// satisfies a request for the other. Anchored to the end so an "I" inside a sentence
+    /// is left alone, and matched on word boundaries in the filename so "I" does not find
+    /// itself inside "II" and "V" does not find itself inside "IV".
+    /// </summary>
+    private static readonly Regex TrailingRomanNumeral = new(
+        @"\b(I|II|III|IV|V|VI|VII|VIII|IX|X)\b\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
     /// Does the FILENAME look like the track we asked for?
@@ -611,29 +663,21 @@ public class SoulseekDownloadService : BaseDownloadService
     /// the track "Mezzanine" while the file inside was a different song entirely. And it
     /// accepted any single token, so "Group Four" would have been satisfied by "Four
     /// Seasons". Now every significant token must appear in the leaf name. Tokens are
-    /// >=3 chars so short titles like "DNA." or "M.I.A." are not over-filtered.
+    /// >=3 chars so short titles like "DNA." or "M.I.A." are not over-filtered, with a
+    /// trailing roman numeral handled separately since that rule would erase it.
     /// </summary>
     internal static bool FilenamePlausiblyMatchesTitle(string filename, string title)
     {
         if (string.IsNullOrEmpty(filename) || string.IsNullOrEmpty(title)) return true;
         var leaf = LeafOf(filename).ToLowerInvariant();
-        var wantedRoman = Regex.Match(
-            title.Trim(),
-                                      @"\b(I|II|III|IV|V|VI|VII|VIII|IX|X)\b\s*$",
-                                      RegexOptions.IgnoreCase);
 
-        if (wantedRoman.Success)
+        var wantedRoman = TrailingRomanNumeral.Match(title.Trim());
+        if (wantedRoman.Success
+            && !Regex.IsMatch(leaf, $@"\b{Regex.Escape(wantedRoman.Groups[1].Value)}\b", RegexOptions.IgnoreCase))
         {
-            var roman = wantedRoman.Groups[1].Value;
-
-            if (!Regex.IsMatch(
-                leaf,
-                $@"\b{Regex.Escape(roman)}\b",
-                               RegexOptions.IgnoreCase))
-            {
-                return false;
-            }
+            return false;
         }
+
         var tokens = TitleTokens(title);
         if (tokens.Count == 0) return true;
         return tokens.All(t => leaf.Contains(t));

--- a/octo/octo.csproj
+++ b/octo/octo.csproj
@@ -8,8 +8,8 @@
         <!-- Dated releases. Version must be numeric for the assembly, so 07 loses its
              leading zero there; InformationalVersion carries the tag name verbatim and
              is what the dashboard shows. Bump both when tagging a release. -->
-        <Version>2026.8.12</Version>
-        <InformationalVersion>2026.08.12</InformationalVersion>
+        <Version>2026.8.13</Version>
+        <InformationalVersion>2026.08.13</InformationalVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Follow-up to #16, which landed a good set of Soulseek matching fixes without the comments or tests the ranking code carries everywhere else.

## The size tiebreak was pointing one way only

#16 made file size the last signal in candidate ranking and sorted it ascending, on the reasoning that when a peer reports no bit depth the smaller of two equals is the CD rip rather than the hi-res transfer. That reasoning is right, and it matters more than it looks: slskd reports queue length and upload speed per RESPONSE, not per file, so every file one peer offers ties on both and size is what actually separates them.

It is only right for lossless. An install running `SLSKD_PREFERRED_EXTENSION=mp3` reports no bit depth on anything and a 44.1kHz sample rate on everything, so every candidate ties on quality and the ascending size sort picks the lowest bitrate on the shelf, every time. `SizeSortKey` picks the direction from what is being chased.

## Extension normalization now covers both sides

The fix in #16 normalizes the extension slskd reports. The configured `PreferredExtension` it gets compared against was left raw, so `SLSKD_PREFERRED_EXTENSION=.flac` hit exactly the same wall from the other side and matched nothing. Both now run through `SoulseekClient.NormalizeExtension`.

## Prose and tests

The roman numeral guard, the quality penalty and the size direction are all judgement calls about which recording ends up in someone's library, which is the kind of decision the rest of this file explains at length. Each now says why it exists and is pinned by a test named for the failure it prevents, bringing `SoulseekCandidateMatchingTests` to 23 cases. The roman regex is built once rather than once per candidate.

`Soulseek:DownloadTimeoutSeconds` did nothing until #16 wired it up, so nothing documented it. It is per peer attempt and a walk can spend it five times over; that is now said in the settings doc and in `.env.example`.

Also bumps the version for the `2026.08.13` release.
