### PR TITLE
Stream diagnostics, interactive-priority gate, Soulseek search fixes, library tools, and push notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,3 +111,19 @@ LASTFM_API_KEY=
 LASTFM_ENABLE_RADIO=true
 LASTFM_RADIO_TRACK_COUNT=50
 LASTFM_RADIO_CACHE_HOURS=24
+
+# ===== NOTIFICATIONS (ntfy / Discord webhook) — both optional =====
+# Push a message when Octo fetches (or fails to fetch) music. A transport is
+# enabled simply by its URL being set; both empty = notifications off.
+# ntfy: pick any unique topic name, subscribe to it in the ntfy app, and put the
+# same URL here (e.g. https://ntfy.sh/octo-yourname). Token only for protected
+# servers. Discord: Server Settings -> Integrations -> Webhooks.
+NTFY_URL=
+NTFY_TOKEN=
+DISCORD_WEBHOOK_URL=
+# Per-event toggles, also editable live in the admin dashboard.
+NOTIFY_DOWNLOAD_STARTED=false
+NOTIFY_DOWNLOAD_COMPLETED=true
+NOTIFY_LOSSLESS_FALLBACK=true
+NOTIFY_DOWNLOAD_FAILED=true
+NOTIFY_ALBUM_COMPLETED=true

--- a/.env.example
+++ b/.env.example
@@ -79,7 +79,9 @@ DOWNLOAD_PATH=./downloads
 # below for those.
 SLSKD_USERNAME=slskd
 SLSKD_PASSWORD=slskd
-SLSKD_SEARCH_WAIT_SECONDS=6
+# Soulseek results only become readable from slskd around the 20s mark; at 6s
+# every star silently fell back to a YouTube MP3 while lossless copies sat unseen.
+SLSKD_SEARCH_WAIT_SECONDS=30
 SLSKD_MIN_FILE_SIZE_BYTES=5242880
 SLSKD_PREFERRED_EXTENSION=flac
 # Per PEER attempt, not per track. Octo walks up to five candidates and can spend

--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,12 @@ SLSKD_SOULSEEK_PASSWORD=
 
 # ===== YT-DLP SHIM (preview-stream sidecar) — usually leave defaults =====
 YTDLP_MAX_CONCURRENT=5
+# How many of those slots stay out of reach of background work, so a play never
+# waits behind prewarm. Must be less than YTDLP_MAX_CONCURRENT; it is clamped if
+# not. Raising it makes plays snappier under load and discovery warm more slowly.
+YTDLP_GATE_RESERVE=2
+# How long background work waits for a slot before giving up (seconds).
+YTDLP_BG_GATE_WAIT_SEC=10
 YTDLP_SEARCH_CACHE_MAX=1024
 YTDLP_URL_CACHE_MAX=512
 YTDLP_URL_CACHE_TTL=3600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,29 @@ jobs:
 
       - name: Test
         run: dotnet test --configuration Release --no-build --verbosity normal
+
+  # The shim is Python and its image is only ever built on the deploy host, so
+  # before this job a syntax error in app.py passed CI and was discovered when
+  # the container failed to restart in production. compileall alone justifies
+  # the two minutes; the gate tests cover the concurrency logic that decides
+  # whether a play queues behind background prewarm.
+  shim:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Syntax check
+        run: python -m compileall -q yt-dlp-shim
+
+      - name: Install test dependencies
+        run: pip install -r yt-dlp-shim/requirements-dev.txt
+
+      - name: Gate tests
+        run: pytest yt-dlp-shim/tests -q

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ octo-config/
 slskd-state/
 # The compose default for DOWNLOAD_PATH, so a default install creates it here.
 /downloads/
+
+# Python bytecode + pytest state from the shim's tests
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ Prebuilt multi-arch images are also published to `ghcr.io/winters27/octo`, tagge
 
 Every setting has a form, every backing service has a live status indicator, and the **Raw Config** tab lets you edit the whole effective configuration as a JSON file if you'd rather work that way. Changes hot-reload — no rebuild, no restart for most settings.
 
+## Notifications
+
+Optional push notifications for the download lifecycle, because Subsonic has no way to
+tell you a starred track landed — or quietly settled for a lossy copy.
+
+- **Two transports, either works alone**: [ntfy](https://ntfy.sh/) (paste a topic URL,
+  subscribe to the same topic in the ntfy app) and Discord webhooks (rich embed with
+  album art). A transport is on when its URL is set.
+- **Five events, each with its own toggle** in the dashboard's Notifications tab:
+  download started (did it find lossless, or is it settling?), download completed,
+  lossless fallback, download failed, and one summary per album instead of a ping per
+  track.
+- A **Send test** button verifies your URLs and tokens without waiting for a real
+  download, and reports each transport's outcome separately.
+
 ---
 
 ## Frequently asked questions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,16 @@ services:
       LastFm__EnableRadio: ${LASTFM_ENABLE_RADIO:-true}
       LastFm__RadioTrackCount: ${LASTFM_RADIO_TRACK_COUNT:-50}
       LastFm__RadioCacheDurationHours: ${LASTFM_RADIO_CACHE_HOURS:-24}
+
+      # ----- Notifications (ntfy / Discord webhook) — both optional -----
+      Notifications__NtfyUrl: ${NTFY_URL:-}
+      Notifications__NtfyToken: ${NTFY_TOKEN:-}
+      Notifications__DiscordWebhookUrl: ${DISCORD_WEBHOOK_URL:-}
+      Notifications__NotifyDownloadStarted: ${NOTIFY_DOWNLOAD_STARTED:-false}
+      Notifications__NotifyDownloadCompleted: ${NOTIFY_DOWNLOAD_COMPLETED:-true}
+      Notifications__NotifyLosslessFallback: ${NOTIFY_LOSSLESS_FALLBACK:-true}
+      Notifications__NotifyDownloadFailed: ${NOTIFY_DOWNLOAD_FAILED:-true}
+      Notifications__NotifyAlbumCompleted: ${NOTIFY_ALBUM_COMPLETED:-true}
     volumes:
       - ${DOWNLOAD_PATH:-./downloads}:/music
       # Editable settings file — admin UI writes here, ASP.NET hot-reloads on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       Soulseek__BaseUrl: http://slskd:5030
       Soulseek__Username: ${SLSKD_USERNAME:-slskd}
       Soulseek__Password: ${SLSKD_PASSWORD:-slskd}
-      Soulseek__SearchWaitSeconds: ${SLSKD_SEARCH_WAIT_SECONDS:-6}
+      Soulseek__SearchWaitSeconds: ${SLSKD_SEARCH_WAIT_SECONDS:-30}
       Soulseek__MinFileSizeBytes: ${SLSKD_MIN_FILE_SIZE_BYTES:-5242880}
       Soulseek__PreferredExtension: ${SLSKD_PREFERRED_EXTENSION:-flac}
       Soulseek__DownloadTimeoutSeconds: ${SLSKD_DOWNLOAD_TIMEOUT_SECONDS:-180}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,12 @@ services:
     restart: unless-stopped
     environment:
       MAX_CONCURRENT_YTDLP: ${YTDLP_MAX_CONCURRENT:-5}
+      # Slots of the above that background work (prewarm, star-downloads) can
+      # never occupy, so pressing play does not queue behind a prewarm burst.
+      GATE_RESERVE_INTERACTIVE: ${YTDLP_GATE_RESERVE:-2}
+      # Background gives up on a full gate quickly: it is fire-and-forget and
+      # already stale by the time a long queue clears.
+      BG_GATE_WAIT_SEC: ${YTDLP_BG_GATE_WAIT_SEC:-10}
       SEARCH_CACHE_MAX: ${YTDLP_SEARCH_CACHE_MAX:-1024}
       URL_CACHE_MAX: ${YTDLP_URL_CACHE_MAX:-512}
       URL_CACHE_TTL: ${YTDLP_URL_CACHE_TTL:-3600}

--- a/octo.Tests/BrowseSessionStoreTests.cs
+++ b/octo.Tests/BrowseSessionStoreTests.cs
@@ -1,0 +1,45 @@
+using Octo.Services.Admin;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// This token is the only thing standing between the browse endpoint and anyone who
+/// can reach Octo's port, so the interesting cases are the ones where a naive store
+/// says yes: an empty token, an unknown token, or one that should have lapsed.
+/// </summary>
+public class BrowseSessionStoreTests
+{
+    [Fact]
+    public void AMintedTokenValidates()
+    {
+        var store = new BrowseSessionStore();
+
+        Assert.True(store.Validate(store.Create("winters")));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-real-token")]
+    public void AnythingNotMintedByUsIsRejected(string? token)
+    {
+        var store = new BrowseSessionStore();
+        store.Create("winters"); // a live session must not make other tokens valid
+
+        Assert.False(store.Validate(token));
+    }
+
+    [Fact]
+    public void TokensAreUnpredictableAndNotSharedBetweenSessions()
+    {
+        var store = new BrowseSessionStore();
+
+        var first = store.Create("winters");
+        var second = store.Create("winters");
+
+        Assert.NotEqual(first, second);
+        // 32 bytes hex. Guessing is not meant to be on the table.
+        Assert.Equal(64, first.Length);
+    }
+}

--- a/octo.Tests/DirectoryBrowserTests.cs
+++ b/octo.Tests/DirectoryBrowserTests.cs
@@ -61,6 +61,30 @@ public class DirectoryBrowserTests
     }
 
     [Fact]
+    public void AFlatLibraryReportsItsTrackCountRatherThanLookingEmpty()
+    {
+        // The real library is ~2,350 loose tracks under four album folders. Listing
+        // directories alone made it render as an almost-empty folder, so there was
+        // no way to tell the right folder from a stray one.
+        var root = NewTempDir();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "Currents"));
+            foreach (var n in new[] { "a.flac", "b.mp3", "c.m4a", "d.opus" })
+                File.WriteAllText(Path.Combine(root, n), "x");
+            File.WriteAllText(Path.Combine(root, "cover.jpg"), "x");   // not audio
+            File.WriteAllText(Path.Combine(root, "notes.txt"), "x");   // not audio
+
+            var result = NewBrowser().Browse(root);
+
+            Assert.Equal(4, result.AudioFiles);
+            Assert.Single(result.Entries);                              // still directories only
+            Assert.DoesNotContain(result.Entries, e => e.Name.Contains('.'));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
     public void AMissingPathIsReportedRatherThanThrowing()
     {
         var missing = Path.Combine(Path.GetTempPath(), "octo-not-here-" + Guid.NewGuid().ToString("N"));

--- a/octo.Tests/DirectoryBrowserTests.cs
+++ b/octo.Tests/DirectoryBrowserTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Octo.Services.Admin;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The picker exists to stop a user choosing a folder Octo cannot actually download
+/// into, so the properties that matter are the ones that would quietly mislead:
+/// reporting a path different from the one listed, claiming a folder is writable
+/// because it merely exists, or failing a whole listing because one subdirectory
+/// refused to be read.
+/// </summary>
+public class DirectoryBrowserTests
+{
+    private static DirectoryBrowser NewBrowser() =>
+        new(NullLogger<DirectoryBrowser>.Instance);
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "octo-browse-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void TheReportedPathIsCanonicalSoItMatchesWhatWasListed()
+    {
+        var root = NewTempDir();
+        try
+        {
+            var child = Path.Combine(root, "child");
+            Directory.CreateDirectory(child);
+
+            // Round-trips through the child and back up: the answer must describe
+            // the directory actually listed, not the expression used to reach it.
+            var result = NewBrowser().Browse(Path.Combine(child, ".."));
+
+            Assert.True(result.Exists);
+            Assert.Equal(Path.GetFullPath(root), result.Path);
+            Assert.DoesNotContain("..", result.Path);
+            Assert.Contains(result.Entries, e => e.Name == "child");
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void ListingReturnsSubdirectoriesAndNeverFileNames()
+    {
+        var root = NewTempDir();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "albums"));
+            File.WriteAllText(Path.Combine(root, "secret-track.flac"), "x");
+
+            var result = NewBrowser().Browse(root);
+
+            Assert.Contains(result.Entries, e => e.Name == "albums");
+            Assert.DoesNotContain(result.Entries, e => e.Name.EndsWith(".flac"));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void AMissingPathIsReportedRatherThanThrowing()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "octo-not-here-" + Guid.NewGuid().ToString("N"));
+
+        var result = NewBrowser().Browse(missing);
+
+        Assert.False(result.Exists);
+        Assert.Empty(result.Entries);
+        Assert.False(result.Writable);
+    }
+
+    [Fact]
+    public void WritabilityIsProvedByWritingNotByExistence()
+    {
+        var root = NewTempDir();
+        try
+        {
+            var result = NewBrowser().Browse(root);
+            Assert.True(result.Exists);
+            Assert.True(result.Writable);
+
+            // The negative case cannot be forced portably (Windows ACLs and Unix
+            // modes diverge, and CI often runs as root, for whom mode 0500 is no
+            // obstacle), so assert the probe leaves nothing behind instead. A probe
+            // that littered the music library would be worse than no probe.
+            Assert.Empty(Directory.GetFiles(root));
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void AnEmptyPathStartsAtThePlatformRoot()
+    {
+        var result = NewBrowser().Browse(null);
+
+        if (OperatingSystem.IsWindows())
+        {
+            // No single root to enumerate on Windows, so the drives are the entry point.
+            Assert.NotEmpty(result.Entries);
+            Assert.All(result.Entries, e => Assert.Contains(":", e.Path));
+        }
+        else
+        {
+            Assert.Equal("/", result.Path);
+            Assert.True(result.Exists);
+        }
+    }
+
+    [Fact]
+    public void ParentIsOfferedForNavigationAndIsNullAtTheTop()
+    {
+        var root = NewTempDir();
+        try
+        {
+            var child = Path.Combine(root, "nested");
+            Directory.CreateDirectory(child);
+
+            Assert.Equal(Path.GetFullPath(root), NewBrowser().Browse(child).Parent);
+
+            var top = Path.GetPathRoot(Path.GetFullPath(root));
+            Assert.Null(NewBrowser().Browse(top).Parent);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+}

--- a/octo.Tests/DiscordSinkTests.cs
+++ b/octo.Tests/DiscordSinkTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+using Moq;
+using Octo.Models.Settings;
+using Octo.Services.Notifications;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// Discord rejects malformed embeds with a 400 the user never sees (the send is
+/// fire-and-forget), so the wire shape is pinned statically: field limits are
+/// enforced by truncation rather than trusted, and a missing cover omits the
+/// thumbnail object entirely because Discord 400s on a null url.
+/// </summary>
+public class DiscordSinkTests
+{
+    private static NotificationMessage Message(
+        string title = "Downloaded: A – B",
+        string body = "FLAC via Soulseek, 33.1 MB",
+        string? image = "https://cdn.example/cover.jpg") =>
+        new(NotificationEventType.DownloadCompleted, title, body, image);
+
+    [Fact]
+    public void EmbedCarriesTitleBodyThumbnailAndColor()
+    {
+        var payload = DiscordSink.BuildPayload(Message());
+        var embed = payload["embeds"]![0]!;
+
+        Assert.Equal("Downloaded: A – B", (string)embed["title"]!);
+        Assert.Equal("FLAC via Soulseek, 33.1 MB", (string)embed["description"]!);
+        Assert.Equal(0x22C55E, (int)embed["color"]!);
+        Assert.Equal("https://cdn.example/cover.jpg", (string)embed["thumbnail"]!["url"]!);
+        Assert.Equal("Octo", (string)embed["footer"]!["text"]!);
+        Assert.NotNull(embed["timestamp"]);
+    }
+
+    [Fact]
+    public void DiscordLimitsAreEnforced()
+    {
+        var payload = DiscordSink.BuildPayload(Message(
+            title: new string('t', 300),
+            body: new string('d', 5000)));
+        var embed = payload["embeds"]![0]!;
+
+        Assert.Equal(256, ((string)embed["title"]!).Length);
+        Assert.Equal(4096, ((string)embed["description"]!).Length);
+    }
+
+    [Fact]
+    public void NoThumbnailKeyWithoutCoverArt()
+    {
+        var payload = DiscordSink.BuildPayload(Message(image: null));
+        var embed = payload["embeds"]![0]!;
+
+        // Discord 400s on {"url": null}; the key must be absent, not null.
+        Assert.Null(embed["thumbnail"]);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Request = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        }
+    }
+
+    [Fact]
+    public async Task PostGoesToTheConfiguredWebhookAsJson()
+    {
+        var handler = new CapturingHandler();
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler));
+        var monitor = new Mock<IOptionsMonitor<NotificationSettings>>();
+        monitor.Setup(m => m.CurrentValue).Returns(new NotificationSettings
+        {
+            DiscordWebhookUrl = "https://discord.com/api/webhooks/1/abc",
+        });
+
+        await new DiscordSink(factory.Object, monitor.Object)
+            .SendAsync(Message(), CancellationToken.None);
+
+        Assert.Equal("https://discord.com/api/webhooks/1/abc", handler.Request!.RequestUri!.ToString());
+        Assert.Equal("application/json", handler.Request.Content!.Headers.ContentType!.MediaType);
+    }
+}

--- a/octo.Tests/DiscordSinkTests.cs
+++ b/octo.Tests/DiscordSinkTests.cs
@@ -47,6 +47,81 @@ public class DiscordSinkTests
     }
 
     [Fact]
+    public void FieldsTurnTheEmbedIntoASongCard()
+    {
+        var rendered = Octo.Services.Notifications.NotificationService.Render(new NotificationEvent
+        {
+            Type = NotificationEventType.DownloadCompleted,
+            Artist = "Randy Rogers Band",
+            Title = "In My Arms Instead",
+            Album = "Randy Rogers Band",
+            Format = "FLAC",
+            Source = "Soulseek",
+            SizeBytes = 34_684_600,
+            DurationSeconds = 223,
+            Year = 2008,
+            CoverArtUrl = "https://cdn.example/cover.jpg",
+        });
+        var embed = DiscordSink.BuildPayload(rendered)["embeds"]![0]!;
+
+        // Album as the description line, stats as inline fields, cover full-width.
+        Assert.Equal("Randy Rogers Band", (string)embed["description"]!);
+        var fields = embed["fields"]!.AsArray()
+            .ToDictionary(f => (string)f!["name"]!, f => (string)f!["value"]!);
+        Assert.Equal("FLAC", fields["Format"]);
+        Assert.Equal("Soulseek", fields["Source"]);
+        Assert.Equal("33.1 MB", fields["Size"]);
+        Assert.Equal("3:43", fields["Length"]);
+        Assert.Equal("≈1,244 kbps", fields["Bitrate"]);
+        Assert.Equal("2008", fields["Year"]);
+        Assert.All(embed["fields"]!.AsArray(), f => Assert.True((bool)f!["inline"]!));
+        // The card uses the full-width image slot, not the corner thumbnail, and
+        // does not repeat the prose body alongside the structured fields.
+        Assert.Equal("https://cdn.example/cover.jpg", (string)embed["image"]!["url"]!);
+        Assert.Null(embed["thumbnail"]);
+        Assert.DoesNotContain("FLAC via Soulseek", (string?)embed["description"] ?? "");
+    }
+
+    [Fact]
+    public void UnknownStatsAreOmittedFromTheCardNotRenderedAsPlaceholders()
+    {
+        var rendered = Octo.Services.Notifications.NotificationService.Render(new NotificationEvent
+        {
+            Type = NotificationEventType.DownloadStarted,
+            Artist = "A",
+            Title = "B",
+            Format = "MP3",
+            Source = "YouTube",
+            // no size, no duration, no year — the YouTube started path
+        });
+        var embed = DiscordSink.BuildPayload(rendered)["embeds"]![0]!;
+
+        var names = embed["fields"]!.AsArray().Select(f => (string)f!["name"]!).ToList();
+        Assert.Equal(new[] { "Format", "Source" }, names);
+    }
+
+    [Fact]
+    public void AlbumSummaryRendersItsCountsAsFields()
+    {
+        var rendered = Octo.Services.Notifications.NotificationService.Render(new NotificationEvent
+        {
+            Type = NotificationEventType.AlbumCompleted,
+            Artist = "Tame Impala",
+            Title = "Currents",
+            TrackCount = 15,
+            LosslessCount = 12,
+            FailedCount = 1,
+        });
+        var embed = DiscordSink.BuildPayload(rendered)["embeds"]![0]!;
+
+        var fields = embed["fields"]!.AsArray()
+            .ToDictionary(f => (string)f!["name"]!, f => (string)f!["value"]!);
+        Assert.Equal("15", fields["Tracks"]);
+        Assert.Equal("12", fields["Lossless"]);
+        Assert.Equal("1", fields["Failed"]);
+    }
+
+    [Fact]
     public void NoThumbnailKeyWithoutCoverArt()
     {
         var payload = DiscordSink.BuildPayload(Message(image: null));

--- a/octo.Tests/NotificationServiceTests.cs
+++ b/octo.Tests/NotificationServiceTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
+using Octo.Services.Notifications;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The orchestrator's one unforgivable failure would be disturbing a download, so
+/// the properties pinned here are the quiet ones: a disabled event must be dropped,
+/// an unconfigured sink must never be called, one transport being down must not
+/// take the other with it, and nothing may ever escape as an exception. Rendering
+/// is pinned too, because both transports carry the same text and the whole point
+/// of the Started event is naming the format up front.
+/// </summary>
+public class NotificationServiceTests
+{
+    private sealed class RecordingSink : INotificationSink
+    {
+        public List<NotificationMessage> Sent { get; } = new();
+        public bool Configured { get; set; } = true;
+        public bool Throw { get; set; }
+
+        public string Name => "recording";
+        public bool IsConfigured => Configured;
+
+        public Task SendAsync(NotificationMessage message, CancellationToken ct)
+        {
+            if (Throw) throw new InvalidOperationException("sink down");
+            Sent.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StaticMonitor : IOptionsMonitor<NotificationSettings>
+    {
+        public StaticMonitor(NotificationSettings value) => CurrentValue = value;
+        public NotificationSettings CurrentValue { get; }
+        public NotificationSettings Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<NotificationSettings, string?> listener) => null;
+    }
+
+    private static NotificationService Build(NotificationSettings settings, params INotificationSink[] sinks) =>
+        new(sinks, new StaticMonitor(settings), NullLogger<NotificationService>.Instance);
+
+    private static NotificationEvent Completed() => new()
+    {
+        Type = NotificationEventType.DownloadCompleted,
+        Artist = "Randy Rogers Band",
+        Title = "In My Arms Instead",
+        Format = "FLAC",
+        Source = "Soulseek",
+        SizeBytes = 34_684_600,
+    };
+
+    [Fact]
+    public async Task DisabledEventTypesAreDropped()
+    {
+        var sink = new RecordingSink();
+        var svc = Build(new NotificationSettings { NotifyDownloadCompleted = false }, sink);
+
+        await svc.NotifyInternalAsync(Completed());
+
+        Assert.Empty(sink.Sent);
+    }
+
+    [Fact]
+    public async Task EventsFanOutOnlyToConfiguredSinks()
+    {
+        var on = new RecordingSink();
+        var off = new RecordingSink { Configured = false };
+        var svc = Build(new NotificationSettings(), on, off);
+
+        await svc.NotifyInternalAsync(Completed());
+
+        Assert.Single(on.Sent);
+        Assert.Empty(off.Sent);
+    }
+
+    [Fact]
+    public async Task OneSinkFailingDoesNotStopTheOther()
+    {
+        var broken = new RecordingSink { Throw = true };
+        var healthy = new RecordingSink();
+        var svc = Build(new NotificationSettings(), broken, healthy);
+
+        await svc.NotifyInternalAsync(Completed());
+
+        Assert.Single(healthy.Sent);
+    }
+
+    [Fact]
+    public async Task NotifyNeverThrows()
+    {
+        var broken = new RecordingSink { Throw = true };
+        var svc = Build(new NotificationSettings(), broken);
+
+        // A throwing sink plus an event with every optional field missing: the
+        // combination most likely to surface a swallowed NullReferenceException.
+        await svc.NotifyInternalAsync(new NotificationEvent { Type = NotificationEventType.DownloadFailed });
+        svc.Notify(new NotificationEvent { Type = NotificationEventType.DownloadCompleted });
+    }
+
+    [Fact]
+    public void StartedMessageNamesTheFormatUpFront()
+    {
+        var msg = NotificationService.Render(new NotificationEvent
+        {
+            Type = NotificationEventType.DownloadStarted,
+            Artist = "Randy Rogers Band",
+            Title = "In My Arms Instead",
+            Format = "FLAC",
+            Source = "Soulseek",
+            SizeBytes = 34_684_600,
+        });
+
+        // "Did it find lossless or is it settling?" is the event's entire reason
+        // to exist, so the answer leads the body.
+        Assert.Contains("FLAC via Soulseek", msg.Body);
+        Assert.Contains("33.1 MB", msg.Body);
+        Assert.StartsWith("Downloading:", msg.Title);
+    }
+
+    [Fact]
+    public void FallbackMessageSaysWhatWasLost()
+    {
+        var msg = NotificationService.Render(new NotificationEvent
+        {
+            Type = NotificationEventType.LosslessFallback,
+            Artist = "A",
+            Title = "B",
+            Detail = "No Soulseek FLAC found",
+        });
+
+        Assert.Contains("MP3", msg.Body);
+        Assert.Contains("No Soulseek FLAC found", msg.Body);
+    }
+
+    [Fact]
+    public void TestEventBypassesEveryToggle()
+    {
+        var everythingOff = new NotificationSettings
+        {
+            NotifyDownloadStarted = false,
+            NotifyDownloadCompleted = false,
+            NotifyLosslessFallback = false,
+            NotifyDownloadFailed = false,
+            NotifyAlbumCompleted = false,
+        };
+
+        // The test button exists to verify transports; toggles must not mute it.
+        Assert.True(NotificationService.IsEnabled(everythingOff, NotificationEventType.Test));
+    }
+
+    [Fact]
+    public async Task TestSendReportsEachSinkSeparately()
+    {
+        var healthy = new RecordingSink();
+        var broken = new RecordingSink { Throw = true };
+        var svc = Build(new NotificationSettings(), healthy, broken);
+
+        var results = await svc.SendTestAsync(CancellationToken.None);
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, r => r.Ok);
+        Assert.Contains(results, r => !r.Ok && r.Detail.Contains("sink down"));
+    }
+
+    [Fact]
+    public void AlbumSummaryCountsTracksAndLosslessness()
+    {
+        var msg = NotificationService.Render(new NotificationEvent
+        {
+            Type = NotificationEventType.AlbumCompleted,
+            Artist = "Tame Impala",
+            Title = "Currents",
+            TrackCount = 15,
+            LosslessCount = 12,
+            FailedCount = 1,
+        });
+
+        Assert.Contains("15 tracks fetched, 12 lossless, 1 failed", msg.Body);
+    }
+
+    [Fact]
+    public void AlbumSummaryIsSkippedWhenTheWalkDidNothing()
+    {
+        // A re-star whose tracks are all already present must not ping the phone.
+        var album = new Octo.Models.Domain.Album { Artist = "A", Title = "B" };
+
+        Assert.Null(Octo.Services.Common.BaseDownloadService.BuildAlbumSummary(album, 0, 0, 0));
+        Assert.NotNull(Octo.Services.Common.BaseDownloadService.BuildAlbumSummary(album, 1, 1, 0));
+    }
+}

--- a/octo.Tests/NtfySinkTests.cs
+++ b/octo.Tests/NtfySinkTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+using Moq;
+using Octo.Models.Settings;
+using Octo.Services.Notifications;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The ntfy sink publishes in JSON mode on purpose: ntfy's header mode carries the
+/// title in an HTTP header, and .NET's HttpClient rejects non-ASCII header values,
+/// which for a music library ("Sigur Rós", "坂本龍一") is the normal case. These
+/// tests pin that choice, the topic-URL parsing that lets the config stay one
+/// field, and the auth header only appearing when a token is set.
+/// </summary>
+public class NtfySinkTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Request { get; private set; }
+        public string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Request = request;
+            Body = request.Content is null ? null : await request.Content.ReadAsStringAsync(ct);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private static (NtfySink Sink, CapturingHandler Handler) Build(string url, string token = "")
+    {
+        var handler = new CapturingHandler();
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler));
+        var opts = Options.Create(new NotificationSettings { NtfyUrl = url, NtfyToken = token });
+        var monitor = new Mock<IOptionsMonitor<NotificationSettings>>();
+        monitor.Setup(m => m.CurrentValue).Returns(opts.Value);
+        return (new NtfySink(factory.Object, monitor.Object), handler);
+    }
+
+    private static NotificationMessage Message(string title = "t", string body = "b", string? image = null) =>
+        new(NotificationEventType.DownloadCompleted, title, body, image);
+
+    [Theory]
+    [InlineData("https://ntfy.sh/octo", "https://ntfy.sh", "octo")]
+    [InlineData("https://host/ntfy/octo", "https://host/ntfy", "octo")]
+    [InlineData("https://ntfy.sh/octo/", "https://ntfy.sh", "octo")]
+    public void TopicUrlSplitsIntoRootAndTopic(string url, string root, string topic)
+    {
+        var parsed = NtfySink.ParseTopicUrl(url);
+
+        Assert.Equal(root, parsed.ServerRoot);
+        Assert.Equal(topic, parsed.Topic);
+    }
+
+    [Fact]
+    public void BareServerUrlIsReportedNotSwallowed()
+    {
+        // The admin test button surfaces this message verbatim, so it names the fix.
+        var ex = Assert.Throws<InvalidOperationException>(() => NtfySink.ParseTopicUrl("https://ntfy.sh"));
+
+        Assert.Contains("must include a topic", ex.Message);
+    }
+
+    [Fact]
+    public async Task PublishesUtf8JsonNotHeaders()
+    {
+        var (sink, handler) = Build("https://ntfy.sh/octo");
+
+        await sink.SendAsync(Message(title: "Sigur Rós – Ágætis byrjun"), CancellationToken.None);
+
+        // The whole reason for JSON mode: the title travels in the UTF-8 body and
+        // never as an HTTP header.
+        Assert.Contains("Sigur Rós", handler.Body);
+        Assert.False(handler.Request!.Headers.Contains("Title"));
+        Assert.Contains("\"topic\":\"octo\"", handler.Body);
+        Assert.Equal("https://ntfy.sh/", handler.Request.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task BearerTokenOnlyWhenConfigured()
+    {
+        var (bare, bareHandler) = Build("https://ntfy.sh/octo");
+        await bare.SendAsync(Message(), CancellationToken.None);
+        Assert.False(bareHandler.Request!.Headers.Contains("Authorization"));
+
+        var (authed, authedHandler) = Build("https://ntfy.sh/octo", token: "tk_secret");
+        await authed.SendAsync(Message(), CancellationToken.None);
+        Assert.Equal("Bearer tk_secret", authedHandler.Request!.Headers.GetValues("Authorization").Single());
+    }
+
+    [Fact]
+    public async Task CoverArtBecomesAttachAndAbsentMeansNoKey()
+    {
+        var (sink, handler) = Build("https://ntfy.sh/octo");
+
+        await sink.SendAsync(Message(image: "https://cdn.example/cover.jpg"), CancellationToken.None);
+        Assert.Contains("\"attach\":\"https://cdn.example/cover.jpg\"", handler.Body);
+
+        await sink.SendAsync(Message(image: null), CancellationToken.None);
+        Assert.DoesNotContain("attach", handler.Body);
+    }
+}

--- a/octo.Tests/NtfySinkTests.cs
+++ b/octo.Tests/NtfySinkTests.cs
@@ -92,14 +92,50 @@ public class NtfySinkTests
     }
 
     [Fact]
-    public async Task CoverArtBecomesAttachAndAbsentMeansNoKey()
+    public async Task CoverArtBecomesIconAndAttachAndAbsentMeansNoKeys()
     {
         var (sink, handler) = Build("https://ntfy.sh/octo");
 
+        // Icon shows in the notification shade, attach when expanded — art in
+        // both places is the "really nice" ask for the phone side.
         await sink.SendAsync(Message(image: "https://cdn.example/cover.jpg"), CancellationToken.None);
         Assert.Contains("\"attach\":\"https://cdn.example/cover.jpg\"", handler.Body);
+        Assert.Contains("\"icon\":\"https://cdn.example/cover.jpg\"", handler.Body);
 
         await sink.SendAsync(Message(image: null), CancellationToken.None);
         Assert.DoesNotContain("attach", handler.Body);
+        Assert.DoesNotContain("icon", handler.Body);
+    }
+
+    [Fact]
+    public void FieldsFoldIntoDotSeparatedStatsWithTheAlbumLineFirst()
+    {
+        var body = NtfySink.BuildBody(new NotificationMessage(
+            NotificationEventType.DownloadCompleted,
+            "Downloaded: A – B",
+            "prose fallback",
+            null,
+            Description: "Some Album",
+            Fields: new List<KeyValuePair<string, string>>
+            {
+                new("Format", "FLAC"),
+                new("Source", "Soulseek"),
+                new("Size", "33.1 MB"),
+                new("Length", "3:43"),
+            }));
+
+        Assert.Equal("Some Album\nFLAC · Soulseek · 33.1 MB · 3:43", body);
+    }
+
+    [Fact]
+    public void ProseEventsKeepTheirBodyVerbatim()
+    {
+        var body = NtfySink.BuildBody(new NotificationMessage(
+            NotificationEventType.LosslessFallback,
+            "Lossless miss: A – B",
+            "Soulseek failed (nothing usable); settling for YouTube MP3.",
+            null));
+
+        Assert.Equal("Soulseek failed (nothing usable); settling for YouTube MP3.", body);
     }
 }

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -197,6 +197,7 @@ public class AdminController : ControllerBase
             result.Exists,
             result.Entries,
             result.Truncated,
+            result.AudioFiles,
             // Under Docker this is the container's mount namespace, not the host's
             // drives. Saying so in the payload keeps the UI honest about why a
             // user's D: drive is nowhere to be seen.

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -33,6 +33,9 @@ public class AdminController : ControllerBase
     private readonly SoulseekClient _slskd;
     private readonly SubsonicProxyService _proxy;
     private readonly SubsonicDiscoveryService _discovery;
+    private readonly NavidromeIdentityService _navIdentity;
+    private readonly DirectoryBrowser _browser;
+    private readonly BrowseSessionStore _browseSessions;
     private readonly Octo.Services.Local.DownloadHistoryService _history;
     private readonly Octo.Services.Metadata.DeezerMetadataService _deezer;
     private readonly Octo.Services.CoverArt.CoverArtAggregator _coverArt;
@@ -49,6 +52,9 @@ public class AdminController : ControllerBase
         SoulseekClient slskd,
         SubsonicProxyService proxy,
         SubsonicDiscoveryService discovery,
+        NavidromeIdentityService navIdentity,
+        DirectoryBrowser browser,
+        BrowseSessionStore browseSessions,
         Octo.Services.Local.DownloadHistoryService history,
         Octo.Services.Metadata.DeezerMetadataService deezer,
         Octo.Services.CoverArt.CoverArtAggregator coverArt,
@@ -66,6 +72,9 @@ public class AdminController : ControllerBase
         _slskd = slskd;
         _proxy = proxy;
         _discovery = discovery;
+        _navIdentity = navIdentity;
+        _browser = browser;
+        _browseSessions = browseSessions;
         _history = history;
         _httpFactory = httpFactory;
         _lifetime = lifetime;
@@ -84,6 +93,119 @@ public class AdminController : ControllerBase
         var servers = await _discovery.ScanAsync(ct);
         return Ok(new { servers });
     }
+
+    /// <summary>
+    /// Where downloads will actually land, and why. Octo fronts Navidrome, so the
+    /// library Navidrome scans is the source of truth and the default; this states
+    /// the whole chain (what Navidrome reports, whether Octo can see it, what is
+    /// therefore in effect) so "my downloads went nowhere" is answerable from the
+    /// UI instead of the container logs.
+    /// </summary>
+    [HttpGet("library-status")]
+    public async Task<IActionResult> LibraryStatus(CancellationToken ct)
+    {
+        var subsonic = _subsonicOpts.CurrentValue;
+        var configured = _config["Library:DownloadPath"] ?? "";
+
+        // Cheap when already detected: this is TTL-cached inside the service.
+        await _navIdentity.DetectMusicFolderAsync(ct: ct);
+
+        var reported = _navIdentity.DetectedMusicFolder;
+        var effective = _navIdentity.EffectiveDownloadPath(configured);
+        var libraries = _navIdentity.KnownLibraries
+            .Select(l => new { l.Id, l.Name, l.Folder, visible = Directory.Exists(l.Folder) })
+            .ToList();
+
+        return Ok(new
+        {
+            autoDetect = subsonic.AutoDetectDownloadPath,
+            pinnedLibraryPath = subsonic.LibraryPath ?? "",
+            navidromeReports = reported,
+            // Navidrome describes paths as IT sees them. Whether Octo can see the
+            // same path is the difference between downloads being scanned and
+            // vanishing, so it is stated rather than implied.
+            visibleToOcto = !string.IsNullOrEmpty(reported) && Directory.Exists(reported),
+            configuredFallback = configured,
+            effectiveDownloadPath = effective,
+            writable = !string.IsNullOrEmpty(effective) && Directory.Exists(effective)
+                       && DirectoryBrowser.IsWritable(effective),
+            rescanAuthenticated = _navIdentity.GetScanAuth() != null,
+            libraries,
+        });
+    }
+
+    /// <summary>
+    /// Exchange Navidrome admin credentials for a short-lived browse token.
+    ///
+    /// Credentials arrive in the body, never the query string, so they cannot end up
+    /// in access logs or a referrer. Verification is delegated to the Navidrome Octo
+    /// already fronts: no new credential store, and admin rights are Navidrome's call
+    /// rather than something Octo asserts for itself.
+    /// </summary>
+    [HttpPost("browse/auth")]
+    public async Task<IActionResult> BrowseAuth([FromBody] BrowseAuthRequest req, CancellationToken ct)
+    {
+        var url = _subsonicOpts.CurrentValue.Url?.TrimEnd('/');
+        if (string.IsNullOrEmpty(url))
+            return StatusCode(503, new { error = "Navidrome URL is not configured yet." });
+        if (req is null || string.IsNullOrWhiteSpace(req.Username) || string.IsNullOrWhiteSpace(req.Password))
+            return Unauthorized(new { error = "Username and password are required." });
+
+        try
+        {
+            var http = _httpFactory.CreateClient();
+            var payload = JsonSerializer.Serialize(new { username = req.Username, password = req.Password });
+            using var content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
+            using var resp = await http.PostAsync($"{url}/auth/login", content, ct);
+            if (!resp.IsSuccessStatusCode)
+                return Unauthorized(new { error = "Navidrome rejected those credentials." });
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct));
+            var isAdmin = doc.RootElement.TryGetProperty("isAdmin", out var adminEl)
+                          && adminEl.ValueKind == JsonValueKind.True;
+            if (!isAdmin)
+                return Unauthorized(new { error = "That account is not a Navidrome admin." });
+
+            _logger.LogInformation("Browse session opened for Navidrome admin {User}", req.Username);
+            return Ok(new { token = _browseSessions.Create(req.Username) });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Browse auth against Navidrome failed: {Msg}", ex.Message);
+            return StatusCode(502, new { error = "Could not reach Navidrome to verify credentials." });
+        }
+    }
+
+    /// <summary>
+    /// List directories so the download folder can be picked rather than typed.
+    /// Requires a token from browse/auth; a 401 discloses nothing about the
+    /// filesystem, not even whether a path exists.
+    /// </summary>
+    [HttpGet("browse")]
+    public IActionResult Browse([FromQuery] string? path, [FromHeader(Name = "X-Octo-Browse-Token")] string? token)
+    {
+        if (!_browseSessions.Validate(token))
+            return Unauthorized(new { error = "Browse session required." });
+
+        var result = _browser.Browse(path);
+        return Ok(new
+        {
+            result.Path,
+            result.Parent,
+            result.Separator,
+            result.Writable,
+            result.Exists,
+            result.Entries,
+            result.Truncated,
+            // Under Docker this is the container's mount namespace, not the host's
+            // drives. Saying so in the payload keeps the UI honest about why a
+            // user's D: drive is nowhere to be seen.
+            containerised = !OperatingSystem.IsWindows() && Directory.Exists("/.dockerenv"),
+        });
+    }
+
+    /// <summary>Credentials for <see cref="BrowseAuth"/>. Body-only by design.</summary>
+    public record BrowseAuthRequest(string? Username, string? Password);
 
     /// <summary>The running log of songs Octo has fetched, newest first.</summary>
     [HttpGet("downloads")]
@@ -144,6 +266,7 @@ public class AdminController : ControllerBase
                 // fields never pre-filled with the saved value.
                 ["DownloadSource"] = subsonic.DownloadSource.ToString(),
                 ["AutoDetectDownloadPath"] = subsonic.AutoDetectDownloadPath,
+                ["LibraryPath"] = subsonic.LibraryPath,
                 ["FolderStructure"] = subsonic.FolderStructure.ToString(),
                 ["UseLocalStaging"] = subsonic.UseLocalStaging,
                 ["ExplicitFilter"] = subsonic.ExplicitFilter.ToString(),
@@ -264,6 +387,7 @@ public class AdminController : ControllerBase
                 ["LosslessWaitTimeoutSeconds"] = subsonic.LosslessWaitTimeoutSeconds,
                 ["DownloadSource"] = subsonic.DownloadSource.ToString(),
                 ["AutoDetectDownloadPath"] = subsonic.AutoDetectDownloadPath,
+                ["LibraryPath"] = subsonic.LibraryPath,
                 ["FolderStructure"] = subsonic.FolderStructure.ToString(),
                 ["UseLocalStaging"] = subsonic.UseLocalStaging,
                 ["ExplicitFilter"] = subsonic.ExplicitFilter.ToString(),
@@ -365,7 +489,7 @@ public class AdminController : ControllerBase
             "Subsonic:Url", "Subsonic:StorageMode", "Subsonic:DownloadMode",
             "Subsonic:DownloadOnStar", "Subsonic:DownloadAlbumOnStar",
             "Subsonic:WaitForLosslessOnPlay", "Subsonic:LosslessWaitTimeoutSeconds",
-            "Subsonic:DownloadSource", "Subsonic:AutoDetectDownloadPath",
+            "Subsonic:DownloadSource", "Subsonic:AutoDetectDownloadPath", "Subsonic:LibraryPath",
             "Subsonic:FolderStructure",
             "Subsonic:UseLocalStaging", "Subsonic:ExplicitFilter",
             "Subsonic:CacheDurationHours", "Subsonic:EnableExternalPlaylists",

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -167,7 +167,23 @@ public class AdminController : ControllerBase
                 return Unauthorized(new { error = "That account is not a Navidrome admin." });
 
             _logger.LogInformation("Browse session opened for Navidrome admin {User}", req.Username);
-            return Ok(new { token = _browseSessions.Create(req.Username) });
+            var token = _browseSessions.Create(req.Username);
+
+            // Hand the session back as an HttpOnly cookie rather than something the
+            // page has to hold. It survives a reload, so the user is not asked to
+            // sign in again every time they come back to the settings, and script
+            // on the page cannot read it even if something managed to inject some.
+            // Secure only over HTTPS, since this is normally reached over plain HTTP
+            // on a LAN and a Secure cookie would simply be dropped there.
+            Response.Cookies.Append(BrowseCookieName, token, new CookieOptions
+            {
+                HttpOnly = true,
+                SameSite = SameSiteMode.Strict,
+                Secure = Request.IsHttps,
+                Path = "/api/admin",
+                MaxAge = BrowseSessionStore.Ttl,
+            });
+            return Ok(new { ok = true });
         }
         catch (Exception ex)
         {
@@ -184,7 +200,10 @@ public class AdminController : ControllerBase
     [HttpGet("browse")]
     public IActionResult Browse([FromQuery] string? path, [FromHeader(Name = "X-Octo-Browse-Token")] string? token)
     {
-        if (!_browseSessions.Validate(token))
+        // Cookie first (how the admin UI authenticates), header second so the
+        // endpoint stays usable from curl or a script without one.
+        var session = Request.Cookies[BrowseCookieName] ?? token;
+        if (!_browseSessions.Validate(session))
             return Unauthorized(new { error = "Browse session required." });
 
         var result = _browser.Browse(path);
@@ -207,6 +226,10 @@ public class AdminController : ControllerBase
 
     /// <summary>Credentials for <see cref="BrowseAuth"/>. Body-only by design.</summary>
     public record BrowseAuthRequest(string? Username, string? Password);
+
+    /// <summary>Cookie carrying the browse session. Scoped to /api/admin so it is
+    /// never sent with the Subsonic traffic Octo proxies.</summary>
+    private const string BrowseCookieName = "octo_browse";
 
     /// <summary>The running log of songs Octo has fetched, newest first.</summary>
     [HttpGet("downloads")]

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -29,6 +29,8 @@ public class AdminController : ControllerBase
     private readonly IOptionsMonitor<SubsonicSettings> _subsonicOpts;
     private readonly IOptionsMonitor<SoulseekSettings> _soulseekOpts;
     private readonly IOptionsMonitor<LastFmSettings> _lastFmOpts;
+    private readonly IOptionsMonitor<NotificationSettings> _notificationOpts;
+    private readonly Octo.Services.Notifications.NotificationService _notifications;
     private readonly IConfiguration _config;
     private readonly SoulseekClient _slskd;
     private readonly SubsonicProxyService _proxy;
@@ -48,6 +50,8 @@ public class AdminController : ControllerBase
         IOptionsMonitor<SubsonicSettings> subsonicOpts,
         IOptionsMonitor<SoulseekSettings> soulseekOpts,
         IOptionsMonitor<LastFmSettings> lastFmOpts,
+        IOptionsMonitor<NotificationSettings> notificationOpts,
+        Octo.Services.Notifications.NotificationService notifications,
         IConfiguration config,
         SoulseekClient slskd,
         SubsonicProxyService proxy,
@@ -68,6 +72,8 @@ public class AdminController : ControllerBase
         _subsonicOpts = subsonicOpts;
         _soulseekOpts = soulseekOpts;
         _lastFmOpts = lastFmOpts;
+        _notificationOpts = notificationOpts;
+        _notifications = notifications;
         _config = config;
         _slskd = slskd;
         _proxy = proxy;
@@ -224,6 +230,18 @@ public class AdminController : ControllerBase
         });
     }
 
+    /// <summary>
+    /// Sends a test notification through every configured sink so URLs and tokens can
+    /// be verified without waiting for a real download. Reports per-sink outcome,
+    /// including the transport's real error text on failure.
+    /// </summary>
+    [HttpPost("test-notification")]
+    public async Task<IActionResult> TestNotification(CancellationToken ct)
+    {
+        var results = await _notifications.SendTestAsync(ct);
+        return Ok(new { results });
+    }
+
     /// <summary>Credentials for <see cref="BrowseAuth"/>. Body-only by design.</summary>
     public record BrowseAuthRequest(string? Username, string? Password);
 
@@ -270,6 +288,7 @@ public class AdminController : ControllerBase
         var subsonic = _subsonicOpts.CurrentValue;
         var soulseek = _soulseekOpts.CurrentValue;
         var lastfm = _lastFmOpts.CurrentValue;
+        var notif = _notificationOpts.CurrentValue;
 
         // Use Dictionary<string, object> so System.Text.Json doesn't camelCase
         // the keys. The admin UI's form fields are named "Subsonic.FolderStructure"
@@ -322,6 +341,17 @@ public class AdminController : ControllerBase
                 ["EnableRadio"] = lastfm.EnableRadio,
                 ["RadioTrackCount"] = lastfm.RadioTrackCount,
                 ["RadioCacheDurationHours"] = lastfm.RadioCacheDurationHours,
+            },
+            ["Notifications"] = new Dictionary<string, object>
+            {
+                ["NtfyUrl"] = notif.NtfyUrl ?? "",
+                ["NtfyToken"] = notif.NtfyToken ?? "",
+                ["DiscordWebhookUrl"] = notif.DiscordWebhookUrl ?? "",
+                ["NotifyDownloadStarted"] = notif.NotifyDownloadStarted,
+                ["NotifyDownloadCompleted"] = notif.NotifyDownloadCompleted,
+                ["NotifyLosslessFallback"] = notif.NotifyLosslessFallback,
+                ["NotifyDownloadFailed"] = notif.NotifyDownloadFailed,
+                ["NotifyAlbumCompleted"] = notif.NotifyAlbumCompleted,
             },
             ["_meta"] = new Dictionary<string, object>
             {
@@ -397,6 +427,7 @@ public class AdminController : ControllerBase
         var subsonic = _subsonicOpts.CurrentValue;
         var soulseek = _soulseekOpts.CurrentValue;
         var lastfm = _lastFmOpts.CurrentValue;
+        var notif = _notificationOpts.CurrentValue;
 
         var effective = new JsonObject
         {
@@ -443,6 +474,17 @@ public class AdminController : ControllerBase
                 ["EnableRadio"] = lastfm.EnableRadio,
                 ["RadioTrackCount"] = lastfm.RadioTrackCount,
                 ["RadioCacheDurationHours"] = lastfm.RadioCacheDurationHours,
+            },
+            ["Notifications"] = new JsonObject
+            {
+                ["NtfyUrl"] = notif.NtfyUrl ?? "",
+                ["NtfyToken"] = notif.NtfyToken ?? "",
+                ["DiscordWebhookUrl"] = notif.DiscordWebhookUrl ?? "",
+                ["NotifyDownloadStarted"] = notif.NotifyDownloadStarted,
+                ["NotifyDownloadCompleted"] = notif.NotifyDownloadCompleted,
+                ["NotifyLosslessFallback"] = notif.NotifyLosslessFallback,
+                ["NotifyDownloadFailed"] = notif.NotifyDownloadFailed,
+                ["NotifyAlbumCompleted"] = notif.NotifyAlbumCompleted,
             },
         };
         var json = effective.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
@@ -525,6 +567,11 @@ public class AdminController : ControllerBase
             "YouTube:ShimUrl",
             "LastFm:ApiKey", "LastFm:EnableRadio", "LastFm:RadioTrackCount",
             "LastFm:RadioCacheDurationHours",
+            "Notifications:NtfyUrl", "Notifications:NtfyToken",
+            "Notifications:DiscordWebhookUrl",
+            "Notifications:NotifyDownloadStarted", "Notifications:NotifyDownloadCompleted",
+            "Notifications:NotifyLosslessFallback", "Notifications:NotifyDownloadFailed",
+            "Notifications:NotifyAlbumCompleted",
         };
         var rows = new List<object>();
         foreach (var k in keys)
@@ -533,7 +580,11 @@ public class AdminController : ControllerBase
             // Mask anything that smells like a secret so a screenshot of the
             // page doesn't leak credentials.
             var isSecret = k.EndsWith("Password", StringComparison.OrdinalIgnoreCase)
-                        || k.EndsWith("ApiKey", StringComparison.OrdinalIgnoreCase);
+                        || k.EndsWith("ApiKey", StringComparison.OrdinalIgnoreCase)
+                        // A Discord webhook URL embeds its token, so the whole URL is
+                        // the secret; ntfy tokens are credentials outright.
+                        || k.EndsWith("Token", StringComparison.OrdinalIgnoreCase)
+                        || k.EndsWith("WebhookUrl", StringComparison.OrdinalIgnoreCase);
             var display = isSecret && !string.IsNullOrEmpty(v)
                 ? new string('•', Math.Min(v.Length, 16))
                 : v;

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1590,10 +1590,11 @@ public class SubsonicController : ControllerBase
         _radioQueueStore.Register(resolvedSongs.Select(s => s.Id));
 
         // Fire-and-forget prewarm for the top of the queue so the first few
-        // taps don't pay the full cold yt-dlp resolve. Cap below the shim's
-        // MAX_CONCURRENT_YTDLP=8 (the prewarm method handles its own
-        // concurrency limit internally). Local songs are skipped automatically
-        // by the prewarmer (they have no registry entry).
+        // taps don't pay the full cold yt-dlp resolve. The prewarm method
+        // handles its own concurrency limit, shared across every trigger, and
+        // marks its shim calls as background so they cannot occupy the slots
+        // the shim reserves for interactive plays. Local songs are skipped
+        // automatically by the prewarmer (they have no registry entry).
         _ = _metadataService.PrewarmYouTubeIdsAsync(resolvedSongs, topN: 8);
 
         return BuildSimilarSongsResponse(format, resolvedSongs, responseKey);

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1209,9 +1209,15 @@ public class SubsonicController : ControllerBase
             var contentType = result.ContentType ?? "image/jpeg";
             return File(result.Body, contentType);
         }
-        catch
+        catch (Exception ex)
         {
-            return ServePlaceholder();
+            // Unbranded on purpose. This is the user's own file; stamping the Octo
+            // logo on it makes Octo look like it is claiming a track the user
+            // already owned. Reading embedded art off a cloud-backed mount can take
+            // seconds cold, so this path is reached by ordinary slowness, not just
+            // by missing art — all the more reason not to brand it.
+            _logger.LogDebug("cover art relay failed for local id {Id}: {Msg}", id, ex.Message);
+            return ServePlaceholder(branded: false);
         }
     }
 
@@ -1221,9 +1227,9 @@ public class SubsonicController : ControllerBase
     /// drop play-queue entries whose cover-art request fails, so we always serve
     /// something rather than fail.
     /// </summary>
-    private IActionResult ServePlaceholder()
+    private IActionResult ServePlaceholder(bool branded = true)
     {
-        var bytes = _coverArtService?.GetPlaceholderCover();
+        var bytes = _coverArtService?.GetPlaceholderCover(branded);
         if (bytes == null || bytes.Length == 0) return NotFound();
         return File(bytes, "image/jpeg");
     }

--- a/octo/Models/Settings/NotificationSettings.cs
+++ b/octo/Models/Settings/NotificationSettings.cs
@@ -1,0 +1,60 @@
+namespace Octo.Models.Settings;
+
+/// <summary>
+/// Push notifications for the download lifecycle. Subsonic has no notification
+/// mechanism and Navidrome's event stream only reaches its own web UI, so without
+/// this nothing tells the user a starred track landed, settled for a lossy source,
+/// or failed — the SearchWaitSeconds bug went unnoticed for exactly that reason.
+///
+/// A transport is enabled simply by its URL being non-empty. Every value is read
+/// through IOptionsMonitor at send time, so changes apply without a restart.
+/// </summary>
+public class NotificationSettings
+{
+    /// <summary>
+    /// Full ntfy topic URL, e.g. "https://ntfy.sh/my-octo-topic". Non-empty enables
+    /// the ntfy sink. Subscribe to the same topic in the ntfy app to receive pushes.
+    /// Environment variable: NOTIFICATIONS__NTFYURL
+    /// </summary>
+    public string NtfyUrl { get; set; } = "";
+
+    /// <summary>
+    /// Optional ntfy access token, sent as "Authorization: Bearer". Only needed on
+    /// servers with access control.
+    /// Environment variable: NOTIFICATIONS__NTFYTOKEN
+    /// </summary>
+    public string NtfyToken { get; set; } = "";
+
+    /// <summary>
+    /// Discord webhook URL. Non-empty enables the Discord sink. The URL embeds the
+    /// webhook token, so the whole URL is treated as a secret and masked in the
+    /// config-sources view.
+    /// Environment variable: NOTIFICATIONS__DISCORDWEBHOOKURL
+    /// </summary>
+    public string DiscordWebhookUrl { get; set; } = "";
+
+    /// <summary>
+    /// A transfer actually began, saying up front whether it found lossless or is
+    /// settling for MP3. Off by default: it doubles volume for information
+    /// DownloadCompleted mostly repeats, and LosslessFallback (on by default)
+    /// already covers the settling case.
+    /// </summary>
+    public bool NotifyDownloadStarted { get; set; } = false;
+
+    /// <summary>A track landed: format, source, size, album art.</summary>
+    public bool NotifyDownloadCompleted { get; set; } = true;
+
+    /// <summary>
+    /// Soulseek came up empty and Octo settled for a YouTube MP3. On by default:
+    /// silent quality loss is the failure mode this whole feature exists to expose.
+    /// </summary>
+    public bool NotifyLosslessFallback { get; set; } = true;
+
+    /// <summary>Both sources failed for a starred track. Stars only — a shed
+    /// play-triggered acquisition is a hint, not an unmet promise.</summary>
+    public bool NotifyDownloadFailed { get; set; } = true;
+
+    /// <summary>One summary per album walk (tracks fetched, how many lossless)
+    /// instead of a ping per track.</summary>
+    public bool NotifyAlbumCompleted { get; set; } = true;
+}

--- a/octo/Models/Settings/SoulseekSettings.cs
+++ b/octo/Models/Settings/SoulseekSettings.cs
@@ -35,6 +35,12 @@ public class SoulseekSettings
     /// responseCount well before /responses will hand the files over, so a status
     /// poll makes short waits look adequate when they are not.
     ///
+    /// This is a CEILING, not a duration: the search returns as soon as it has
+    /// enough usable candidates to choose from, or as soon as slskd says the search
+    /// has finished. A short value is therefore still a hard cap on finding
+    /// anything, while a generous one costs nothing when results arrive early or
+    /// when the search comes back empty.
+    ///
     /// Star-triggered downloads are fire-and-forget, so the wait costs the user
     /// nothing; it only delays the file landing.
     /// </summary>

--- a/octo/Models/Settings/SoulseekSettings.cs
+++ b/octo/Models/Settings/SoulseekSettings.cs
@@ -23,10 +23,22 @@ public class SoulseekSettings
 
     /// <summary>
     /// How long to wait (seconds) for a Soulseek search to gather peer responses
-    /// before returning results. Soulseek searches stream in over time; a longer wait
-    /// gives more candidates, a shorter wait keeps radio responsive.
+    /// before returning results. Soulseek searches stream in over time, so this is
+    /// the difference between finding a lossless file and silently settling for a
+    /// transcode.
+    ///
+    /// This was 6, which measurement showed is simply too short: polling slskd's
+    /// /responses for the same query returned nothing at 6s, 10s or 15s, then 14
+    /// responses including 5 FLACs at 20s — reproducibly, across three runs. The
+    /// effect was that every star fell back to YouTube MP3 while lossless copies
+    /// were sitting there unseen. Note that the search status object reports a
+    /// responseCount well before /responses will hand the files over, so a status
+    /// poll makes short waits look adequate when they are not.
+    ///
+    /// Star-triggered downloads are fire-and-forget, so the wait costs the user
+    /// nothing; it only delays the file landing.
     /// </summary>
-    public int SearchWaitSeconds { get; set; } = 6;
+    public int SearchWaitSeconds { get; set; } = 30;
 
     /// <summary>
     /// Minimum file size in bytes to consider a search hit a real lossless file.

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -127,6 +127,16 @@ public class SubsonicSettings
     public bool AutoDetectDownloadPath { get; set; } = true;
 
     /// <summary>
+    /// Which Navidrome library to download into, given as its folder path, for
+    /// servers that serve more than one. Empty (the default) keeps the historical
+    /// behaviour of taking the first library Navidrome reports. A value that no
+    /// longer matches any reported library is ignored with a warning rather than
+    /// leaving downloads with nowhere to go.
+    /// Environment variable: SUBSONIC__LIBRARYPATH
+    /// </summary>
+    public string LibraryPath { get; set; } = "";
+
+    /// <summary>
     /// Explicit content filter mode (default: All)
     /// Environment variable: EXPLICIT_FILTER
     /// Values: "All", "ExplicitOnly", "CleanOnly"

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -64,9 +64,9 @@ builder.Services.AddSingleton<YouTubeResolver>();
 builder.Services.AddHttpClient(YouTubeResolver.SearchClientName, c =>
 {
     // 60s rather than 30s because back-to-back search3 prewarm bursts can fill
-    // the shim's MAX_CONCURRENT_YTDLP=8 gate and queue requests behind 5-8s
-    // yt-dlp ytsearch1: invocations. 30s was canceling the tail of every
-    // prewarm batch.
+    // the shim's yt-dlp gate (MAX_CONCURRENT_YTDLP, which ships as 5) and queue
+    // requests behind 5-8s yt-dlp ytsearch1: invocations. 30s was canceling the
+    // tail of every prewarm batch.
     c.Timeout = TimeSpan.FromSeconds(60);
 });
 builder.Services.AddHttpClient(YouTubeResolver.StreamClientName, c =>

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -77,6 +77,11 @@ builder.Services.AddSingleton<ExternalIdRegistry>();
 builder.Services.AddSingleton<RadioQueueStore>();
 builder.Services.AddSingleton<Octo.Services.Subsonic.NavidromeIdentityService>();
 builder.Services.AddSingleton<Octo.Services.Subsonic.SubsonicDiscoveryService>();
+builder.Services.AddSingleton<Octo.Services.Admin.DirectoryBrowser>();
+// Singleton so browse tokens survive between requests; they are in-memory only,
+// so a restart ends every browse session, which is the right trade for a token
+// that grants filesystem visibility.
+builder.Services.AddSingleton<Octo.Services.Admin.BrowseSessionStore>();
 builder.Services.AddSingleton<Octo.Services.Metadata.DeezerMetadataService>();
 
 // Deezer's public API allows roughly 50 requests per 5 seconds and signals refusal with

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -42,6 +42,8 @@ builder.Services.Configure<SoulseekSettings>(
     builder.Configuration.GetSection("Soulseek"));
 builder.Services.Configure<LastFmSettings>(
     builder.Configuration.GetSection("LastFm"));
+builder.Services.Configure<NotificationSettings>(
+    builder.Configuration.GetSection("Notifications"));
 
 builder.Services.AddSingleton<ILocalLibraryService, LocalLibraryService>();
 
@@ -114,6 +116,18 @@ builder.Services.Configure<HostOptions>(o => o.ShutdownTimeout = TimeSpan.FromSe
 
 builder.Services.AddHttpClient<LastFmService>();
 builder.Services.AddSingleton<LastFmService>();
+
+// Push notifications (ntfy / Discord webhook). The orchestrator takes
+// IEnumerable<INotificationSink>, so adding a transport is one registration line.
+// Short timeout on purpose: a slow notification server must never be felt
+// anywhere near the download path.
+builder.Services.AddHttpClient(Octo.Services.Notifications.NotificationService.ClientName,
+    c => c.Timeout = TimeSpan.FromSeconds(10));
+builder.Services.AddSingleton<Octo.Services.Notifications.INotificationSink,
+    Octo.Services.Notifications.NtfySink>();
+builder.Services.AddSingleton<Octo.Services.Notifications.INotificationSink,
+    Octo.Services.Notifications.DiscordSink>();
+builder.Services.AddSingleton<Octo.Services.Notifications.NotificationService>();
 
 builder.Services.AddSingleton<IStartupValidator, SubsonicStartupValidator>();
 builder.Services.AddSingleton<IStartupValidator, SoulseekStartupValidator>();

--- a/octo/Services/Admin/BrowseSessionStore.cs
+++ b/octo/Services/Admin/BrowseSessionStore.cs
@@ -1,0 +1,57 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+
+namespace Octo.Services.Admin;
+
+/// <summary>
+/// Short-lived tokens proving the holder authenticated as a Navidrome admin.
+///
+/// The admin UI has no authentication of its own, which is tolerable for settings
+/// on a LAN but not for an endpoint that lists directories: unauthenticated, that
+/// would make every Octo install an arbitrary directory-enumeration service. Rather
+/// than invent a login system, the browse endpoints verify credentials against the
+/// Navidrome that Octo already fronts and hand back one of these.
+///
+/// In memory only, and deliberately not persisted: a restart invalidating every
+/// browse session is the correct trade for a token that grants filesystem visibility.
+/// </summary>
+public class BrowseSessionStore
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(15);
+
+    private readonly ConcurrentDictionary<string, (string User, DateTime Expires)> _sessions = new();
+
+    /// <summary>Mint a token for a verified admin. Sliding expiry starts now.</summary>
+    public string Create(string username)
+    {
+        Prune();
+        var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+        _sessions[token] = (username, DateTime.UtcNow.Add(Ttl));
+        return token;
+    }
+
+    /// <summary>
+    /// True when the token is live. Valid use slides the expiry, so a user browsing
+    /// steadily is not logged out mid-task while an abandoned token still lapses.
+    /// </summary>
+    public bool Validate(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token)) return false;
+        if (!_sessions.TryGetValue(token, out var session)) return false;
+        if (session.Expires <= DateTime.UtcNow)
+        {
+            _sessions.TryRemove(token, out _);
+            return false;
+        }
+        _sessions[token] = (session.User, DateTime.UtcNow.Add(Ttl));
+        return true;
+    }
+
+    private void Prune()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var kv in _sessions)
+            if (kv.Value.Expires <= now)
+                _sessions.TryRemove(kv.Key, out _);
+    }
+}

--- a/octo/Services/Admin/BrowseSessionStore.cs
+++ b/octo/Services/Admin/BrowseSessionStore.cs
@@ -17,7 +17,13 @@ namespace Octo.Services.Admin;
 /// </summary>
 public class BrowseSessionStore
 {
-    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(15);
+    /// <summary>
+    /// Sliding lifetime of a browse session. Long enough that configuring a server
+    /// is not punctuated by repeated sign-ins, short enough that an unattended
+    /// browser does not stay authorised indefinitely. The token is HttpOnly and
+    /// SameSite=Strict, so reaching it means reaching the machine.
+    /// </summary>
+    public static readonly TimeSpan Ttl = TimeSpan.FromHours(12);
 
     private readonly ConcurrentDictionary<string, (string User, DateTime Expires)> _sessions = new();
 

--- a/octo/Services/Admin/DirectoryBrowser.cs
+++ b/octo/Services/Admin/DirectoryBrowser.cs
@@ -1,0 +1,131 @@
+namespace Octo.Services.Admin;
+
+/// <summary>One directory offered to the picker.</summary>
+public record BrowseEntry(string Name, string Path, bool Writable);
+
+/// <summary>A directory listing: where we are, where up is, and what is here.</summary>
+public record BrowseResult(
+    string Path,
+    string? Parent,
+    string Separator,
+    bool Writable,
+    bool Exists,
+    IReadOnlyList<BrowseEntry> Entries,
+    bool Truncated);
+
+/// <summary>
+/// Lists directories so the admin UI can pick a download folder instead of the user
+/// typing one from memory and discovering later that downloads landed somewhere
+/// Navidrome never scans.
+///
+/// This browses Octo's OWN view of the filesystem, which under Docker is the
+/// container's mount namespace, not the host's drives. That is the useful view: what
+/// matters is where Octo can write, not where the host thinks the files are.
+///
+/// Directories only, never file names. Choosing a library folder does not need them,
+/// and leaving them out keeps the amount this endpoint can disclose to the minimum
+/// the feature actually requires.
+/// </summary>
+public class DirectoryBrowser
+{
+    /// <summary>A pathological directory must not hang the UI or the response.</summary>
+    public const int MaxEntries = 1000;
+
+    private readonly ILogger<DirectoryBrowser> _logger;
+
+    public DirectoryBrowser(ILogger<DirectoryBrowser> logger) => _logger = logger;
+
+    public BrowseResult Browse(string? path)
+    {
+        var separator = Path.DirectorySeparatorChar.ToString();
+
+        // No path means "start somewhere sensible", which differs by platform: on
+        // Windows there is no single root to enumerate, so offer the drives.
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return OperatingSystem.IsWindows()
+                ? new BrowseResult("", null, separator, false, true, Drives(), false)
+                : Listing("/", separator);
+        }
+
+        // Canonicalise before anything else so what we list is exactly what we
+        // report back, and a caller cannot describe one directory and be shown
+        // another via `..` segments.
+        string full;
+        try
+        {
+            full = Path.GetFullPath(path.Trim());
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            _logger.LogDebug("browse: rejected path {Path}: {Msg}", path, ex.Message);
+            return new BrowseResult(path, null, separator, false, false, Array.Empty<BrowseEntry>(), false);
+        }
+
+        return Listing(full, separator);
+    }
+
+    private static List<BrowseEntry> Drives() =>
+        DriveInfo.GetDrives()
+            .Where(d => d.IsReady)
+            .Select(d => new BrowseEntry(d.Name, d.RootDirectory.FullName, IsWritable(d.RootDirectory.FullName)))
+            .ToList();
+
+    private BrowseResult Listing(string full, string separator)
+    {
+        if (!Directory.Exists(full))
+            return new BrowseResult(full, ParentOf(full), separator, false, false, Array.Empty<BrowseEntry>(), false);
+
+        var entries = new List<BrowseEntry>();
+        var truncated = false;
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(full))
+            {
+                if (entries.Count >= MaxEntries) { truncated = true; break; }
+                try
+                {
+                    entries.Add(new BrowseEntry(Path.GetFileName(dir), dir, IsWritable(dir)));
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                {
+                    // One unreadable subdirectory must not fail the whole listing.
+                    _logger.LogDebug("browse: skipping {Dir}: {Msg}", dir, ex.Message);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            _logger.LogDebug("browse: cannot enumerate {Path}: {Msg}", full, ex.Message);
+            return new BrowseResult(full, ParentOf(full), separator, false, true, Array.Empty<BrowseEntry>(), false);
+        }
+
+        entries.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        return new BrowseResult(full, ParentOf(full), separator, IsWritable(full), true, entries, truncated);
+    }
+
+    private static string? ParentOf(string full)
+    {
+        try { return Directory.GetParent(full)?.FullName; }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Prove write access by writing, rather than inferring it from existence.
+    /// The whole point of the picker is to stop a user choosing a folder Octo
+    /// cannot download into, and Directory.Exists says nothing about that.
+    /// </summary>
+    internal static bool IsWritable(string dir)
+    {
+        try
+        {
+            var probe = Path.Combine(dir, $".octo-write-probe-{Guid.NewGuid():N}");
+            using (File.Create(probe, 1, FileOptions.DeleteOnClose)) { }
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/octo/Services/Admin/DirectoryBrowser.cs
+++ b/octo/Services/Admin/DirectoryBrowser.cs
@@ -3,7 +3,11 @@ namespace Octo.Services.Admin;
 /// <summary>One directory offered to the picker.</summary>
 public record BrowseEntry(string Name, string Path, bool Writable);
 
-/// <summary>A directory listing: where we are, where up is, and what is here.</summary>
+/// <summary>A directory listing: where we are, where up is, and what is here.
+/// <paramref name="AudioFiles"/> counts audio files directly in this folder. It
+/// exists because listing directories alone makes a flat library — thousands of
+/// loose tracks and a handful of album folders — look almost empty, giving no way
+/// to tell the right folder from a stray one.</summary>
 public record BrowseResult(
     string Path,
     string? Parent,
@@ -11,7 +15,8 @@ public record BrowseResult(
     bool Writable,
     bool Exists,
     IReadOnlyList<BrowseEntry> Entries,
-    bool Truncated);
+    bool Truncated,
+    int AudioFiles);
 
 /// <summary>
 /// Lists directories so the admin UI can pick a download folder instead of the user
@@ -31,6 +36,17 @@ public class DirectoryBrowser
     /// <summary>A pathological directory must not hang the UI or the response.</summary>
     public const int MaxEntries = 1000;
 
+    /// <summary>
+    /// Extensions counted as music. Only the count is ever reported, never the
+    /// file names, so the picker can say "2,352 tracks here" without turning into
+    /// a file lister.
+    /// </summary>
+    private static readonly HashSet<string> AudioExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".flac", ".mp3", ".m4a", ".aac", ".ogg", ".oga", ".opus",
+        ".wav", ".wma", ".aiff", ".aif", ".ape", ".wv", ".mpc", ".dsf", ".dff",
+    };
+
     private readonly ILogger<DirectoryBrowser> _logger;
 
     public DirectoryBrowser(ILogger<DirectoryBrowser> logger) => _logger = logger;
@@ -44,7 +60,7 @@ public class DirectoryBrowser
         if (string.IsNullOrWhiteSpace(path))
         {
             return OperatingSystem.IsWindows()
-                ? new BrowseResult("", null, separator, false, true, Drives(), false)
+                ? new BrowseResult("", null, separator, false, true, Drives(), false, 0)
                 : Listing("/", separator);
         }
 
@@ -59,7 +75,7 @@ public class DirectoryBrowser
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
         {
             _logger.LogDebug("browse: rejected path {Path}: {Msg}", path, ex.Message);
-            return new BrowseResult(path, null, separator, false, false, Array.Empty<BrowseEntry>(), false);
+            return new BrowseResult(path, null, separator, false, false, Array.Empty<BrowseEntry>(), false, 0);
         }
 
         return Listing(full, separator);
@@ -74,34 +90,46 @@ public class DirectoryBrowser
     private BrowseResult Listing(string full, string separator)
     {
         if (!Directory.Exists(full))
-            return new BrowseResult(full, ParentOf(full), separator, false, false, Array.Empty<BrowseEntry>(), false);
+            return new BrowseResult(full, ParentOf(full), separator, false, false, Array.Empty<BrowseEntry>(), false, 0);
 
         var entries = new List<BrowseEntry>();
         var truncated = false;
+        var audioFiles = 0;
         try
         {
-            foreach (var dir in Directory.EnumerateDirectories(full))
+            // One pass over the directory yields both the subfolders and the audio
+            // count. Counting is free here because the enumeration is already
+            // happening; doing it per subfolder instead would cost a round trip
+            // each, and on a cloud mount that is seconds per folder.
+            foreach (var item in Directory.EnumerateFileSystemEntries(full))
             {
-                if (entries.Count >= MaxEntries) { truncated = true; break; }
                 try
                 {
-                    entries.Add(new BrowseEntry(Path.GetFileName(dir), dir, IsWritable(dir)));
+                    if (Directory.Exists(item))
+                    {
+                        if (entries.Count >= MaxEntries) { truncated = true; continue; }
+                        entries.Add(new BrowseEntry(Path.GetFileName(item), item, IsWritable(item)));
+                    }
+                    else if (AudioExtensions.Contains(Path.GetExtension(item)))
+                    {
+                        audioFiles++;
+                    }
                 }
                 catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
                 {
-                    // One unreadable subdirectory must not fail the whole listing.
-                    _logger.LogDebug("browse: skipping {Dir}: {Msg}", dir, ex.Message);
+                    // One unreadable entry must not fail the whole listing.
+                    _logger.LogDebug("browse: skipping {Item}: {Msg}", item, ex.Message);
                 }
             }
         }
         catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
         {
             _logger.LogDebug("browse: cannot enumerate {Path}: {Msg}", full, ex.Message);
-            return new BrowseResult(full, ParentOf(full), separator, false, true, Array.Empty<BrowseEntry>(), false);
+            return new BrowseResult(full, ParentOf(full), separator, false, true, Array.Empty<BrowseEntry>(), false, 0);
         }
 
         entries.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
-        return new BrowseResult(full, ParentOf(full), separator, IsWritable(full), true, entries, truncated);
+        return new BrowseResult(full, ParentOf(full), separator, IsWritable(full), true, entries, truncated, audioFiles);
     }
 
     private static string? ParentOf(string full)

--- a/octo/Services/Common/AcquisitionWorker.cs
+++ b/octo/Services/Common/AcquisitionWorker.cs
@@ -1,3 +1,6 @@
+using Octo.Services.Notifications;
+using Octo.Services.Soulseek;
+
 namespace Octo.Services.Common;
 
 /// <summary>
@@ -13,13 +16,18 @@ public sealed class AcquisitionWorker : BackgroundService
 {
     private readonly TrackAcquisitionQueue _queue;
     private readonly IDownloadService _downloads;
+    private readonly ExternalIdRegistry _idRegistry;
+    private readonly NotificationService _notifications;
     private readonly ILogger<AcquisitionWorker> _logger;
 
     public AcquisitionWorker(TrackAcquisitionQueue queue, IDownloadService downloads,
+        ExternalIdRegistry idRegistry, NotificationService notifications,
         ILogger<AcquisitionWorker> logger)
     {
         _queue = queue;
         _downloads = downloads;
+        _idRegistry = idRegistry;
+        _notifications = notifications;
         _logger = logger;
     }
 
@@ -60,6 +68,12 @@ public sealed class AcquisitionWorker : BackgroundService
             {
                 _logger.LogError(ex, "Acquisition failed for {Provider}:{Id}",
                     request.Provider, request.ExternalId);
+                // Stars only: a shed play-triggered acquisition is a hint, a failed
+                // star is the user's explicit ask going unmet. This is the one place
+                // a terminal failure surfaces exactly once per gesture (album-walk
+                // per-track failures are caught inside the walk and aggregate into
+                // its summary instead).
+                if (request.IsStar) NotifyFailed(request, ex);
                 request.Completion.TrySetException(ex);
             }
             finally
@@ -71,5 +85,32 @@ public sealed class AcquisitionWorker : BackgroundService
         }
 
         _logger.LogInformation("Acquisition worker stopped");
+    }
+
+    /// <summary>
+    /// Own try/catch on purpose: a notification error must never disturb the
+    /// TrySetException/queue-release bookkeeping around it. Metadata comes from the
+    /// same routing pair the download path itself uses, so the names match what the
+    /// user starred.
+    /// </summary>
+    private void NotifyFailed(AcquisitionRequest request, Exception ex)
+    {
+        try
+        {
+            var routing = _idRegistry.Lookup(request.ExternalId)
+                ?? SoulseekMetadataService.TryDecodeExternalId(request.ExternalId);
+            _notifications.Notify(new NotificationEvent
+            {
+                Type = NotificationEventType.DownloadFailed,
+                Artist = routing?.Artist,
+                Title = routing?.Title,
+                Album = routing?.Album,
+                Detail = ex.Message,
+            });
+        }
+        catch (Exception nex)
+        {
+            _logger.LogWarning("Failure notification skipped: {Msg}", nex.Message);
+        }
     }
 }

--- a/octo/Services/Common/BaseDownloadService.cs
+++ b/octo/Services/Common/BaseDownloadService.cs
@@ -26,6 +26,7 @@ public abstract class BaseDownloadService : IDownloadService
     private readonly IServiceProvider _serviceProvider;
     private readonly NavidromeIdentityService _navIdentity;
     private readonly DownloadHistoryService _history;
+    protected readonly Octo.Services.Notifications.NotificationService Notifications;
 
     // The configured Library:DownloadPath. With auto-detect on this is only a
     // fallback used until Navidrome's real music folder is detected.
@@ -73,6 +74,7 @@ public abstract class BaseDownloadService : IDownloadService
         SubsonicSettings subsonicSettings,
         NavidromeIdentityService navIdentity,
         DownloadHistoryService history,
+        Octo.Services.Notifications.NotificationService notifications,
         IServiceProvider serviceProvider,
         ILogger logger)
     {
@@ -82,6 +84,7 @@ public abstract class BaseDownloadService : IDownloadService
         SubsonicSettings = subsonicSettings;
         _navIdentity = navIdentity;
         _history = history;
+        Notifications = notifications;
         _serviceProvider = serviceProvider;
         Logger = logger;
 
@@ -200,14 +203,15 @@ public abstract class BaseDownloadService : IDownloadService
     /// </summary>
     /// <param name="trackId">External track ID</param>
     /// <param name="song">Song metadata</param>
+    /// <param name="suppressNotify">Mute per-track notifications (album walk, cache fills)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Local file path where the track was saved</returns>
-    protected abstract Task<string> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken);
+    protected abstract Task<string> DownloadTrackAsync(string trackId, Song song, bool suppressNotify, CancellationToken cancellationToken);
 
     /// <summary>Record a completed download in the fetched-songs log. Best-effort:
     /// format + source are derived from the file extension (flac -> Soulseek/lossless,
     /// otherwise -> YouTube/lossy), which matches Octo's two download sources.</summary>
-    private async Task RecordHistoryAsync(Song song, string localPath)
+    private async Task RecordHistoryAsync(Song song, string localPath, bool suppressNotify)
     {
         try
         {
@@ -250,6 +254,24 @@ public abstract class BaseDownloadService : IDownloadService
                 SizeBytes = size,
                 DownloadedAt = DateTime.UtcNow.ToString("o"),
             });
+
+            // Same chokepoint as the fetched-songs log, reusing the locals it just
+            // assembled (Deezer-enriched cover and album included) — anything worth
+            // logging is worth telling the user about, with the same data.
+            if (!suppressNotify)
+            {
+                Notifications.Notify(new Octo.Services.Notifications.NotificationEvent
+                {
+                    Type = Octo.Services.Notifications.NotificationEventType.DownloadCompleted,
+                    Artist = song.Artist,
+                    Title = song.Title,
+                    Album = album,
+                    Format = string.IsNullOrEmpty(ext) ? "?" : ext,
+                    Source = ext == "FLAC" ? "Soulseek" : "YouTube",
+                    CoverArtUrl = cover,
+                    SizeBytes = size,
+                });
+            }
         }
         catch (Exception ex)
         {
@@ -283,7 +305,11 @@ public abstract class BaseDownloadService : IDownloadService
     /// otherwise skips library registration, the fetched-songs log and the rescan, which
     /// is wrong for a deliberate "keep this" gesture like hearting an album.
     /// </param>
-    protected async Task<string> DownloadSongInternalAsync(string externalProvider, string externalId, bool triggerAlbumDownload, CancellationToken cancellationToken = default, bool forcePermanent = false)
+    /// <param name="suppressNotify">
+    /// Mute per-track notifications. Set by the album walk, which fires one summary
+    /// at the end instead of a ping per track.
+    /// </param>
+    protected async Task<string> DownloadSongInternalAsync(string externalProvider, string externalId, bool triggerAlbumDownload, CancellationToken cancellationToken = default, bool forcePermanent = false, bool suppressNotify = false)
     {
         if (externalProvider != ProviderName)
         {
@@ -292,6 +318,9 @@ public abstract class BaseDownloadService : IDownloadService
 
         var songId = $"ext-{externalProvider}-{externalId}";
         var isCache = !forcePermanent && SubsonicSettings.StorageMode == StorageMode.Cache;
+        // Cache-mode fills are background plumbing, not a user gesture: they skip the
+        // fetched-songs log, so they skip notifications for the same reason.
+        var silence = suppressNotify || isCache;
         
         // Acquire lock BEFORE checking existence to prevent race conditions with concurrent requests
         await DownloadLock.WaitAsync(cancellationToken);
@@ -398,7 +427,7 @@ public abstract class BaseDownloadService : IDownloadService
             // orphan that Octo has no record of. A client giving up on a slow
             // download used to abort exactly here, which is why a completed
             // download could never be played.
-            var localPath = await DownloadTrackAsync(externalId, song, cancellationToken);
+            var localPath = await DownloadTrackAsync(externalId, song, silence, cancellationToken);
 
             downloadInfo.Status = DownloadStatus.Completed;
             downloadInfo.LocalPath = localPath;
@@ -434,7 +463,7 @@ public abstract class BaseDownloadService : IDownloadService
             if (!isCache)
             {
                 await LocalLibraryService.RegisterDownloadedSongAsync(song, localPath);
-                await RecordHistoryAsync(song, localPath);
+                await RecordHistoryAsync(song, localPath, silence);
 
                 // Trigger a Subsonic library rescan (with debounce)
                 _ = Task.Run(async () =>
@@ -500,8 +529,11 @@ public abstract class BaseDownloadService : IDownloadService
             .Where(s => s.ExternalId != excludeTrackExternalId && !string.IsNullOrEmpty(s.ExternalId))
             .ToList();
 
-        Logger.LogInformation("Found {Count} additional tracks to download for album '{AlbumTitle}'", 
+        Logger.LogInformation("Found {Count} additional tracks to download for album '{AlbumTitle}'",
             tracksToDownload.Count, album.Title);
+
+        // Per-track notifications are muted below; these feed one summary instead.
+        int succeeded = 0, lossless = 0, failed = 0;
 
         foreach (var track in tracksToDownload)
         {
@@ -534,7 +566,9 @@ public abstract class BaseDownloadService : IDownloadService
                 }
 
                 Logger.LogInformation("Downloading track '{Title}' from album '{Album}'", track.Title, album.Title);
-                await DownloadSongInternalAsync(ProviderName, track.ExternalId!, triggerAlbumDownload: false, CancellationToken.None, forcePermanent: true);
+                var path = await DownloadSongInternalAsync(ProviderName, track.ExternalId!, triggerAlbumDownload: false, CancellationToken.None, forcePermanent: true, suppressNotify: true);
+                succeeded++;
+                if (path.EndsWith(".flac", StringComparison.OrdinalIgnoreCase)) lossless++;
 
                 // Force a rescan per track so the album fills in progressively in the
                 // client instead of appearing all at once at the end. The per-download
@@ -545,11 +579,33 @@ public abstract class BaseDownloadService : IDownloadService
             catch (Exception ex)
             {
                 Logger.LogWarning(ex, "Failed to download track {TrackId} '{Title}'", track.ExternalId, track.Title);
+                failed++;
             }
         }
 
         Logger.LogInformation("Completed background download for album '{AlbumTitle}'", album.Title);
+
+        var summary = BuildAlbumSummary(album, succeeded, lossless, failed);
+        if (summary is not null) Notifications.Notify(summary);
     }
+
+    /// <summary>
+    /// Null when the walk did no work — a re-star whose tracks are all already
+    /// present must not ping the phone. Counts cover the walked tracks only; the
+    /// track whose star triggered the walk got its own DownloadCompleted.
+    /// </summary>
+    internal static Octo.Services.Notifications.NotificationEvent? BuildAlbumSummary(
+        Album album, int succeeded, int lossless, int failed)
+        => succeeded + failed == 0 ? null : new Octo.Services.Notifications.NotificationEvent
+        {
+            Type = Octo.Services.Notifications.NotificationEventType.AlbumCompleted,
+            Artist = album.Artist,
+            Title = album.Title,
+            CoverArtUrl = album.CoverArtUrl,
+            TrackCount = succeeded,
+            LosslessCount = lossless,
+            FailedCount = failed,
+        };
     
     #endregion
     

--- a/octo/Services/Common/BaseDownloadService.cs
+++ b/octo/Services/Common/BaseDownloadService.cs
@@ -270,6 +270,10 @@ public abstract class BaseDownloadService : IDownloadService
                     Source = ext == "FLAC" ? "Soulseek" : "YouTube",
                     CoverArtUrl = cover,
                     SizeBytes = size,
+                    // EnrichAndTagAsync ran before this hook, so these are the
+                    // Deezer-enriched values the file itself was tagged with.
+                    DurationSeconds = song.Duration,
+                    Year = song.Year,
                 });
             }
         }

--- a/octo/Services/CoverArt/CoverArtService.cs
+++ b/octo/Services/CoverArt/CoverArtService.cs
@@ -127,9 +127,16 @@ public class CoverArtService
     /// background. Used when iTunes lookup whiffs so we never 404 a cover-art
     /// request — Subsonic clients drop entries whose cover fetch fails.
     /// </summary>
-    public byte[] GetPlaceholderCover()
+    /// <param name="branded">
+    /// Whether to stamp the Octo logo. True for external tracks, where the badge
+    /// says where the track came from. **False for anything in the user's own
+    /// library**: a local file that simply has no embedded art, or whose art could
+    /// not be read in time, is not Octo's, and branding it reads as Octo claiming
+    /// a song the user already owned.
+    /// </param>
+    public byte[] GetPlaceholderCover(bool branded = true)
     {
-        var logo = GetOctoLogo();
+        var logo = branded ? GetOctoLogo() : null;
         const int Size = 600;
 
         try

--- a/octo/Services/Notifications/DiscordSink.cs
+++ b/octo/Services/Notifications/DiscordSink.cs
@@ -40,14 +40,39 @@ public sealed class DiscordSink : INotificationSink
         var embed = new JsonObject
         {
             ["title"] = Truncate(message.Title, 256),
-            ["description"] = Truncate(message.Body, 4096),
             ["color"] = ColorFor(message.Type),
             ["footer"] = new JsonObject { ["text"] = "Octo" },
             ["timestamp"] = DateTime.UtcNow.ToString("o"),
         };
-        // Key omitted entirely when there is no cover: Discord rejects a null url.
-        if (!string.IsNullOrEmpty(message.ImageUrl))
-            embed["thumbnail"] = new JsonObject { ["url"] = message.ImageUrl };
+
+        if (message.Fields is { Count: > 0 })
+        {
+            // Song-card layout: the album as the description line, the stats as
+            // inline fields (Discord flows up to three per row), and the cover
+            // full-width. Body prose is NOT repeated here — the fields carry the
+            // same facts, structured.
+            if (!string.IsNullOrEmpty(message.Description))
+                embed["description"] = Truncate(message.Description, 4096);
+            embed["fields"] = new JsonArray(message.Fields
+                .Select(f => (JsonNode)new JsonObject
+                {
+                    ["name"] = Truncate(f.Key, 256),
+                    ["value"] = Truncate(f.Value, 1024),
+                    ["inline"] = true,
+                })
+                .ToArray());
+            // Full-width art, not the corner thumbnail: on a song card the cover
+            // IS the card.
+            if (!string.IsNullOrEmpty(message.ImageUrl))
+                embed["image"] = new JsonObject { ["url"] = message.ImageUrl };
+        }
+        else
+        {
+            embed["description"] = Truncate(message.Body, 4096);
+            // Key omitted entirely when there is no cover: Discord rejects a null url.
+            if (!string.IsNullOrEmpty(message.ImageUrl))
+                embed["thumbnail"] = new JsonObject { ["url"] = message.ImageUrl };
+        }
 
         return new JsonObject { ["embeds"] = new JsonArray(embed) };
     }

--- a/octo/Services/Notifications/DiscordSink.cs
+++ b/octo/Services/Notifications/DiscordSink.cs
@@ -1,0 +1,67 @@
+using System.Text;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
+
+namespace Octo.Services.Notifications;
+
+/// <summary>
+/// Discord webhook transport. One rich embed and no top-level content, which both
+/// looks better (thumbnail album art) and sidesteps the 2000-character content
+/// limit entirely; a request with embeds and no content is valid per the API.
+/// </summary>
+public sealed class DiscordSink : INotificationSink
+{
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly IOptionsMonitor<NotificationSettings> _opts;
+
+    public DiscordSink(IHttpClientFactory httpFactory, IOptionsMonitor<NotificationSettings> opts)
+    {
+        _httpFactory = httpFactory;
+        _opts = opts;
+    }
+
+    public string Name => "discord";
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(_opts.CurrentValue.DiscordWebhookUrl);
+
+    public async Task SendAsync(NotificationMessage message, CancellationToken ct)
+    {
+        var http = _httpFactory.CreateClient(NotificationService.ClientName);
+        using var content = new StringContent(
+            BuildPayload(message).ToJsonString(), Encoding.UTF8, "application/json");
+        using var resp = await http.PostAsync(_opts.CurrentValue.DiscordWebhookUrl, content, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>Static so tests pin the exact wire shape without HTTP.</summary>
+    internal static JsonObject BuildPayload(NotificationMessage message)
+    {
+        var embed = new JsonObject
+        {
+            ["title"] = Truncate(message.Title, 256),
+            ["description"] = Truncate(message.Body, 4096),
+            ["color"] = ColorFor(message.Type),
+            ["footer"] = new JsonObject { ["text"] = "Octo" },
+            ["timestamp"] = DateTime.UtcNow.ToString("o"),
+        };
+        // Key omitted entirely when there is no cover: Discord rejects a null url.
+        if (!string.IsNullOrEmpty(message.ImageUrl))
+            embed["thumbnail"] = new JsonObject { ["url"] = message.ImageUrl };
+
+        return new JsonObject { ["embeds"] = new JsonArray(embed) };
+    }
+
+    internal static int ColorFor(NotificationEventType type) => type switch
+    {
+        NotificationEventType.DownloadStarted => 0x3B82F6,
+        NotificationEventType.DownloadCompleted => 0x22C55E,
+        NotificationEventType.LosslessFallback => 0xF59E0B,
+        NotificationEventType.DownloadFailed => 0xEF4444,
+        NotificationEventType.AlbumCompleted => 0x8B5CF6,
+        _ => 0x64748B,
+    };
+
+    internal static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..max];
+}

--- a/octo/Services/Notifications/INotificationSink.cs
+++ b/octo/Services/Notifications/INotificationSink.cs
@@ -1,0 +1,26 @@
+namespace Octo.Services.Notifications;
+
+/// <summary>
+/// One notification transport. Sinks MAY throw from SendAsync — the orchestrator
+/// owns the catch for pipeline events, and the admin test endpoint wants the real
+/// error text rather than a swallowed failure.
+/// </summary>
+public interface INotificationSink
+{
+    /// <summary>Stable short name for logs and the test endpoint ("ntfy", "discord").</summary>
+    string Name { get; }
+
+    /// <summary>True when this sink's URL is non-empty in current settings. Reads
+    /// IOptionsMonitor at call time, so toggling in the admin UI applies without a
+    /// restart.</summary>
+    bool IsConfigured { get; }
+
+    Task SendAsync(NotificationMessage message, CancellationToken ct);
+}
+
+/// <summary>Transport-agnostic rendered content, produced once per event.</summary>
+public sealed record NotificationMessage(
+    NotificationEventType Type, string Title, string Body, string? ImageUrl);
+
+/// <summary>Per-sink outcome of the admin "Send test" button.</summary>
+public sealed record NotificationTestResult(string Sink, bool Configured, bool Ok, string Detail);

--- a/octo/Services/Notifications/INotificationSink.cs
+++ b/octo/Services/Notifications/INotificationSink.cs
@@ -18,9 +18,23 @@ public interface INotificationSink
     Task SendAsync(NotificationMessage message, CancellationToken ct);
 }
 
-/// <summary>Transport-agnostic rendered content, produced once per event.</summary>
+/// <summary>
+/// Transport-agnostic rendered content, produced once per event.
+///
+/// Body is the complete plain-text rendering and is what text-first transports
+/// (ntfy) send. Description and Fields exist for transports with layout: when
+/// Fields is non-null, Discord builds a song card — description line, inline
+/// stat fields, full-width art — instead of repeating the Body prose. Both forms
+/// are produced by the same Render call from the same event, so the transports
+/// never disagree on facts, only on formatting.
+/// </summary>
 public sealed record NotificationMessage(
-    NotificationEventType Type, string Title, string Body, string? ImageUrl);
+    NotificationEventType Type,
+    string Title,
+    string Body,
+    string? ImageUrl,
+    string? Description = null,
+    IReadOnlyList<KeyValuePair<string, string>>? Fields = null);
 
 /// <summary>Per-sink outcome of the admin "Send test" button.</summary>
 public sealed record NotificationTestResult(string Sink, bool Configured, bool Ok, string Detail);

--- a/octo/Services/Notifications/NotificationEvent.cs
+++ b/octo/Services/Notifications/NotificationEvent.cs
@@ -40,6 +40,13 @@ public sealed record NotificationEvent
     /// DownloadCompleted carries the real file's.</summary>
     public long? SizeBytes { get; init; }
 
+    /// <summary>Track length in seconds. On the completed path this is the enriched
+    /// song's duration (EnrichAndTagAsync runs before the hook); on started it is
+    /// the routing's expected duration.</summary>
+    public int? DurationSeconds { get; init; }
+
+    public int? Year { get; init; }
+
     /// <summary>Fallback reason or failure message.</summary>
     public string? Detail { get; init; }
 

--- a/octo/Services/Notifications/NotificationEvent.cs
+++ b/octo/Services/Notifications/NotificationEvent.cs
@@ -1,0 +1,51 @@
+namespace Octo.Services.Notifications;
+
+public enum NotificationEventType
+{
+    DownloadStarted,
+    DownloadCompleted,
+    LosslessFallback,
+    DownloadFailed,
+    AlbumCompleted,
+
+    /// <summary>The admin "Send test" button. Always allowed regardless of the
+    /// per-event toggles; never fired by the download pipeline.</summary>
+    Test,
+}
+
+/// <summary>
+/// One thing that happened, in domain terms. Rendering to title/body text happens
+/// once in <see cref="NotificationService.Render"/> so every transport says the
+/// same thing. All fields except Type are optional on purpose: events fire from
+/// paths where metadata may be partial, and a missing field must degrade the text,
+/// never the send.
+/// </summary>
+public sealed record NotificationEvent
+{
+    public required NotificationEventType Type { get; init; }
+
+    public string? Artist { get; init; }
+    public string? Title { get; init; }
+    public string? Album { get; init; }
+
+    /// <summary>"FLAC" / "MP3" / "M4A".</summary>
+    public string? Format { get; init; }
+
+    /// <summary>"Soulseek" / "YouTube".</summary>
+    public string? Source { get; init; }
+
+    public string? CoverArtUrl { get; init; }
+
+    /// <summary>For DownloadStarted this is the chosen candidate's advertised size;
+    /// DownloadCompleted carries the real file's.</summary>
+    public long? SizeBytes { get; init; }
+
+    /// <summary>Fallback reason or failure message.</summary>
+    public string? Detail { get; init; }
+
+    // AlbumCompleted only. Counts cover the walked tracks; the track whose star
+    // triggered the walk got its own DownloadCompleted.
+    public int? TrackCount { get; init; }
+    public int? LosslessCount { get; init; }
+    public int? FailedCount { get; init; }
+}

--- a/octo/Services/Notifications/NotificationService.cs
+++ b/octo/Services/Notifications/NotificationService.cs
@@ -104,7 +104,9 @@ public sealed class NotificationService
         _ => false,
     };
 
-    /// <summary>Single source of truth for the text both transports carry.</summary>
+    /// <summary>Single source of truth for the text both transports carry. Track
+    /// events additionally get structured stat fields so layout-capable transports
+    /// can render a song card instead of prose.</summary>
     internal static NotificationMessage Render(NotificationEvent evt)
     {
         var track = string.IsNullOrEmpty(evt.Artist) ? evt.Title ?? "unknown track"
@@ -116,15 +118,20 @@ public sealed class NotificationService
                 evt.Type,
                 $"Downloading: {track}",
                 $"{evt.Format} via {evt.Source}" + (evt.SizeBytes is long sb and > 0 ? $" ({FormatSize(sb)})" : ""),
-                evt.CoverArtUrl),
+                evt.CoverArtUrl,
+                Description: evt.Album,
+                Fields: TrackFields(evt)),
 
             NotificationEventType.DownloadCompleted => new NotificationMessage(
                 evt.Type,
                 $"Downloaded: {track}",
                 (string.IsNullOrEmpty(evt.Album) ? "" : evt.Album + "\n")
                     + $"{evt.Format} via {evt.Source}"
-                    + (evt.SizeBytes is long cb and > 0 ? $", {FormatSize(cb)}" : ""),
-                evt.CoverArtUrl),
+                    + (evt.SizeBytes is long cb and > 0 ? $", {FormatSize(cb)}" : "")
+                    + (evt.DurationSeconds is int ds and > 0 ? $" · {FormatDuration(ds)}" : ""),
+                evt.CoverArtUrl,
+                Description: evt.Album,
+                Fields: TrackFields(evt)),
 
             NotificationEventType.LosslessFallback => new NotificationMessage(
                 evt.Type,
@@ -143,7 +150,9 @@ public sealed class NotificationService
                 $"Album complete: {track}",
                 $"{evt.TrackCount} tracks fetched, {evt.LosslessCount} lossless"
                     + (evt.FailedCount is int f and > 0 ? $", {f} failed" : ""),
-                evt.CoverArtUrl),
+                evt.CoverArtUrl,
+                Description: null,
+                Fields: AlbumFields(evt)),
 
             _ => new NotificationMessage(
                 evt.Type,
@@ -153,8 +162,46 @@ public sealed class NotificationService
         };
     }
 
+    /// <summary>The stats a song card shows, in display order, skipping unknowns.
+    /// Bitrate is derived from size and duration — it describes the actual file,
+    /// which is the number a lossless-vs-lossy glance wants.</summary>
+    private static List<KeyValuePair<string, string>> TrackFields(NotificationEvent evt)
+    {
+        var fields = new List<KeyValuePair<string, string>>();
+        void Add(string name, string? value)
+        {
+            if (!string.IsNullOrEmpty(value))
+                fields.Add(new KeyValuePair<string, string>(name, value));
+        }
+
+        Add("Format", evt.Format);
+        Add("Source", evt.Source);
+        if (evt.SizeBytes is long size and > 0) Add("Size", FormatSize(size));
+        if (evt.DurationSeconds is int dur and > 0)
+        {
+            Add("Length", FormatDuration(dur));
+            if (evt.SizeBytes is long b and > 0)
+                Add("Bitrate", $"≈{b * 8 / dur / 1000:N0} kbps");
+        }
+        if (evt.Year is int year and > 0) Add("Year", year.ToString());
+        return fields;
+    }
+
+    private static List<KeyValuePair<string, string>> AlbumFields(NotificationEvent evt) =>
+        new()
+        {
+            new("Tracks", (evt.TrackCount ?? 0).ToString()),
+            new("Lossless", (evt.LosslessCount ?? 0).ToString()),
+            new("Failed", (evt.FailedCount ?? 0).ToString()),
+        };
+
     internal static string FormatSize(long bytes) =>
         bytes >= 1024L * 1024 * 1024 ? $"{bytes / (1024.0 * 1024 * 1024):F1} GB"
         : bytes >= 1024L * 1024 ? $"{bytes / (1024.0 * 1024):F1} MB"
         : $"{bytes / 1024.0:F0} KB";
+
+    internal static string FormatDuration(int seconds) =>
+        seconds >= 3600
+            ? $"{seconds / 3600}:{seconds % 3600 / 60:D2}:{seconds % 60:D2}"
+            : $"{seconds / 60}:{seconds % 60:D2}";
 }

--- a/octo/Services/Notifications/NotificationService.cs
+++ b/octo/Services/Notifications/NotificationService.cs
@@ -21,15 +21,20 @@ public sealed class NotificationService
     private readonly IReadOnlyList<INotificationSink> _sinks;
     private readonly IOptionsMonitor<NotificationSettings> _opts;
     private readonly ILogger<NotificationService> _logger;
+    private readonly Octo.Services.Metadata.DeezerMetadataService? _deezer;
 
+    // Deezer is optional so tests can construct the service without an HTTP
+    // stack; the DI container resolves it in production.
     public NotificationService(
         IEnumerable<INotificationSink> sinks,
         IOptionsMonitor<NotificationSettings> opts,
-        ILogger<NotificationService> logger)
+        ILogger<NotificationService> logger,
+        Octo.Services.Metadata.DeezerMetadataService? deezer = null)
     {
         _sinks = sinks.ToList();
         _opts = opts;
         _logger = logger;
+        _deezer = deezer;
     }
 
     /// <summary>THE publish call. Never throws and never blocks the caller.</summary>
@@ -46,6 +51,13 @@ public sealed class NotificationService
 
             var configured = _sinks.Where(s => s.IsConfigured).ToList();
             if (configured.Count == 0) return;
+
+            // Events fired from deep in the download path (Started, Fallback,
+            // Failed) only carry artist/title — the routing has no artwork. This
+            // whole method is already off the caller's path, so a cached Deezer
+            // lookup here is free and gives every event art instead of only the
+            // ones that happened to have it in scope.
+            evt = await EnsureCoverArtAsync(evt);
 
             var message = Render(evt);
             await Task.WhenAll(configured.Select(async sink =>
@@ -90,6 +102,29 @@ public sealed class NotificationService
             }
         }
         return results;
+    }
+
+    /// <summary>Best-effort: fills a missing cover (and album) from Deezer's cached
+    /// lookup. Any failure returns the event untouched — art is decoration, and
+    /// decoration must never delay or break a notification.</summary>
+    private async Task<NotificationEvent> EnsureCoverArtAsync(NotificationEvent evt)
+    {
+        if (!string.IsNullOrEmpty(evt.CoverArtUrl) || _deezer is null) return evt;
+        if (string.IsNullOrEmpty(evt.Artist) || string.IsNullOrEmpty(evt.Title)) return evt;
+        try
+        {
+            var meta = await _deezer.EnrichTrackAsync(evt.Artist, evt.Title, includeYear: false);
+            if (meta is null) return evt;
+            return evt with
+            {
+                CoverArtUrl = meta.AlbumCoverUrl,
+                Album = string.IsNullOrEmpty(evt.Album) ? meta.AlbumTitle : evt.Album,
+            };
+        }
+        catch
+        {
+            return evt;
+        }
     }
 
     internal static bool IsEnabled(NotificationSettings s, NotificationEventType type) => type switch

--- a/octo/Services/Notifications/NotificationService.cs
+++ b/octo/Services/Notifications/NotificationService.cs
@@ -1,0 +1,160 @@
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
+
+namespace Octo.Services.Notifications;
+
+/// <summary>
+/// Fans one domain event out to every configured transport, if its toggle is on.
+///
+/// The one unforgivable failure here would be disturbing a download, so the public
+/// entry point is fire-and-forget and the whole dispatch is caught at two levels:
+/// once around the body, and once per sink so one transport being down cannot delay
+/// or kill the other. Rendering happens exactly once so ntfy and Discord always say
+/// the same thing.
+/// </summary>
+public sealed class NotificationService
+{
+    /// <summary>Named HttpClient with a short timeout: a slow notification server
+    /// must never be felt anywhere near the download path.</summary>
+    public const string ClientName = "notifications";
+
+    private readonly IReadOnlyList<INotificationSink> _sinks;
+    private readonly IOptionsMonitor<NotificationSettings> _opts;
+    private readonly ILogger<NotificationService> _logger;
+
+    public NotificationService(
+        IEnumerable<INotificationSink> sinks,
+        IOptionsMonitor<NotificationSettings> opts,
+        ILogger<NotificationService> logger)
+    {
+        _sinks = sinks.ToList();
+        _opts = opts;
+        _logger = logger;
+    }
+
+    /// <summary>THE publish call. Never throws and never blocks the caller.</summary>
+    public void Notify(NotificationEvent evt) => _ = NotifyInternalAsync(evt);
+
+    /// <summary>Awaitable core, internal so tests can pin behavior deterministically
+    /// instead of racing a discarded task.</summary>
+    internal async Task NotifyInternalAsync(NotificationEvent evt)
+    {
+        try
+        {
+            var settings = _opts.CurrentValue;
+            if (!IsEnabled(settings, evt.Type)) return;
+
+            var configured = _sinks.Where(s => s.IsConfigured).ToList();
+            if (configured.Count == 0) return;
+
+            var message = Render(evt);
+            await Task.WhenAll(configured.Select(async sink =>
+            {
+                try
+                {
+                    await sink.SendAsync(message, CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Notification via {Sink} failed: {Msg}", sink.Name, ex.Message);
+                }
+            }));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Notification dispatch failed: {Msg}", ex.Message);
+        }
+    }
+
+    /// <summary>Admin test button. Unlike Notify this awaits every sink and reports
+    /// each outcome, including the transport's real error text on failure.</summary>
+    public async Task<IReadOnlyList<NotificationTestResult>> SendTestAsync(CancellationToken ct)
+    {
+        var message = Render(new NotificationEvent { Type = NotificationEventType.Test });
+        var results = new List<NotificationTestResult>();
+        foreach (var sink in _sinks)
+        {
+            if (!sink.IsConfigured)
+            {
+                results.Add(new NotificationTestResult(sink.Name, Configured: false, Ok: false, "not configured"));
+                continue;
+            }
+            try
+            {
+                await sink.SendAsync(message, ct);
+                results.Add(new NotificationTestResult(sink.Name, Configured: true, Ok: true, "delivered"));
+            }
+            catch (Exception ex)
+            {
+                results.Add(new NotificationTestResult(sink.Name, Configured: true, Ok: false, ex.Message));
+            }
+        }
+        return results;
+    }
+
+    internal static bool IsEnabled(NotificationSettings s, NotificationEventType type) => type switch
+    {
+        NotificationEventType.DownloadStarted => s.NotifyDownloadStarted,
+        NotificationEventType.DownloadCompleted => s.NotifyDownloadCompleted,
+        NotificationEventType.LosslessFallback => s.NotifyLosslessFallback,
+        NotificationEventType.DownloadFailed => s.NotifyDownloadFailed,
+        NotificationEventType.AlbumCompleted => s.NotifyAlbumCompleted,
+        // The test button bypasses toggles by design: it verifies transports.
+        NotificationEventType.Test => true,
+        _ => false,
+    };
+
+    /// <summary>Single source of truth for the text both transports carry.</summary>
+    internal static NotificationMessage Render(NotificationEvent evt)
+    {
+        var track = string.IsNullOrEmpty(evt.Artist) ? evt.Title ?? "unknown track"
+            : $"{evt.Artist} – {evt.Title}";
+
+        return evt.Type switch
+        {
+            NotificationEventType.DownloadStarted => new NotificationMessage(
+                evt.Type,
+                $"Downloading: {track}",
+                $"{evt.Format} via {evt.Source}" + (evt.SizeBytes is long sb and > 0 ? $" ({FormatSize(sb)})" : ""),
+                evt.CoverArtUrl),
+
+            NotificationEventType.DownloadCompleted => new NotificationMessage(
+                evt.Type,
+                $"Downloaded: {track}",
+                (string.IsNullOrEmpty(evt.Album) ? "" : evt.Album + "\n")
+                    + $"{evt.Format} via {evt.Source}"
+                    + (evt.SizeBytes is long cb and > 0 ? $", {FormatSize(cb)}" : ""),
+                evt.CoverArtUrl),
+
+            NotificationEventType.LosslessFallback => new NotificationMessage(
+                evt.Type,
+                $"Lossless miss: {track}",
+                $"Soulseek failed ({evt.Detail ?? "no usable result"}); settling for YouTube MP3.",
+                evt.CoverArtUrl),
+
+            NotificationEventType.DownloadFailed => new NotificationMessage(
+                evt.Type,
+                $"Download failed: {track}",
+                evt.Detail ?? "Both sources failed.",
+                evt.CoverArtUrl),
+
+            NotificationEventType.AlbumCompleted => new NotificationMessage(
+                evt.Type,
+                $"Album complete: {track}",
+                $"{evt.TrackCount} tracks fetched, {evt.LosslessCount} lossless"
+                    + (evt.FailedCount is int f and > 0 ? $", {f} failed" : ""),
+                evt.CoverArtUrl),
+
+            _ => new NotificationMessage(
+                evt.Type,
+                "Octo test notification",
+                "Transports are wired up correctly.",
+                null),
+        };
+    }
+
+    internal static string FormatSize(long bytes) =>
+        bytes >= 1024L * 1024 * 1024 ? $"{bytes / (1024.0 * 1024 * 1024):F1} GB"
+        : bytes >= 1024L * 1024 ? $"{bytes / (1024.0 * 1024):F1} MB"
+        : $"{bytes / 1024.0:F0} KB";
+}

--- a/octo/Services/Notifications/NtfySink.cs
+++ b/octo/Services/Notifications/NtfySink.cs
@@ -49,11 +49,17 @@ public sealed class NtfySink : INotificationSink
         {
             ["topic"] = topic,
             ["title"] = message.Title,
-            ["message"] = message.Body,
+            ["message"] = BuildBody(message),
             ["tags"] = new JsonArray(TagFor(message.Type)),
         };
         if (!string.IsNullOrEmpty(message.ImageUrl))
+        {
+            // Both slots on purpose: icon is what the phone shows in the
+            // notification shade next to the text, attach is the full-size art
+            // when the notification is expanded.
+            payload["icon"] = message.ImageUrl;
             payload["attach"] = message.ImageUrl;
+        }
 
         var http = _httpFactory.CreateClient(NotificationService.ClientName);
         using var req = new HttpRequestMessage(HttpMethod.Post, serverRoot)
@@ -65,6 +71,22 @@ public sealed class NtfySink : INotificationSink
 
         using var resp = await http.SendAsync(req, ct);
         resp.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    /// ntfy is plain text, so the song card renders as lines rather than embed
+    /// fields: the album on its own line, then the stats dot-separated. Built
+    /// from the same NotificationMessage as Discord's card, so the transports
+    /// carry identical facts.
+    /// </summary>
+    internal static string BuildBody(NotificationMessage message)
+    {
+        if (message.Fields is not { Count: > 0 }) return message.Body;
+
+        var stats = string.Join(" · ", message.Fields.Select(f => f.Value));
+        return string.IsNullOrEmpty(message.Description)
+            ? stats
+            : $"{message.Description}\n{stats}";
     }
 
     /// <summary>

--- a/octo/Services/Notifications/NtfySink.cs
+++ b/octo/Services/Notifications/NtfySink.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
+
+namespace Octo.Services.Notifications;
+
+/// <summary>
+/// ntfy transport, using JSON publishing mode: POST to the server root with the
+/// topic in the body, not PUT-to-topic with metadata headers.
+///
+/// Deliberate: ntfy's header mode carries the title in an HTTP header, and .NET's
+/// HttpClient rejects non-ASCII header values — for a music app, "Sigur Rós" and
+/// "坂本龍一" are the normal case, not the edge case. ntfy documents RFC-2047-encoding
+/// each header as the workaround; a UTF-8 JSON body needs none of that. The only
+/// header left is the ASCII Bearer token.
+/// </summary>
+public sealed class NtfySink : INotificationSink
+{
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly IOptionsMonitor<NotificationSettings> _opts;
+
+    public NtfySink(IHttpClientFactory httpFactory, IOptionsMonitor<NotificationSettings> opts)
+    {
+        _httpFactory = httpFactory;
+        _opts = opts;
+    }
+
+    // Literal UTF-8 in the body rather than \uXXXX escapes. Both decode the same,
+    // but the un-escaped form is what a human sees tailing the wire, and carrying
+    // "Sigur Rós" readably is the whole reason this sink uses JSON mode.
+    private static readonly JsonSerializerOptions Utf8Json = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    public string Name => "ntfy";
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(_opts.CurrentValue.NtfyUrl);
+
+    public async Task SendAsync(NotificationMessage message, CancellationToken ct)
+    {
+        var settings = _opts.CurrentValue;
+        var (serverRoot, topic) = ParseTopicUrl(settings.NtfyUrl);
+
+        var payload = new JsonObject
+        {
+            ["topic"] = topic,
+            ["title"] = message.Title,
+            ["message"] = message.Body,
+            ["tags"] = new JsonArray(TagFor(message.Type)),
+        };
+        if (!string.IsNullOrEmpty(message.ImageUrl))
+            payload["attach"] = message.ImageUrl;
+
+        var http = _httpFactory.CreateClient(NotificationService.ClientName);
+        using var req = new HttpRequestMessage(HttpMethod.Post, serverRoot)
+        {
+            Content = new StringContent(payload.ToJsonString(Utf8Json), Encoding.UTF8, "application/json"),
+        };
+        if (!string.IsNullOrWhiteSpace(settings.NtfyToken))
+            req.Headers.TryAddWithoutValidation("Authorization", $"Bearer {settings.NtfyToken}");
+
+        using var resp = await http.SendAsync(req, ct);
+        resp.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    /// "https://ntfy.sh/octo" -> ("https://ntfy.sh", "octo");
+    /// "https://host/ntfy/octo" -> ("https://host/ntfy", "octo").
+    /// The config stays one field — the URL users copy out of the ntfy app — and the
+    /// sink derives the server root and topic itself. A URL with no topic throws a
+    /// message the admin test button surfaces verbatim.
+    /// </summary>
+    internal static (string ServerRoot, string Topic) ParseTopicUrl(string url)
+    {
+        var trimmed = url.Trim().TrimEnd('/');
+        var uri = new Uri(trimmed, UriKind.Absolute);
+        var topic = uri.Segments.Length > 1 ? uri.Segments[^1].Trim('/') : "";
+        if (string.IsNullOrEmpty(topic))
+            throw new InvalidOperationException(
+                "ntfy URL must include a topic, e.g. https://ntfy.sh/your-topic");
+        var root = trimmed[..trimmed.LastIndexOf('/')];
+        return (root, topic);
+    }
+
+    internal static string TagFor(NotificationEventType type) => type switch
+    {
+        NotificationEventType.DownloadStarted => "arrow_down",
+        NotificationEventType.DownloadCompleted => "white_check_mark",
+        NotificationEventType.LosslessFallback => "warning",
+        NotificationEventType.DownloadFailed => "x",
+        NotificationEventType.AlbumCompleted => "cd",
+        _ => "bell",
+    };
+}

--- a/octo/Services/Soulseek/SoulseekClient.cs
+++ b/octo/Services/Soulseek/SoulseekClient.cs
@@ -164,10 +164,31 @@ public class SoulseekClient
     }
 
     /// <summary>
-    /// Initiates a search and waits up to SearchWaitSeconds for peer responses,
-    /// then returns the responses regardless of search-completed state.
+    /// Initiates a search and returns as soon as there is an answer, rather than
+    /// always sitting out a fixed wait.
+    ///
+    /// Three things can end the wait, whichever comes first:
+    ///   1. <paramref name="enough"/> says the hits so far are already worth acting on,
+    ///   2. slskd reports the search finished, so nothing more is coming,
+    ///   3. SearchWaitSeconds elapses, which is a ceiling rather than a duration.
+    ///
+    /// This matters in both directions. Peer responses arrive in a burst around the
+    /// 20s mark, so a fixed wait either cuts the search off before its results exist
+    /// or idles long after they have arrived; and a search that comes back empty
+    /// should fall through to the fallback source immediately instead of making the
+    /// user wait out a timer for an answer that is already known.
     /// </summary>
-    public async Task<List<SoulseekFileHit>> SearchAsync(string query, int limit, CancellationToken ct = default)
+    /// <param name="enough">
+    /// Decides whether the hits gathered so far are worth committing to. The client
+    /// cannot judge this itself: "usable" means the right format, size and title
+    /// match, which only the caller's ranking knows. Null means wait for completion
+    /// or the ceiling.
+    /// </param>
+    public async Task<List<SoulseekFileHit>> SearchAsync(
+        string query,
+        int limit,
+        CancellationToken ct = default,
+        Func<IReadOnlyList<SoulseekFileHit>, bool>? enough = null)
     {
         var searchId = Guid.NewGuid().ToString();
         var payload = JsonSerializer.Serialize(new
@@ -193,12 +214,13 @@ public class SoulseekClient
             return new List<SoulseekFileHit>();
         }
 
-        // Poll responses for up to SearchWaitSeconds
         var hits = new List<SoulseekFileHit>();
-        var deadline = DateTime.UtcNow.AddSeconds(_settings.SearchWaitSeconds);
+        var ceiling = DateTime.UtcNow.AddSeconds(_settings.SearchWaitSeconds);
+        var started = DateTime.UtcNow;
         var pollIntervalMs = 1000;
+        string stopReason = "ceiling";
 
-        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
+        while (DateTime.UtcNow < ceiling && !ct.IsCancellationRequested)
         {
             await Task.Delay(pollIntervalMs, ct);
             try
@@ -212,13 +234,30 @@ public class SoulseekClient
 
                 var json = await resp.Content.ReadAsStringAsync(ct);
                 hits = ParseResponses(json);
-                if (hits.Count >= limit) break;
+
+                if (hits.Count >= limit) { stopReason = "hit limit"; break; }
+
+                // Good enough to act on: stop waiting and go download it.
+                if (enough != null && enough(hits)) { stopReason = "found what we needed"; break; }
+
+                // Nothing more is coming. Returning now means an empty search falls
+                // through to the fallback source immediately instead of idling out
+                // the ceiling for an answer that is already settled.
+                if (await IsSearchFinishedAsync(searchId, ct))
+                {
+                    stopReason = "search finished";
+                    break;
+                }
             }
             catch (Exception ex)
             {
                 _logger.LogDebug("Poll failed (transient): {Msg}", ex.Message);
             }
         }
+
+        _logger.LogInformation(
+            "Soulseek search '{Query}': {Count} hits after {Elapsed:F1}s ({Reason})",
+            query, hits.Count, (DateTime.UtcNow - started).TotalSeconds, stopReason);
 
         // Fire-and-forget cleanup so we don't accumulate completed searches
         _ = Task.Run(async () =>
@@ -297,6 +336,42 @@ public class SoulseekClient
             _logger.LogWarning("Failed to parse Soulseek responses: {Msg}", ex.Message);
         }
         return hits;
+    }
+
+    /// <summary>
+    /// <summary>
+    /// True once slskd says the search has stopped gathering responses.
+    ///
+    /// Deliberately reads the STATUS object rather than inferring completion from
+    /// the responses endpoint, and deliberately is not used to decide whether
+    /// results exist: status reports a responseCount well before /responses will
+    /// return the files, so trusting it for anything except "is it over" makes a
+    /// too-short wait look perfectly healthy.
+    ///
+    /// Any failure returns false, so an unreadable status simply means the caller
+    /// keeps polling until the ceiling rather than giving up early.
+    /// </summary>
+    private async Task<bool> IsSearchFinishedAsync(string searchId, CancellationToken ct)
+    {
+        try
+        {
+            using var resp = await SendAsync(HttpMethod.Get, $"{Base}/api/v0/searches/{searchId}", null, ct);
+            if (!resp.IsSuccessStatusCode) return false;
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct));
+            if (!doc.RootElement.TryGetProperty("state", out var stateEl)) return false;
+
+            // slskd reports compound states such as "Completed, TimedOut" or
+            // "Completed, ResponseLimitReached"; all of them mean it is done.
+            var state = stateEl.GetString() ?? "";
+            return state.Contains("Completed", StringComparison.OrdinalIgnoreCase)
+                || state.Contains("Cancelled", StringComparison.OrdinalIgnoreCase)
+                || state.Contains("Errored", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -220,6 +220,7 @@ public class SoulseekDownloadService : BaseDownloadService
                 Album = routing.Album,
                 Source = "YouTube",
                 Format = "MP3",
+                DurationSeconds = routing.Duration,
             });
         }
 
@@ -329,6 +330,7 @@ public class SoulseekDownloadService : BaseDownloadService
                     Source = "Soulseek",
                     Format = _settings.PreferredExtension.ToUpperInvariant(),
                     SizeBytes = hit.Size,
+                    DurationSeconds = routing.Duration,
                 });
             }
 

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -40,9 +40,10 @@ public class SoulseekDownloadService : BaseDownloadService
         IHttpClientFactory httpClientFactory,
         NavidromeIdentityService navIdentity,
         DownloadHistoryService history,
+        Octo.Services.Notifications.NotificationService notifications,
         IServiceProvider serviceProvider,
         ILogger<SoulseekDownloadService> logger)
-        : base(configuration, localLibraryService, metadataService, subsonicSettings.Value, navIdentity, history, serviceProvider, logger)
+        : base(configuration, localLibraryService, metadataService, subsonicSettings.Value, navIdentity, history, notifications, serviceProvider, logger)
     {
         _slskd = slskd;
         _settings = soulseekSettings.Value;
@@ -150,7 +151,7 @@ public class SoulseekDownloadService : BaseDownloadService
     // =========================================================================
     private const int MaxPeerAttempts = 5;
 
-    protected override async Task<string> DownloadTrackAsync(string trackId, Song song, CancellationToken cancellationToken)
+    protected override async Task<string> DownloadTrackAsync(string trackId, Song song, bool suppressNotify, CancellationToken cancellationToken)
     {
         var routing = _idRegistry.Lookup(song.ExternalId ?? "") ?? SoulseekMetadataService.TryDecodeExternalId(song.ExternalId ?? "");
         if (routing is null || !routing.HasArtistTitle)
@@ -161,25 +162,40 @@ public class SoulseekDownloadService : BaseDownloadService
         switch (SubsonicSettings.DownloadSource)
         {
             case DownloadSource.YouTube:
-                return await DownloadViaYouTubeAsync(routing, cancellationToken);
+                return await DownloadViaYouTubeAsync(routing, suppressNotify, announceStart: true, cancellationToken);
             case DownloadSource.SoulseekThenYouTube:
                 // The filter matters: a cancelled token means nobody is waiting for
                 // this any more, so falling back would start a second download only
                 // to have it throw on the same token.
-                try { return await DownloadViaSoulseekAsync(routing, cancellationToken); }
+                try { return await DownloadViaSoulseekAsync(routing, suppressNotify, cancellationToken); }
                 catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
                 {
                     Logger.LogWarning("Soulseek download failed ({Msg}); falling back to YouTube MP3", ex.Message);
-                    return await DownloadViaYouTubeAsync(routing, cancellationToken);
+                    if (!suppressNotify)
+                    {
+                        Notifications.Notify(new Octo.Services.Notifications.NotificationEvent
+                        {
+                            Type = Octo.Services.Notifications.NotificationEventType.LosslessFallback,
+                            Artist = routing.Artist,
+                            Title = routing.Title,
+                            Album = routing.Album,
+                            Source = "YouTube",
+                            Format = "MP3",
+                            Detail = ex.Message,
+                        });
+                    }
+                    // announceStart false: the fallback event above already announces
+                    // the MP3, and one gesture should never ping twice.
+                    return await DownloadViaYouTubeAsync(routing, suppressNotify, announceStart: false, cancellationToken);
                 }
             default:
-                return await DownloadViaSoulseekAsync(routing, cancellationToken);
+                return await DownloadViaSoulseekAsync(routing, suppressNotify, cancellationToken);
         }
     }
 
     // Lossy MP3 via the yt-dlp shim's /download. The shim writes <dest>.mp3 in
     // the final layout with clean tags + cover, so there is no post-move.
-    private async Task<string> DownloadViaYouTubeAsync(SoulseekRouting routing, CancellationToken cancellationToken)
+    private async Task<string> DownloadViaYouTubeAsync(SoulseekRouting routing, bool suppressNotify, bool announceStart, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(DownloadPath))
             throw new InvalidOperationException("DownloadPath is not configured");
@@ -193,6 +209,19 @@ public class SoulseekDownloadService : BaseDownloadService
         }
         if (string.IsNullOrEmpty(videoId))
             throw new FileNotFoundException($"No YouTube match for '{routing.Artist} - {routing.Title}'");
+
+        if (!suppressNotify && announceStart)
+        {
+            Notifications.Notify(new Octo.Services.Notifications.NotificationEvent
+            {
+                Type = Octo.Services.Notifications.NotificationEventType.DownloadStarted,
+                Artist = routing.Artist,
+                Title = routing.Title,
+                Album = routing.Album,
+                Source = "YouTube",
+                Format = "MP3",
+            });
+        }
 
         var ytArtist = SanitizeForFs(routing.Artist) ?? "Unknown Artist";
         // Strip a redundant "Artist - " prefix from the title before naming the file,
@@ -216,7 +245,7 @@ public class SoulseekDownloadService : BaseDownloadService
 
     // Lossless FLAC via Soulseek/slskd: walk the top-N peers in quality order,
     // first successful transfer wins.
-    private async Task<string> DownloadViaSoulseekAsync(SoulseekRouting routing, CancellationToken cancellationToken)
+    private async Task<string> DownloadViaSoulseekAsync(SoulseekRouting routing, bool suppressNotify, CancellationToken cancellationToken)
     {
         // Clean the title before searching Soulseek. Last.fm's track.search
         // sometimes returns `title="Adele - Hello"` with the artist redundantly
@@ -263,6 +292,7 @@ public class SoulseekDownloadService : BaseDownloadService
             ranked.Count, primaryQuery);
 
         Exception? lastError = null;
+        var startAnnounced = false;
         foreach (var (hit, attemptIdx) in ranked.Select((h, i) => (h, i + 1)))
         {
             Logger.LogInformation("Soulseek attempt {N}/{Total}: {User} -> {File} (queue={Q}, speed={S})",
@@ -280,6 +310,26 @@ public class SoulseekDownloadService : BaseDownloadService
                 Logger.LogWarning("Soulseek enqueue failed for {User} ({Msg}); trying next peer", hit.Username, ex.Message);
                 lastError = ex;
                 continue;
+            }
+
+            // Announced only after a peer actually accepted the transfer -- firing
+            // before the loop would claim a start that five straight rejections later
+            // never happened. Once per track: a retry on the next peer is the same
+            // download, not a new one. SizeBytes is this candidate's advertised size;
+            // DownloadCompleted carries the real file's.
+            if (!suppressNotify && !startAnnounced)
+            {
+                startAnnounced = true;
+                Notifications.Notify(new Octo.Services.Notifications.NotificationEvent
+                {
+                    Type = Octo.Services.Notifications.NotificationEventType.DownloadStarted,
+                    Artist = routing.Artist,
+                    Title = routing.Title,
+                    Album = routing.Album,
+                    Source = "Soulseek",
+                    Format = _settings.PreferredExtension.ToUpperInvariant(),
+                    SizeBytes = hit.Size,
+                });
             }
 
             // Cancelling the WAIT must never cancel the TRANSFER. slskd already

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -99,7 +99,7 @@ public class SoulseekDownloadService : BaseDownloadService
         var videoId = routing.YouTubeId;
         if (string.IsNullOrEmpty(videoId) && routing.HasArtistTitle)
         {
-            var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, cancellationToken);
+            var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, ct: cancellationToken);
             videoId = hit?.VideoId;
             // Cache back on the routing so a second click on the same placeholder
             // skips the yt-dlp ytsearch1: round trip — that 3-8s saving is the
@@ -187,7 +187,7 @@ public class SoulseekDownloadService : BaseDownloadService
         var videoId = routing.YouTubeId;
         if (string.IsNullOrEmpty(videoId))
         {
-            var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, cancellationToken);
+            var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, ct: cancellationToken);
             videoId = hit?.VideoId;
             if (!string.IsNullOrEmpty(videoId)) routing.YouTubeId = videoId;
         }

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -227,7 +227,16 @@ public class SoulseekDownloadService : BaseDownloadService
         var primaryQuery = $"{routing.Artist} {cleanTitle}".Trim();
 
         Logger.LogInformation("Soulseek search-for-star: '{Query}'", primaryQuery);
-        var hits = await _slskd.SearchAsync(primaryQuery, _settings.MinFileSizeBytes > 0 ? 30 : 10, cancellationToken);
+        var hits = await _slskd.SearchAsync(
+            primaryQuery,
+            _settings.MinFileSizeBytes > 0 ? 30 : 10,
+            cancellationToken,
+            // Stop waiting once there is a real choice to make. Not on the first
+            // usable hit: ranking picks on queue length and upload speed, so
+            // committing to a single candidate would often mean committing to the
+            // slowest peer that happened to answer first. A handful is enough to
+            // choose well without waiting for stragglers.
+            enough: h => RankCandidates(h.ToList(), routing.Title!, routing.Duration).Count >= 3);
 
         var ranked = RankCandidates(hits, routing.Title!, routing.Duration);
 
@@ -238,7 +247,11 @@ public class SoulseekDownloadService : BaseDownloadService
         if (ranked.Count == 0 && !string.IsNullOrWhiteSpace(cleanTitle))
         {
             Logger.LogInformation("Soulseek primary query returned no usable hits; retrying with title-only");
-            hits = await _slskd.SearchAsync(cleanTitle, _settings.MinFileSizeBytes > 0 ? 30 : 10, cancellationToken);
+            hits = await _slskd.SearchAsync(
+                cleanTitle,
+                _settings.MinFileSizeBytes > 0 ? 30 : 10,
+                cancellationToken,
+                enough: h => RankCandidates(h.ToList(), routing.Title!, routing.Duration).Count >= 3);
             ranked = RankCandidates(hits, routing.Title!, routing.Duration);
         }
 

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -168,12 +168,22 @@ public class SoulseekMetadataService : IMusicMetadataService
     // means playback reuses this exact video (durations match) and it is prewarmed.
     private const int TopDurationResolveLimit = 8;
 
+    // Shared across ALL invocations, not created per call. The shim runs 5
+    // yt-dlp processes at a time; per-invocation semaphores let the three
+    // prewarm triggers (radio, scrobble, external search) stack to 12
+    // concurrent /search against it, and the old value of 6 here exceeded the
+    // whole gate on its own. Sized to the shim's background capacity
+    // (MAX_CONCURRENT_YTDLP - GATE_RESERVE_INTERACTIVE). This service is
+    // registered as a singleton, so an instance field is already process-wide
+    // without being static (which would make parallel test runs hostile).
+    private readonly SemaphoreSlim _prewarmGate = new(3);
+    private static readonly TimeSpan PrewarmQueueWait = TimeSpan.FromSeconds(2);
+
     public async Task ResolveTopDurationsAsync(List<Song> songs, CancellationToken ct = default)
     {
-        var sem = new SemaphoreSlim(6);
         var tasks = songs.Where(s => !s.IsLocal).Take(TopDurationResolveLimit).Select(async song =>
         {
-            await sem.WaitAsync(ct);
+            if (!await _prewarmGate.WaitAsync(PrewarmQueueWait, ct)) return;
             try
             {
                 // Fast metadata-only lookup (flat search, no URL solve). Pass the
@@ -193,7 +203,7 @@ public class SoulseekMetadataService : IMusicMetadataService
                 }
             }
             catch { /* best-effort; keeps the existing duration on a miss */ }
-            finally { sem.Release(); }
+            finally { _prewarmGate.Release(); }
         });
         await Task.WhenAll(tasks);
     }
@@ -234,18 +244,19 @@ public class SoulseekMetadataService : IMusicMetadataService
             .ToList();
         if (targets.Count == 0) return Task.CompletedTask;
 
-        // Concurrency cap below the shim's MAX_CONCURRENT_YTDLP=8 so we don't
-        // monopolize it during a search burst (the shim is also serving any
-        // in-flight /stream calls).
-        var sem = new SemaphoreSlim(4);
         var tasks = targets.Select(async t =>
         {
-            await sem.WaitAsync(ct);
+            // Bounded wait, then drop. With a shared limiter an unbounded wait
+            // lets a skip-happy user pile up prewarm tasks for songs they left
+            // behind five tracks ago. Prewarm is best-effort by design, so its
+            // queueing is best-effort too.
+            if (!await _prewarmGate.WaitAsync(PrewarmQueueWait, ct)) return;
             try
             {
                 var routing = t.routing!;
                 if (!string.IsNullOrEmpty(routing.YouTubeId)) return;
-                var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}", routing.Duration, ct);
+                var hit = await _youtube.SearchAsync($"{routing.Artist} {routing.Title}",
+                    routing.Duration, background: true, ct: ct);
                 if (hit is { VideoId: { Length: > 0 } })
                 {
                     routing.YouTubeId = hit.VideoId;
@@ -253,7 +264,7 @@ public class SoulseekMetadataService : IMusicMetadataService
                 }
             }
             catch { /* best-effort warm; never throw out of fire-and-forget */ }
-            finally { sem.Release(); }
+            finally { _prewarmGate.Release(); }
         });
         return Task.WhenAll(tasks);
     }

--- a/octo/Services/Subsonic/NavidromeIdentityService.cs
+++ b/octo/Services/Subsonic/NavidromeIdentityService.cs
@@ -5,6 +5,11 @@ using Octo.Models.Settings;
 
 namespace Octo.Services.Subsonic;
 
+/// <summary>One library as Navidrome reports it. <paramref name="Folder"/> is the
+/// path Octo should use: remotePath when Navidrome supplies one (how other services
+/// see the same library), otherwise its own path.</summary>
+public record NavidromeLibrary(string? Id, string? Name, string Folder);
+
 /// <summary>
 /// Octo's own standing identity toward the upstream Navidrome. Octo is a proxy, so
 /// most requests carry the client's credentials. But background work has no client
@@ -33,6 +38,7 @@ public class NavidromeIdentityService
     private string? _username;
 
     private string? _detectedFolder;
+    private List<NavidromeLibrary> _libraries = new();
     private DateTime _detectedAt;
     private static readonly TimeSpan DetectTtl = TimeSpan.FromMinutes(30);
     private readonly SemaphoreSlim _detectGate = new(1, 1);
@@ -49,6 +55,11 @@ public class NavidromeIdentityService
 
     /// <summary>The Navidrome music folder detected from /api/library, or null.</summary>
     public string? DetectedMusicFolder { get { lock (_lock) return _detectedFolder; } }
+
+    /// <summary>Every library Navidrome reported on the last successful detection.
+    /// Empty until one has run. Used by the admin UI to offer a choice instead of
+    /// silently adopting whichever one Navidrome listed first.</summary>
+    public IReadOnlyList<NavidromeLibrary> KnownLibraries { get { lock (_lock) return _libraries; } }
 
     /// <summary>
     /// Effective download path: an explicit override wins, else the Navidrome-detected
@@ -147,11 +158,45 @@ public class NavidromeIdentityService
             if (doc.RootElement.ValueKind != JsonValueKind.Array || doc.RootElement.GetArrayLength() == 0)
                 return null;
 
-            var lib = doc.RootElement[0];
-            var remote = lib.TryGetProperty("remotePath", out var rp) ? rp.GetString() : null;
-            var path = lib.TryGetProperty("path", out var p) ? p.GetString() : null;
-            var folder = !string.IsNullOrEmpty(remote) ? remote : path;
-            if (string.IsNullOrEmpty(folder)) return null;
+            // Navidrome can serve several libraries. Read them all: taking [0] and
+            // calling it "the" music folder meant a multi-library server had its
+            // download target chosen by whatever order Navidrome happened to return,
+            // with no way to say otherwise.
+            var libraries = new List<NavidromeLibrary>();
+            foreach (var entry in doc.RootElement.EnumerateArray())
+            {
+                // remotePath is the path as OTHER services see this library, which is
+                // what Octo needs; path is how Navidrome itself sees it.
+                var remote = entry.TryGetProperty("remotePath", out var rp) ? rp.GetString() : null;
+                var path = entry.TryGetProperty("path", out var p) ? p.GetString() : null;
+                var f = !string.IsNullOrEmpty(remote) ? remote : path;
+                if (string.IsNullOrEmpty(f)) continue;
+                libraries.Add(new NavidromeLibrary(
+                    entry.TryGetProperty("id", out var idEl) ? idEl.ToString() : null,
+                    entry.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : null,
+                    f));
+            }
+            if (libraries.Count == 0) return null;
+            lock (_lock) _libraries = libraries;
+
+            // An explicit pin wins. Absent one, behave exactly as before and take the
+            // first entry, so an existing install's download target cannot move on
+            // update. A pin that no longer matches anything Navidrome reports falls
+            // back the same way rather than stranding downloads.
+            var pinned = _settings.LibraryPath?.Trim();
+            var chosen = libraries[0];
+            if (!string.IsNullOrEmpty(pinned))
+            {
+                var match = libraries.FirstOrDefault(l =>
+                    string.Equals(l.Folder, pinned, StringComparison.Ordinal));
+                if (match != null) chosen = match;
+                else
+                    _logger.LogWarning(
+                        "Pinned library path '{Pinned}' is not among the {Count} libraries " +
+                        "Navidrome reports; using '{Fallback}' instead.",
+                        pinned, libraries.Count, chosen.Folder);
+            }
+            var folder = chosen.Folder;
 
             // Safety gate: only ADOPT the detected path if it actually exists inside
             // Octo's own container. Navidrome reports the path as IT sees it, which is

--- a/octo/Services/YouTube/YouTubeResolver.cs
+++ b/octo/Services/YouTube/YouTubeResolver.cs
@@ -29,11 +29,19 @@ public class YouTubeResolver
     /// <summary>
     /// Resolves "Artist - Title" to a single best YouTube hit via the shim.
     /// </summary>
-    public async Task<YouTubeHit?> SearchAsync(string query, int? durationHint = null, CancellationToken ct = default)
+    /// <param name="background">
+    /// True only for fire-and-forget prewarm. The shim keeps a slice of its
+    /// yt-dlp gate unreachable to background work, so a user pressing play never
+    /// queues behind a prewarm burst. Absence means interactive, so a call site
+    /// that forgets this fails safe: slower prewarm, never a slower play.
+    /// </param>
+    public async Task<YouTubeHit?> SearchAsync(string query, int? durationHint = null,
+        bool background = false, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query)) return null;
         var url = $"{_baseUrl}/search?q={Uri.EscapeDataString(query)}"
-            + (durationHint is int dh && dh > 0 ? $"&duration={dh}" : "");
+            + (durationHint is int dh && dh > 0 ? $"&duration={dh}" : "")
+            + (background ? "&bg=1" : "");
         try
         {
             var http = _httpClientFactory.CreateClient(SearchClientName);

--- a/octo/appsettings.json
+++ b/octo/appsettings.json
@@ -33,5 +33,15 @@
     "EnableRadio": true,
     "RadioTrackCount": 50,
     "RadioCacheDurationHours": 24
+  },
+  "Notifications": {
+    "NtfyUrl": "",
+    "NtfyToken": "",
+    "DiscordWebhookUrl": "",
+    "NotifyDownloadStarted": false,
+    "NotifyDownloadCompleted": true,
+    "NotifyLosslessFallback": true,
+    "NotifyDownloadFailed": true,
+    "NotifyAlbumCompleted": true
   }
 }

--- a/octo/octo.csproj
+++ b/octo/octo.csproj
@@ -8,8 +8,8 @@
         <!-- Dated releases. Version must be numeric for the assembly, so 07 loses its
              leading zero there; InformationalVersion carries the tag name verbatim and
              is what the dashboard shows. Bump both when tagging a release. -->
-        <Version>2026.8.13</Version>
-        <InformationalVersion>2026.08.13</InformationalVersion>
+        <Version>2026.8.15</Version>
+        <InformationalVersion>2026.08.15</InformationalVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/octo/wwwroot/admin/admin.css
+++ b/octo/wwwroot/admin/admin.css
@@ -10,6 +10,12 @@
  *   • Dark surface palette ramps from --bg-0 (deepest) to --bg-3 (lightest)
  */
 
+/* The hidden attribute must actually hide. Any class that sets `display` is an
+ * author style and so outranks the browser's own [hidden] rule no matter how
+ * specific it looks — .set-row's `display: flex` was enough to keep a row Octo
+ * had marked hidden on screen, empty, overlapping the row beneath it. */
+[hidden] { display: none !important; }
+
 :root {
   /* Surfaces — near-black base with a faint blue-gray (Winters' Glass) cast */
   --bg-0: #0c0c0d;        /* page */

--- a/octo/wwwroot/admin/admin.css
+++ b/octo/wwwroot/admin/admin.css
@@ -727,6 +727,64 @@ section[data-pane].active { display: block; }
 .detect-pick { justify-content: space-between; text-align: left; }
 .detect-tag { color: var(--fg-mute); font-size: 12px; }
 
+/* Sign-in modal.
+ *
+ * Exists because window.prompt() cannot be styled at all and, worse, has no
+ * password mode — it renders the password in clear on screen. This is the first
+ * modal in the admin UI, so it deliberately reuses the existing card, input and
+ * button tokens rather than introducing a second visual language. */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 6, 7, 0.62);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  animation: modal-fade var(--t-fast) ease-out;
+}
+.modal {
+  width: min(380px, calc(100vw - 32px));
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  padding: 20px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.55);
+  animation: modal-rise 160ms cubic-bezier(.16, 1, .3, 1);
+}
+.modal-title { font-size: 15px; font-weight: 550; color: var(--fg); }
+.modal-desc {
+  margin-top: 5px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--fg-soft);
+}
+.modal-fields { display: flex; flex-direction: column; gap: 10px; margin-top: 16px; }
+.modal-error {
+  margin-top: 10px;
+  font-size: 12.5px;
+  color: #e6a3a3;
+  min-height: 0;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+@keyframes modal-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes modal-rise {
+  from { opacity: 0; transform: translateY(6px) scale(.99); }
+  to   { opacity: 1; transform: none; }
+}
+/* The entrance is decoration, never the thing that makes the dialog visible:
+ * both elements are opaque by default and the keyframes only animate up to
+ * that. Motion is dropped entirely when the user asks for less of it. */
+@media (prefers-reduced-motion: reduce) {
+  .modal-backdrop, .modal { animation: none; }
+}
+
 /* Inline notice banner (e.g. discovery-off warning) */
 .notice {
   padding: 12px 14px;

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -405,6 +405,148 @@ function updateDiscoveryBanner() {
 document.getElementById('f-lastfm-key')?.addEventListener('input', updateDiscoveryBanner);
 
 // ────────────────────────────────────────────────────────────────
+// Library status, library picker, and the download-folder browser
+//
+// Octo fronts Navidrome, so Navidrome's library is the source of truth for where
+// downloads belong. The status line states the whole chain (what Navidrome
+// reports, whether Octo can see it, what is therefore in effect) because when
+// that chain breaks the symptom is silent: files download fine and never appear.
+// ────────────────────────────────────────────────────────────────
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, c =>
+  ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+async function refreshLibraryStatus() {
+  const row = document.getElementById('library-status-row');
+  const out = document.getElementById('library-status');
+  const pickRow = document.getElementById('library-pick-row');
+  const pick = document.getElementById('f-library-path');
+  if (!row || !out) return;
+  try {
+    const r = await fetch('/api/admin/library-status', { cache: 'no-store' });
+    if (!r.ok) return;
+    const s = await r.json();
+
+    const bits = [];
+    if (s.navidromeReports) {
+      bits.push(s.visibleToOcto
+        ? `Navidrome's library is <code>${esc(s.navidromeReports)}</code>, and Octo can see it.`
+        : `Navidrome reports <code>${esc(s.navidromeReports)}</code>, but <strong>Octo cannot see that path</strong>. Mount it into Octo's container, or set Navidrome's remotePath, or pick a folder below.`);
+    } else if (s.autoDetect) {
+      bits.push('Waiting on Navidrome to report its music folder. Until then the path below is used.');
+    } else {
+      bits.push('Auto-detect is off, so the path below is used verbatim.');
+    }
+    bits.push(`Downloads go to <code>${esc(s.effectiveDownloadPath || '(unset)')}</code>${s.writable ? '' : ' — <strong>not writable by Octo</strong>'}.`);
+    if (!s.rescanAuthenticated) {
+      bits.push('No Navidrome admin identity yet, so the rescan after a download may not run. Set admin credentials, or sign in once from a client.');
+    }
+    out.innerHTML = bits.join(' ');
+    row.hidden = false;
+
+    // Only ask which library when there is genuinely a choice to make.
+    const libs = s.libraries || [];
+    if (pick && pickRow && libs.length > 1) {
+      pick.innerHTML = [`<option value="">First library Navidrome reports</option>`]
+        .concat(libs.map(l => {
+          const label = `${l.name || l.folder}${l.visible ? '' : ' (not visible to Octo)'}`;
+          return `<option value="${esc(l.folder)}">${esc(label)}</option>`;
+        })).join('');
+      pick.value = s.pinnedLibraryPath || '';
+      pickRow.hidden = false;
+    }
+  } catch { /* status is informational; never block the settings UI on it */ }
+}
+refreshLibraryStatus();
+
+// ── Browse for a download folder ────────────────────────────────
+// The endpoint requires a Navidrome admin, because an unauthenticated directory
+// lister would turn every Octo install into one. The token lives in memory only:
+// not sessionStorage, so it dies with the tab.
+let browseToken = null;
+
+async function browseFetch(path) {
+  const url = '/api/admin/browse' + (path ? `?path=${encodeURIComponent(path)}` : '');
+  return fetch(url, { cache: 'no-store', headers: { 'X-Octo-Browse-Token': browseToken || '' } });
+}
+
+async function browseAuthenticate(result) {
+  const username = window.prompt('Navidrome admin username');
+  if (!username) return false;
+  const password = window.prompt('Navidrome password for ' + username);
+  if (!password) return false;
+  const r = await fetch('/api/admin/browse/auth', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) {
+    result.innerHTML = esc(data.error || 'Sign-in failed.');
+    return false;
+  }
+  browseToken = data.token;
+  return true;
+}
+
+function renderBrowse(data, result, input) {
+  const rows = [];
+  if (data.parent) {
+    rows.push(`<button type="button" class="btn btn-ghost detect-pick browse-nav" data-path="${esc(data.parent)}">.. <span class="detect-tag">up</span></button>`);
+  }
+  for (const e of data.entries || []) {
+    rows.push(`<button type="button" class="btn btn-ghost detect-pick browse-nav" data-path="${esc(e.path)}">${esc(e.name)}<span class="detect-tag">${e.writable ? 'writable' : 'read-only'}</span></button>`);
+  }
+  const here = data.path
+    ? `<code>${esc(data.path)}</code> ${data.writable ? '' : '<strong>(Octo cannot write here)</strong>'}`
+    : 'Drives';
+  const note = data.containerised
+    ? '<div class="detect-tag">Octo runs in a container, so this is what it can see — the host\'s own drives are not visible unless mounted.</div>'
+    : '';
+  const useBtn = data.path && data.exists
+    ? `<button type="button" class="btn" id="browse-use" data-path="${esc(data.path)}">Use this folder</button>`
+    : '';
+  const truncated = data.truncated ? '<div class="detect-tag">Showing the first 1000 folders.</div>' : '';
+
+  result.innerHTML = `${here}${note}<div class="detect-list">${rows.join('')}</div>${truncated}<div style="margin-top:8px">${useBtn}</div>`;
+
+  result.querySelectorAll('.browse-nav').forEach(b =>
+    b.addEventListener('click', () => openBrowse(b.dataset.path)));
+  document.getElementById('browse-use')?.addEventListener('click', () => {
+    input.value = data.path;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    result.innerHTML = `Set to <code>${esc(data.path)}</code>. Save, then restart Octo to apply.`;
+  });
+}
+
+async function openBrowse(path) {
+  const result = document.getElementById('browse-result');
+  const input = document.getElementById('f-download-path');
+  if (!result || !input) return;
+  result.hidden = false;
+  result.textContent = 'Loading…';
+  try {
+    let r = await browseFetch(path);
+    if (r.status === 401) {
+      if (!await browseAuthenticate(result)) return;
+      r = await browseFetch(path);
+    }
+    if (!r.ok) {
+      const data = await r.json().catch(() => ({}));
+      result.innerHTML = esc(data.error || `Browse failed (HTTP ${r.status}).`);
+      return;
+    }
+    renderBrowse(await r.json(), result, input);
+  } catch (e) {
+    result.textContent = 'Browse failed: ' + (e?.message || 'unknown error');
+  }
+}
+
+document.getElementById('btn-browse-path')?.addEventListener('click', () => {
+  const current = document.getElementById('f-download-path')?.value?.trim();
+  openBrowse(current || '');
+});
+
+// ────────────────────────────────────────────────────────────────
 // Detect Subsonic/Navidrome server on the local network
 // ────────────────────────────────────────────────────────────────
 const detectBtn = document.getElementById('btn-detect-server');

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -425,6 +425,7 @@ async function refreshLibraryStatus() {
     const r = await fetch('/api/admin/library-status', { cache: 'no-store' });
     if (!r.ok) return;
     const s = await r.json();
+    effectiveLibraryPath = s.effectiveDownloadPath || '';
 
     const bits = [];
     if (s.navidromeReports) {
@@ -463,6 +464,10 @@ refreshLibraryStatus();
 // lister would turn every Octo install into one. The token lives in memory only:
 // not sessionStorage, so it dies with the tab.
 let browseToken = null;
+// Where Navidrome says its library is. Used as the browser's starting point when
+// the path field is empty, so it opens on the folder Octo is actually using
+// rather than at the filesystem root.
+let effectiveLibraryPath = '';
 
 async function browseFetch(path) {
   const url = '/api/admin/browse' + (path ? `?path=${encodeURIComponent(path)}` : '');
@@ -550,8 +555,14 @@ function renderBrowse(data, result, input) {
   for (const e of data.entries || []) {
     rows.push(`<button type="button" class="btn btn-ghost detect-pick browse-nav" data-path="${esc(e.path)}">${esc(e.name)}<span class="detect-tag">${e.writable ? 'writable' : 'read-only'}</span></button>`);
   }
+  // The track count is what tells you this is the right folder. A library of
+  // loose files under a few album folders otherwise renders as almost empty,
+  // because only directories are listed.
+  const tracks = data.audioFiles > 0
+    ? ` <span class="detect-tag">${data.audioFiles.toLocaleString()} audio ${data.audioFiles === 1 ? 'file' : 'files'} here</span>`
+    : (data.path && !data.entries?.length ? ' <span class="detect-tag">empty</span>' : '');
   const here = data.path
-    ? `<code>${esc(data.path)}</code> ${data.writable ? '' : '<strong>(Octo cannot write here)</strong>'}`
+    ? `<code>${esc(data.path)}</code>${tracks} ${data.writable ? '' : '<strong>(Octo cannot write here)</strong>'}`
     : 'Drives';
   const note = data.containerised
     ? '<div class="detect-tag">Octo runs in a container, so this is what it can see — the host\'s own drives are not visible unless mounted.</div>'
@@ -597,7 +608,7 @@ async function openBrowse(path) {
 
 document.getElementById('btn-browse-path')?.addEventListener('click', () => {
   const current = document.getElementById('f-download-path')?.value?.trim();
-  openBrowse(current || '');
+  openBrowse(current || effectiveLibraryPath || '');
 });
 
 // ────────────────────────────────────────────────────────────────

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -405,6 +405,29 @@ function updateDiscoveryBanner() {
 document.getElementById('f-lastfm-key')?.addEventListener('input', updateDiscoveryBanner);
 
 // ────────────────────────────────────────────────────────────────
+// Notifications: send a test through every configured transport
+// ────────────────────────────────────────────────────────────────
+document.getElementById('btn-test-notification')?.addEventListener('click', async () => {
+  const box = document.getElementById('test-notification-result');
+  const btn = document.getElementById('btn-test-notification');
+  if (!box) return;
+  box.hidden = false;
+  box.textContent = 'Sending…';
+  btn.disabled = true;
+  try {
+    const r = await fetch('/api/admin/test-notification', { method: 'POST' });
+    const d = await r.json();
+    const parts = (d.results || []).map(s =>
+      `${s.sink}: ${!s.configured ? 'not configured' : s.ok ? 'OK' : 'failed — ' + s.detail}`);
+    box.textContent = parts.length ? parts.join('  ·  ') : 'No transports registered.';
+  } catch (e) {
+    box.textContent = 'Test failed: ' + (e?.message || 'unknown error');
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+// ────────────────────────────────────────────────────────────────
 // Library status, library picker, and the download-folder browser
 //
 // Octo fronts Navidrome, so Navidrome's library is the source of truth for where

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -463,7 +463,9 @@ refreshLibraryStatus();
 // The endpoint requires a Navidrome admin, because an unauthenticated directory
 // lister would turn every Octo install into one. The token lives in memory only:
 // not sessionStorage, so it dies with the tab.
-let browseToken = null;
+// The session lives in an HttpOnly cookie the server sets, so it survives a page
+// reload and this script never holds it (and could not read it if it tried).
+// Nothing about the sign-in is stored client-side, least of all the password.
 // Where Navidrome says its library is. Used as the browser's starting point when
 // the path field is empty, so it opens on the folder Octo is actually using
 // rather than at the filesystem root.
@@ -471,7 +473,8 @@ let effectiveLibraryPath = '';
 
 async function browseFetch(path) {
   const url = '/api/admin/browse' + (path ? `?path=${encodeURIComponent(path)}` : '');
-  return fetch(url, { cache: 'no-store', headers: { 'X-Octo-Browse-Token': browseToken || '' } });
+  // same-origin credentials carry the session cookie; nothing to attach by hand.
+  return fetch(url, { cache: 'no-store', credentials: 'same-origin' });
 }
 
 // Resolves to {username, password} or null if dismissed. A native prompt() was
@@ -535,6 +538,7 @@ async function browseAuthenticate(result) {
   if (!creds) return false;
   const r = await fetch('/api/admin/browse/auth', {
     method: 'POST',
+    credentials: 'same-origin',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(creds),
   });
@@ -543,8 +547,7 @@ async function browseAuthenticate(result) {
     result.innerHTML = esc(data.error || 'Sign-in failed.');
     return false;
   }
-  browseToken = data.token;
-  return true;
+  return true;   // the session is now in the cookie the response set
 }
 
 function renderBrowse(data, result, input) {

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -469,15 +469,69 @@ async function browseFetch(path) {
   return fetch(url, { cache: 'no-store', headers: { 'X-Octo-Browse-Token': browseToken || '' } });
 }
 
+// Resolves to {username, password} or null if dismissed. A native prompt() was
+// used here first: it cannot be themed, and it has no password mode, so the
+// password appeared in clear on screen.
+function askCredentials() {
+  const modal = document.getElementById('signin-modal');
+  const user = document.getElementById('signin-user');
+  const pass = document.getElementById('signin-pass');
+  const err = document.getElementById('signin-error');
+  const submit = document.getElementById('signin-submit');
+  const cancel = document.getElementById('signin-cancel');
+  if (!modal) return Promise.resolve(null);
+
+  user.value = '';
+  pass.value = '';
+  err.textContent = '';
+  modal.hidden = false;
+  // Focus straight away rather than inside requestAnimationFrame: rAF only runs
+  // when the page is producing frames, so a background or non-compositing tab
+  // would open the dialog with nothing focused. setTimeout is the belt-and-braces
+  // retry for browsers that will not focus an element in the same tick it is shown.
+  user.focus();
+  if (document.activeElement !== user) setTimeout(() => user.focus(), 0);
+
+  return new Promise(resolve => {
+    const close = (value) => {
+      modal.hidden = true;
+      submit.removeEventListener('click', onSubmit);
+      cancel.removeEventListener('click', onCancel);
+      modal.removeEventListener('keydown', onKey);
+      modal.removeEventListener('mousedown', onBackdrop);
+      pass.value = '';
+      resolve(value);
+    };
+    const onSubmit = () => {
+      if (!user.value.trim() || !pass.value) {
+        err.textContent = 'Both a username and a password are required.';
+        return;
+      }
+      close({ username: user.value.trim(), password: pass.value });
+    };
+    const onCancel = () => close(null);
+    const onKey = (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); onSubmit(); }
+      if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+    };
+    // Clicking the backdrop dismisses, but only the backdrop itself — a drag
+    // that starts inside the card must not count as an outside click.
+    const onBackdrop = (e) => { if (e.target === modal) onCancel(); };
+
+    submit.addEventListener('click', onSubmit);
+    cancel.addEventListener('click', onCancel);
+    modal.addEventListener('keydown', onKey);
+    modal.addEventListener('mousedown', onBackdrop);
+  });
+}
+
 async function browseAuthenticate(result) {
-  const username = window.prompt('Navidrome admin username');
-  if (!username) return false;
-  const password = window.prompt('Navidrome password for ' + username);
-  if (!password) return false;
+  const creds = await askCredentials();
+  if (!creds) return false;
   const r = await fetch('/api/admin/browse/auth', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify(creds),
   });
   const data = await r.json().catch(() => ({}));
   if (!r.ok) {

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -69,6 +69,12 @@
             </svg>
             <span>Last.fm</span>
           </button>
+          <button class="sidebar-nav-item" data-tab="notifications">
+            <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M8 2a4 4 0 0 0-4 4v3L2.5 11h11L12 9V6a4 4 0 0 0-4-4z"/><path d="M6.5 13a1.5 1.5 0 0 0 3 0"/>
+            </svg>
+            <span>Notifications</span>
+          </button>
           <button class="sidebar-nav-item" data-tab="soulseek">
             <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
               <circle cx="7" cy="7" r="4"/><path d="m10 10 3 3"/>
@@ -505,6 +511,87 @@
                 <div class="set-info-d">How long Last.fm responses are cached server-side.</div>
               </div>
               <input class="set-input" id="f-lastfm-cache" name="LastFm.RadioCacheDurationHours" type="number" min="0" />
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <!-- ─── NOTIFICATIONS ─────────────────────────────────── -->
+      <section data-pane="notifications">
+        <header class="page-header">
+          <div>
+            <h1>Notifications</h1>
+            <p>Push a message when Octo fetches (or fails to fetch) music. ntfy and Discord; either works alone.</p>
+          </div>
+          <button class="btn" id="btn-test-notification" type="button">Send test</button>
+        </header>
+
+        <div id="test-notification-result" class="notice" hidden></div>
+
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Transports</h3></div>
+          <form data-section="notifications-transports" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">ntfy topic URL</div>
+                <div class="set-info-d">Leave empty to disable ntfy. Pick any unique topic name, subscribe to it in the <a href="https://ntfy.sh/" target="_blank" rel="noopener">ntfy app</a>, and paste the same URL here.</div>
+              </div>
+              <input class="set-input" id="f-ntfy-url" name="Notifications.NtfyUrl" placeholder="https://ntfy.sh/your-topic" />
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">ntfy access token <span class="set-opt">optional</span></div>
+                <div class="set-info-d">Only needed on servers with access control. Sent as a Bearer token.</div>
+              </div>
+              <input class="set-input" id="f-ntfy-token" name="Notifications.NtfyToken" type="password" autocomplete="off" />
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Discord webhook URL</div>
+                <div class="set-info-d">Leave empty to disable Discord. Server Settings &rarr; Integrations &rarr; Webhooks. The URL contains its own secret, so it is stored like a password.</div>
+              </div>
+              <input class="set-input" id="f-discord-webhook" name="Notifications.DiscordWebhookUrl" type="password" autocomplete="off" placeholder="https://discord.com/api/webhooks/…" />
+            </div>
+          </form>
+        </div>
+
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Events</h3></div>
+          <form data-section="notifications-events" class="set-card">
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Download started</div>
+                <div class="set-info-d">A transfer actually began, saying up front whether it found a FLAC or is settling for MP3.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-notify-started" name="Notifications.NotifyDownloadStarted" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Download completed</div>
+                <div class="set-info-d">A track landed: format, source and size, with album art.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-notify-completed" name="Notifications.NotifyDownloadCompleted" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Lossless fallback</div>
+                <div class="set-info-d">Soulseek came up empty and Octo settled for a YouTube MP3. The quality-loss alarm.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-notify-fallback" name="Notifications.NotifyLosslessFallback" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Download failed</div>
+                <div class="set-info-d">Both sources failed for a starred track.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-notify-failed" name="Notifications.NotifyDownloadFailed" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+            </div>
+            <div class="set-row">
+              <div class="set-info">
+                <div class="set-info-t">Album completed</div>
+                <div class="set-info-d">One summary per album: tracks fetched and how many are lossless. Per-track pings are muted during album downloads.</div>
+              </div>
+              <label class="switch"><input type="checkbox" id="f-notify-album" name="Notifications.NotifyAlbumCompleted" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
             </div>
           </form>
         </div>

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -693,6 +693,24 @@
 
   <div id="toast" role="status" aria-live="polite"></div>
 
+  <!-- Sign-in modal for the folder browser. Hidden until needed; the browser
+       endpoint refuses to list anything without a Navidrome admin. -->
+  <div class="modal-backdrop" id="signin-modal" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="signin-title">
+      <div class="modal-title" id="signin-title">Sign in to browse</div>
+      <div class="modal-desc">Browsing folders needs a Navidrome <strong>admin</strong> account. Octo checks it with your Navidrome server and never stores it.</div>
+      <div class="modal-fields">
+        <input class="set-input" id="signin-user" type="text" autocomplete="username" placeholder="Username" />
+        <input class="set-input" id="signin-pass" type="password" autocomplete="current-password" placeholder="Password" />
+      </div>
+      <div class="modal-error" id="signin-error"></div>
+      <div class="modal-actions">
+        <button type="button" class="btn btn-ghost" id="signin-cancel">Cancel</button>
+        <button type="button" class="btn btn-primary" id="signin-submit">Sign in</button>
+      </div>
+    </div>
+  </div>
+
   <script src="/admin/admin.js"></script>
 </body>
 </html>

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -229,6 +229,21 @@
         <div class="set-section">
           <div class="set-head"><h3 class="set-title">Storage</h3></div>
           <form data-section="library" class="set-card">
+            <!-- Where downloads actually land, stated plainly. Filled by admin.js
+                 from /api/admin/library-status; hidden until it answers. -->
+            <div class="set-row stack" id="library-status-row" hidden>
+              <div class="set-info">
+                <div class="set-info-t">Where downloads go</div>
+                <div class="set-info-d" id="library-status"></div>
+              </div>
+            </div>
+            <div class="set-row stack" id="library-pick-row" hidden>
+              <div class="set-info">
+                <div class="set-info-t">Navidrome library</div>
+                <div class="set-info-d">This server has more than one library. Pick the one Octo should download into; otherwise it uses whichever Navidrome lists first.</div>
+              </div>
+              <select class="set-input" id="f-library-path" name="Subsonic.LibraryPath" data-restart="true"></select>
+            </div>
             <div class="set-row">
               <div class="set-info">
                 <div class="set-info-t">Auto-detect download path from Navidrome</div>
@@ -241,7 +256,11 @@
                 <div class="set-info-t">Download path <span class="set-opt">override / fallback</span></div>
                 <div class="set-info-d">Path INSIDE the Octo container where downloaded files land (default /music, backed by the DOWNLOAD_PATH bind mount). To move the library on the host, change DOWNLOAD_PATH in .env instead; a host path like E:\Media\Music does not work here. With auto-detect on, this is only used until Navidrome's folder is detected.</div>
               </div>
-              <input class="set-input" id="f-download-path" name="Library.DownloadPath" data-restart="true" placeholder="/music" />
+              <div class="field-inline">
+                <input class="set-input" id="f-download-path" name="Library.DownloadPath" data-restart="true" placeholder="/music" />
+                <button type="button" class="btn btn-ghost" id="btn-browse-path">Browse…</button>
+              </div>
+              <div class="detect-result" id="browse-result"></div>
             </div>
           </form>
         </div>

--- a/yt-dlp-shim/Dockerfile
+++ b/yt-dlp-shim/Dockerfile
@@ -1,11 +1,12 @@
 FROM python:3.12-slim
 
 ARG YTDLP_VERSION=latest
+ARG DENO_VERSION=latest
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl ffmpeg \
+        ca-certificates curl ffmpeg unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Pull yt-dlp directly from GitHub releases. Pinning to "latest" by default so
@@ -19,11 +20,42 @@ RUN if [ "$YTDLP_VERSION" = "latest" ]; then \
     && chmod +x /usr/local/bin/yt-dlp \
     && yt-dlp --version
 
+# yt-dlp solves YouTube's JavaScript challenges (signatures, nsig) with an
+# external runtime. Without one it warns that "YouTube extraction without a JS
+# runtime has been deprecated, and some formats may be missing", and upstream
+# says availability will keep getting worse. deno is the only runtime yt-dlp
+# enables by default, so having it on PATH is the whole integration -- no flag,
+# unlike node/quickjs/bun which need --js-runtimes. Minimum supported is 2.3.0.
+# https://github.com/yt-dlp/yt-dlp/wiki/EJS
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+        amd64) target="x86_64-unknown-linux-gnu" ;; \
+        arm64) target="aarch64-unknown-linux-gnu" ;; \
+        *) echo "unsupported arch for deno: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac; \
+    if [ "$DENO_VERSION" = "latest" ]; then \
+        url="https://github.com/denoland/deno/releases/latest/download/deno-${target}.zip"; \
+    else \
+        url="https://github.com/denoland/deno/releases/download/${DENO_VERSION}/deno-${target}.zip"; \
+    fi; \
+    curl -fsSL -o /tmp/deno.zip "$url"; \
+    unzip -q /tmp/deno.zip -d /usr/local/bin; \
+    rm /tmp/deno.zip; \
+    chmod +x /usr/local/bin/deno; \
+    deno --version
+
 RUN pip install --no-cache-dir flask gunicorn requests
 
-COPY app.py /app/app.py
+# gate.py too, not just app.py -- app.py imports it at module scope, so omitting
+# it here is a ModuleNotFoundError at startup and total loss of playback. The
+# shim image is never built in CI, so nothing else would catch that.
+COPY app.py gate.py /app/
 
 EXPOSE 8080
 
 # Single worker, threaded — yt-dlp is the bottleneck not Python; threading is fine.
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "-w", "1", "--threads", "8", "--timeout", "120", "app:app"]
+# Threads are sized well above MAX_CONCURRENT_YTDLP deliberately: /stream holds
+# its thread for the whole song, so at 8 threads a few simultaneous playbacks
+# could consume the worker and leave gate slots idle with nobody able to reach
+# them. A thread parked on a socket read costs a stack and nothing else.
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "-w", "1", "--threads", "32", "--timeout", "120", "app:app"]

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -37,6 +37,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from flask import Flask, Response, abort, jsonify, request, stream_with_context
 
+from gate import TieredGate
+
 YTDLP = os.environ.get("YTDLP_PATH", "/usr/local/bin/yt-dlp")
 PORT = int(os.environ.get("PORT", "8080"))
 
@@ -54,6 +56,22 @@ _AUDIO_FORMAT = os.environ.get(
     "YTDLP_AUDIO_FORMAT",
     "140/bestaudio[ext=m4a]/bestaudio[ext=webm]/bestaudio",
 )
+
+# User-Agent sent to googlevideo when proxying bytes. Empty (the default) keeps
+# requests' own python-requests/x.y, i.e. existing behaviour. Signed URLs from
+# some player clients are refused for a mismatched UA, so this exists to test
+# that without a code change; it is off by default so it cannot confound the
+# 403 diagnostics in stream().
+_UPSTREAM_UA = os.environ.get("UPSTREAM_USER_AGENT", "").strip()
+
+# yt-dlp's cache holds the player base.js and solved signatures, and is
+# deliberately persistent (see the note in _run). Nothing invalidates it, so a
+# rotated player leaves every resolve producing URLs googlevideo refuses.
+# Purging is the standard recovery, but doing it on every 403 would throw the
+# cache away during a burst and make things worse -- hence the interval.
+_CACHE_PURGE_MIN_INTERVAL_SEC = int(os.environ.get("CACHE_PURGE_MIN_INTERVAL_SEC", "900"))
+_CACHE_PURGE_LOCK = threading.Lock()
+_last_cache_purge = 0.0
 
 # In-memory LRU cache of search-query -> json result. Cuts repeat searches
 # from a 3-8s yt-dlp invocation to a dict lookup. Bounded so we never grow
@@ -120,29 +138,62 @@ def _url_cache_evict(video_id: str):
     with _URL_CACHE_LOCK:
         _URL_CACHE.pop(video_id, None)
 
+def _url_cache_evict_if(video_id: str, expected_url: str):
+    """Evict only if the cache still holds the URL that just failed.
+
+    Two threads can 403 on the same stale URL (an iOS client sends a
+    `Range: bytes=0-1` probe and then the real GET). An unconditional evict lets
+    the second thread discard the good URL the first one just resolved, and fork
+    another yt-dlp to rediscover it.
+    """
+    with _URL_CACHE_LOCK:
+        entry = _URL_CACHE.get(video_id)
+        if entry and entry[1] == expected_url:
+            _URL_CACHE.pop(video_id, None)
+
 # Cap concurrent yt-dlp processes globally. Each one is fork+exec heavy;
-# letting them stack starves a small container.
-_GATE = threading.Semaphore(int(os.environ.get("MAX_CONCURRENT_YTDLP", "5")))
+# letting them stack starves a small container. GATE_RESERVE_INTERACTIVE of the
+# slots are unreachable by background work (prewarm, /download), so a user
+# pressing play never queues behind a prewarm burst.
+_MAX_CONCURRENT = int(os.environ.get("MAX_CONCURRENT_YTDLP", "5"))
+_RESERVE_INTERACTIVE = int(os.environ.get("GATE_RESERVE_INTERACTIVE", "2"))
+_GATE = TieredGate(_MAX_CONCURRENT, _RESERVE_INTERACTIVE)
 # Max time a queued request will wait for a free slot. Long enough that a
 # burst of 10 parallel radio-resolution searches all eventually succeed
 # rather than dropping requests on the floor.
 _GATE_WAIT_SEC = int(os.environ.get("GATE_WAIT_SEC", "45"))
+# Background waits far less than that: it is fire-and-forget, it is already
+# stale by the time a 45s queue clears, and a parked thread is one of a finite
+# gunicorn pool. Shedding it early is better than holding a thread for nothing.
+_BG_GATE_WAIT_SEC = int(os.environ.get("BG_GATE_WAIT_SEC", "10"))
+# How long an interactive resolve coalesces behind an in-flight one before
+# giving up and resolving in parallel. See _resolve_url.
+_INFLIGHT_WAIT_SEC = float(os.environ.get("INFLIGHT_WAIT_SEC", "0.25"))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger("ytdlp-shim")
 
 app = Flask(__name__)
 
+log.info(
+    "gate: total=%d reserve=%d bg_capacity=%d",
+    _GATE.total, _GATE.reserve, _GATE.total - _GATE.reserve,
+)
 
-def _run(args: list[str], timeout: int = 20, label: str = "ytdlp") -> Optional[str]:
+
+def _run(args: list[str], timeout: int = 20, label: str = "ytdlp",
+         bg: bool = False) -> Optional[str]:
     """Run yt-dlp with a hard timeout. Returns stdout or None on any failure.
 
     Logs gate-wait and wall time so a real box can show whether interactive
-    resolves are queuing behind background prewarm (grep `gate_wait_ms`).
+    resolves are queuing behind background prewarm (grep `gate_wait_ms`), and
+    `bg` so the two can actually be told apart in the log.
     """
     t_acquire = time.monotonic()
-    if not _GATE.acquire(timeout=_GATE_WAIT_SEC):
-        log.warning("yt-dlp gate full after %ds, dropping: %s", _GATE_WAIT_SEC, " ".join(args))
+    wait = _BG_GATE_WAIT_SEC if bg else _GATE_WAIT_SEC
+    if not _GATE.acquire(bg, wait):
+        log.warning("yt-dlp gate full after %ds (bg=%d), dropping: %s",
+                    wait, int(bg), " ".join(args))
         return None
     gate_ms = (time.monotonic() - t_acquire) * 1000.0
     try:
@@ -164,18 +215,30 @@ def _run(args: list[str], timeout: int = 20, label: str = "ytdlp") -> Optional[s
             log.warning("yt-dlp timed out (%s, gate_wait_ms=%.0f): %s", label, gate_ms, " ".join(args))
             return None
         wall_ms = (time.monotonic() - t_run) * 1000.0
-        log.info("ytdlp label=%s gate_wait_ms=%.0f wall_ms=%.0f rc=%d", label, gate_ms, wall_ms, cp.returncode)
+        log.info("ytdlp label=%s bg=%d gate_wait_ms=%.0f wall_ms=%.0f rc=%d",
+                 label, int(bg), gate_ms, wall_ms, cp.returncode)
         if cp.returncode != 0:
             log.warning("yt-dlp exit %d (%s): %s", cp.returncode, label, cp.stderr.strip()[:300])
             return None
         return cp.stdout
     finally:
-        _GATE.release()
+        _GATE.release(bg)
 
 
 @app.get("/health")
 def health():
     return jsonify(ok=True)
+
+
+def _is_bg() -> bool:
+    """True for fire-and-forget prewarm, which yields gate slots to real plays.
+
+    Absence means interactive, so a caller that forgets the flag fails safe:
+    slower background, never a deprioritised play. NEVER fold this into a cache
+    key -- the result is identical either way, and keying on it would halve the
+    hit rate for no benefit.
+    """
+    return request.args.get("bg") == "1"
 
 
 @app.get("/search")
@@ -186,13 +249,14 @@ def search():
 
     hint_str = request.args.get("duration", "").strip()
     duration_hint = int(hint_str) if hint_str.isdigit() else None
+    bg = _is_bg()
 
     cache_key = f"{q.lower()}|{duration_hint or ''}"
     cached = _cache_get(cache_key)
     if cached is not None:
         return jsonify(**cached)
 
-    payload = _search_with_hint(q, duration_hint) if duration_hint is not None else _search_single(q)
+    payload = _search_with_hint(q, duration_hint, bg) if duration_hint is not None else _search_single(q, bg)
     if payload is None:
         return jsonify(error="search_failed"), 502
     if not payload.get("video_id"):
@@ -211,7 +275,7 @@ def _payload_from(data: dict) -> dict:
     }
 
 
-def _search_single(q: str) -> Optional[dict]:
+def _search_single(q: str, bg: bool = False) -> Optional[dict]:
     """No duration hint: fast path. One extraction yields metadata AND the
     stream URL, which we warm into the URL cache so /stream is a cache hit."""
     out = _run(
@@ -224,6 +288,7 @@ def _search_single(q: str) -> Optional[dict]:
         ],
         timeout=15,
         label="search+resolve",
+        bg=bg,
     )
     if out is None:
         return None
@@ -246,9 +311,13 @@ def _search_single(q: str) -> Optional[dict]:
     return payload
 
 
-def _search_with_hint(q: str, duration_hint: int) -> Optional[dict]:
+def _search_with_hint(q: str, duration_hint: int, bg: bool = False) -> Optional[dict]:
     """Duration hint present: pick the closest-length of 5 flat candidates
-    (cheap, no per-video extraction), then resolve the winner's URL once."""
+    (cheap, no per-video extraction), then resolve the winner's URL once.
+
+    Note this path costs TWO gated yt-dlp runs per track (search5 then resolve),
+    where the no-hint path gets both from one extraction.
+    """
     out = _run(
         [
             f"ytsearch5:{q}",
@@ -257,6 +326,7 @@ def _search_with_hint(q: str, duration_hint: int) -> Optional[dict]:
         ],
         timeout=20,
         label="search5",
+        bg=bg,
     )
     if out is None:
         return None
@@ -280,7 +350,7 @@ def _search_with_hint(q: str, duration_hint: int) -> Optional[dict]:
     payload = _payload_from(candidates[0])
     if payload.get("video_id"):
         # Warm the URL cache for the coming /stream (single-flight + cached).
-        _resolve_url(payload["video_id"])
+        _resolve_url(payload["video_id"], bg)
     return payload
 
 
@@ -421,7 +491,7 @@ def meta():
     return jsonify(**payload)
 
 
-def _resolve_url(video_id: str) -> Optional[str]:
+def _resolve_url(video_id: str, bg: bool = False) -> Optional[str]:
     cached = _url_cache_get(video_id)
     if cached:
         return cached
@@ -431,29 +501,65 @@ def _resolve_url(video_id: str) -> Optional[str]:
     # second identical `yt-dlp -g`.
     with _INFLIGHT_LOCK:
         lock = _INFLIGHT.setdefault(video_id, threading.Lock())
-    with lock:
+
+    # An interactive caller must not inherit a background leader's queue
+    # position. The leader may be parked in the gate for seconds, and that wait
+    # is invisible to the reserve because a follower never reaches a gate at
+    # all -- it is asleep on this lock. If the leader does not hand over
+    # promptly, resolve in parallel: one extra yt-dlp fork is far cheaper than a
+    # user-visible stall.
+    coalesced = lock.acquire(timeout=_GATE_WAIT_SEC if bg else _INFLIGHT_WAIT_SEC)
+    try:
+        # Re-check on BOTH branches. The leader may have finished while we
+        # waited, and without this every interactive caller for a contended id
+        # forks its own resolve -- burning the very slots the reserve protects.
         cached = _url_cache_get(video_id)
         if cached:
             return cached
-        try:
-            out = _run(
-                [
-                    "-g",
-                    "-f", _AUDIO_FORMAT,
-                    f"https://www.youtube.com/watch?v={video_id}",
-                ],
-                timeout=15,
-                label="resolve",
-            )
-            if not out:
-                return None
-            url = out.strip().split("\n", 1)[0].strip()
-            if url:
-                _url_cache_put(video_id, url)
-            return url or None
-        finally:
+        out = _run(
+            [
+                "-g",
+                "-f", _AUDIO_FORMAT,
+                f"https://www.youtube.com/watch?v={video_id}",
+            ],
+            timeout=15,
+            label="resolve",
+            bg=bg,
+        )
+        if not out:
+            return None
+        url = out.strip().split("\n", 1)[0].strip()
+        if url:
+            _url_cache_put(video_id, url)
+        return url or None
+    finally:
+        # Only the thread that actually holds the lock may pop and release it.
+        if coalesced:
             with _INFLIGHT_LOCK:
                 _INFLIGHT.pop(video_id, None)
+            lock.release()
+
+
+def _purge_ytdlp_cache(video_id: str) -> None:
+    """Drop yt-dlp's player/signature cache after a 403 survives a re-resolve.
+
+    The cache is persistent by design (see _run), which means a rotated YouTube
+    player leaves every resolve producing URLs googlevideo refuses, forever.
+    Purging is the standard recovery. It is rate-limited because doing it on
+    every 403 would throw away base.js during a burst and make things worse, and
+    it deliberately does not retry the current play -- the next one benefits.
+    """
+    global _last_cache_purge
+    with _CACHE_PURGE_LOCK:
+        now = time.monotonic()
+        if now - _last_cache_purge < _CACHE_PURGE_MIN_INTERVAL_SEC:
+            return
+        _last_cache_purge = now
+    log.warning(
+        "stream %s: 403 survived a re-resolve, purging yt-dlp cache "
+        "(rotated player is the usual cause)", video_id,
+    )
+    _run(["--rm-cache-dir"], timeout=30, label="rm-cache", bg=True)
 
 
 def _open_upstream(url: str, headers: dict, video_id: str):
@@ -485,6 +591,8 @@ def stream():
     incoming_range = request.headers.get("Range")
     if incoming_range:
         upstream_headers["Range"] = incoming_range
+    if _UPSTREAM_UA:
+        upstream_headers["User-Agent"] = _UPSTREAM_UA
 
     upstream = _open_upstream(url, upstream_headers, video_id)
     # A signed googlevideo URL can expire between resolve and play (long or
@@ -492,11 +600,26 @@ def stream():
     # the bad entry, re-resolve once, and retry before surfacing a failure, so
     # one stale URL does not fail every play of this id for the cache TTL.
     if upstream is not None and upstream.status_code in (403, 410):
+        # Google states the reason in the body and headers. Closing without
+        # reading them threw away the only direct evidence of why a play failed,
+        # which cost a long debugging session on 2026-08-14. Bounded read: a
+        # refusal body is small, and we are about to discard the response.
+        try:
+            detail = upstream.raw.read(512, decode_content=True) or b""
+        except Exception:
+            detail = b""
+        log.warning(
+            "stream %s: upstream %d headers=%s body=%r",
+            video_id, upstream.status_code, dict(upstream.headers), detail[:200],
+        )
         upstream.close()
-        log.info("stream %s: signed url expired (%d), re-resolving", video_id, upstream.status_code)
-        _url_cache_evict(video_id)
+        _url_cache_evict_if(video_id, url)
         url = _resolve_url(video_id)
         upstream = _open_upstream(url, upstream_headers, video_id) if url else None
+        # A freshly resolved URL that is refused again is not an expiry; the
+        # most common remaining cause is a stale cached player.
+        if upstream is not None and upstream.status_code in (403, 410):
+            _purge_ytdlp_cache(video_id)
 
     if upstream is None or upstream.status_code not in (200, 206):
         code = upstream.status_code if upstream is not None else "n/a"
@@ -571,6 +694,10 @@ def download():
         ],
         timeout=300,
         label="download",
+        # Background on purpose, regardless of what triggered it: this holds its
+        # slot for up to five minutes, and a single star-triggered download must
+        # never be able to sit in a slot a play is waiting for.
+        bg=True,
     )
     path = f"{full_dest}.mp3"
     if out is None or not os.path.exists(path):

--- a/yt-dlp-shim/gate.py
+++ b/yt-dlp-shim/gate.py
@@ -1,0 +1,66 @@
+"""Global cap on concurrent yt-dlp processes, with a slice reserved for
+interactive work.
+
+Octo prewarms upcoming tracks in the background. Those resolves are
+fire-and-forget, but they used to compete on equal terms with a user pressing
+play, so a burst could leave an interactive resolve queued behind eight
+background ones.
+
+Background callers must clear an outer semaphore sized (total - reserve) before
+they reach the main gate, so background can never hold more than that many slots
+and `reserve` slots stay reachable by an interactive request. Interactive
+callers take the main gate directly and are never blocked by the outer one.
+
+Acquire and release are paired on one object on purpose. The failure mode of a
+hand-rolled two-semaphore scheme is a mismatched release: forget to hand back
+the outer permit and background capacity decays toward zero, hand back a permit
+that was never taken and the gate silently stops bounding anything. Both are
+invisible in production until the box falls over.
+
+Kept free of any app.py import so it stays cheap to unit test: importing app.py
+initialises a sqlite meta cache and pulls in flask and requests.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+
+class TieredGate:
+    """A counting gate where background work cannot consume every slot."""
+
+    def __init__(self, total: int, reserve: int):
+        # Clamp rather than trust the environment. reserve >= total would leave
+        # background with a zero-capacity semaphore, which is not "background is
+        # deprioritised" but "background deadlocks until it times out", and the
+        # symptom (discovery quietly stops working) is far from the cause.
+        total = max(1, total)
+        reserve = min(max(0, reserve), total - 1)
+        self.total = total
+        self.reserve = reserve
+        self._main = threading.Semaphore(total)
+        self._bg = threading.Semaphore(total - reserve)
+
+    def acquire(self, bg: bool, timeout: float) -> bool:
+        """Take a slot. Returns False if `timeout` elapsed without one."""
+        if not bg:
+            return self._main.acquire(timeout=timeout)
+
+        # One budget spanning both acquisitions, not `timeout` each. Two
+        # independent waits would let a background request block for twice the
+        # caller's own HTTP timeout, holding a worker thread for a response
+        # nobody is left to read.
+        deadline = time.monotonic() + timeout
+        if not self._bg.acquire(timeout=timeout):
+            return False
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not self._main.acquire(timeout=remaining):
+            self._bg.release()
+            return False
+        return True
+
+    def release(self, bg: bool) -> None:
+        """Hand a slot back. `bg` must match the value passed to acquire."""
+        self._main.release()
+        if bg:
+            self._bg.release()

--- a/yt-dlp-shim/requirements-dev.txt
+++ b/yt-dlp-shim/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Test-only dependencies. Deliberately not installed into the runtime image --
+# the shim ships flask, gunicorn and requests and nothing else.
+pytest

--- a/yt-dlp-shim/tests/test_gate.py
+++ b/yt-dlp-shim/tests/test_gate.py
@@ -1,0 +1,110 @@
+"""The gate is what stops background prewarm from starving a user pressing play,
+so the properties worth pinning are the ones whose failure is invisible.
+
+A leaked permit does not throw: the gate simply stops bounding anything (or
+decays toward deadlock) and the box falls over later under load, far from the
+edit that caused it. Likewise a doubled timeout budget just looks like "the shim
+is slow sometimes". Both are asserted here directly.
+"""
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gate import TieredGate  # noqa: E402
+
+
+def test_reserved_slots_stay_reachable_when_background_is_saturated():
+    """The whole point: background at capacity must not block a play."""
+    gate = TieredGate(total=5, reserve=2)
+
+    for _ in range(gate.total - gate.reserve):
+        assert gate.acquire(bg=True, timeout=1)
+
+    # Background is now at its ceiling and must be refused...
+    assert not gate.acquire(bg=True, timeout=0.2)
+    # ...while the reserved slots remain available to interactive work.
+    assert gate.acquire(bg=False, timeout=0.2)
+    assert gate.acquire(bg=False, timeout=0.2)
+
+
+def test_failed_background_acquire_does_not_leak_a_permit():
+    """A mismatched release is the classic two-semaphore bug and is silent.
+
+    Fill the gate with interactive holders so a background acquire clears the
+    outer semaphore and then fails on the main one. If the outer permit is not
+    handed back, background capacity shrinks permanently.
+    """
+    gate = TieredGate(total=3, reserve=1)
+    bg_capacity = gate.total - gate.reserve
+
+    for _ in range(gate.total):
+        assert gate.acquire(bg=False, timeout=1)
+
+    # Clears _bg, cannot get _main, must return the _bg permit on the way out.
+    assert not gate.acquire(bg=True, timeout=0.2)
+
+    for _ in range(gate.total):
+        gate.release(bg=False)
+
+    # Full background capacity must still be there.
+    for _ in range(bg_capacity):
+        assert gate.acquire(bg=True, timeout=0.5), "background permit was leaked"
+    assert not gate.acquire(bg=True, timeout=0.2)
+
+
+def test_total_capacity_is_still_bounded_after_churn():
+    """Releasing must not inflate the gate into bounding nothing."""
+    gate = TieredGate(total=3, reserve=1)
+
+    for _ in range(4):
+        assert gate.acquire(bg=True, timeout=1)
+        gate.release(bg=True)
+
+    for _ in range(gate.total):
+        assert gate.acquire(bg=False, timeout=0.5)
+    assert not gate.acquire(bg=False, timeout=0.2), "gate stopped bounding"
+
+
+def test_background_acquire_honours_one_shared_deadline():
+    """Two per-semaphore timeouts would let background wait twice as long as the
+    caller's own HTTP timeout, holding a worker thread for a dead response."""
+    gate = TieredGate(total=2, reserve=1)
+    for _ in range(gate.total):
+        assert gate.acquire(bg=False, timeout=1)
+
+    timeout = 0.4
+    started = time.monotonic()
+    assert not gate.acquire(bg=True, timeout=timeout)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < timeout * 1.8, f"waited {elapsed:.2f}s against a {timeout}s budget"
+
+
+def test_reserve_is_clamped_so_background_never_collapses():
+    """A config typo must degrade background, not deadlock it."""
+    gate = TieredGate(total=5, reserve=9)
+
+    assert gate.total - gate.reserve >= 1
+    assert gate.acquire(bg=True, timeout=0.5)
+
+
+def test_interactive_waits_are_served_once_a_slot_frees():
+    """Sanity check that the gate blocks rather than busy-fails under contention."""
+    gate = TieredGate(total=1, reserve=0)
+    assert gate.acquire(bg=False, timeout=1)
+
+    acquired = []
+
+    def waiter():
+        acquired.append(gate.acquire(bg=False, timeout=2))
+
+    t = threading.Thread(target=waiter)
+    t.start()
+    time.sleep(0.1)
+    gate.release(bg=False)
+    t.join(timeout=3)
+
+    assert acquired == [True]


### PR DESCRIPTION
## What this release-sized PR carries

Eighteen commits from one long field session against a real deployment. Three threads:

**Playback reliability.** A production play failed with googlevideo 403s and the shim was throwing away the response that says why — 403s now log status, headers and body before retrying, eviction is compare-and-swap, and a 403 that survives a re-resolve purges yt-dlp's cache (rate-limited). yt-dlp gets deno for its JS challenges. The yt-dlp gate reserves slots for interactive plays so prewarm bursts can never starve a user pressing play (measured: background queued 3.7-3.9s while an interactive resolve in the same burst waited 0ms), the prewarm limiter is shared across triggers instead of per-invocation, and gunicorn threads rise 8→32 because /stream holds its thread for the whole song.

**Soulseek actually finds lossless now.** `SearchWaitSeconds` shipped as 6, and slskd's `/responses` returns nothing until ~20s — measured three times, identically — so every star silently fell back to YouTube MP3 while FLACs sat unseen. The wait is now a 30s ceiling with event-driven early exit: the search returns as soon as ranking has enough usable candidates or slskd reports the search finished. The same track that fell back three times at 6s landed as a 34.7MB FLAC on the first 30s attempt.

**Seeing what Octo does.** A notification system (ntfy + Discord webhook behind one sink interface, five per-event toggles, admin tab with a Send-test button, hot-reload throughout): download started/completed/lossless-fallback/failed/album-summary, rendered as a song card on Discord (full-width art, inline format/size/length/bitrate/year fields) and the plain-text equivalent on ntfy with the cover as both icon and attachment. Album walks emit one summary instead of per-track pings. Plus a library status readout (what Navidrome reports, whether Octo can see it, where downloads actually land), a multi-library picker, and an authenticated directory browser for the one case auto-detect can't solve.

Also: the shim gets CI (compileall + gate tests — previously a syntax error in app.py passed CI and was found when the container failed to restart), and `[hidden]` now actually hides in the admin UI.

## Verified

End to end on a live instance: real star → 33MB Soulseek FLAC → Discord song card and ntfy push with album art received by an outside subscriber. 246 tests. Known issue carried forward (documented, not fixed here): the title-only Soulseek fallback matches too loosely on short/generic titles.
