### PR TITLE
Actually serialise image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,12 +10,21 @@ on:
   # No pull_request trigger. A merge already arrives here as a push to main, so
   # building on `closed` too meant every merge built the same commit twice.
 
-# Serialise image builds. Concurrent runs export to the same GitHub Actions cache
-# and collide with "failed to reserve cache". Queue rather than cancel: a half
-# published image is worse than a slow one, and tagging a release legitimately
-# overlaps with the merge that preceded it.
+# Serialise image builds across the whole repo. Concurrent runs export to the same
+# GitHub Actions cache and collide with "failed to reserve cache".
+#
+# The group is a fixed name because keying it on github.ref never serialised anything
+# that mattered: a push to main and a release tag are different refs, so they landed in
+# different groups and ran side by side, and that is precisely the pair that overlaps
+# when cutting a release. Three releases got away with it before this was noticed.
+#
+# Queue rather than cancel, because a half published image is worse than a slow one.
+# queue:max is what keeps that promise once a third run shows up: the default is to
+# cancel whatever is already pending when a newer run arrives, so tagging a release
+# would have silently dropped the queued build for the very commit being tagged.
 concurrency:
-  group: docker-${{ github.ref }}
+  group: docker
+  queue: max
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
Follow-up to the `2026.08.13` release, where this turned up while checking why a release fires two Docker builds.

## The group could not see the case it was written for

`concurrency.group` was `docker-${{ github.ref }}`. A push to `main` and a release tag are different refs, so they went into different groups and ran side by side against the same GitHub Actions cache. That pairing is exactly what happens when cutting a release, so the one overlap the group existed to prevent was the one it structurally could not catch.

Checked `2026.08.06`, `2026.08.11`, `2026.08.12` and `2026.08.13`: all four ran the `main` build and the tag build concurrently, and all four succeeded. `failed to reserve cache` was a timing coincidence away rather than avoided. A fixed group name serialises every image build in the repo, which is what the comment already said it did.

## Keeping the queue once the group is fixed

With the group fixed, a release now genuinely queues three runs: the merge to `main`, the release commit, and the tag. GitHub's default is that a newly queued run cancels any run already `pending` in the group, so the tag would silently drop the queued build for the commit it was tagging.

`queue: max` allows up to 100 pending runs instead of one, so the queue keeps what is in it. This workflow already states it would rather have a slow image than a half published one, and that only holds if pending runs survive. `queue: max` cannot be combined with `cancel-in-progress: true`; this workflow sets it to `false`, so there is no conflict.

Refs: [workflow syntax for `concurrency.queue`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrencyqueue).
