### PR TITLE
fix: YouTube downloads were dead, the self-heal was inert, and admin settings never applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,11 @@ Yes. Soulseek peers share full FLAC files with their existing ID3 tags intact. O
 
 ### What if I don't want to use Soulseek?
 
-Set `Subsonic__DownloadOnStar=false` in `.env`. Hearting a song will still register the favorite, but won't trigger any download. You'll keep search and radio enrichment via YouTube preview — useful if you only want the discovery layer and prefer to acquire FLACs another way.
+You have two options, depending on whether you still want a file.
+
+To keep downloading but pull from YouTube instead, set `DOWNLOAD_SOURCE=YouTube` in `.env`, or pick it under **Downloads → Source** in the admin UI. Starring then saves a yt-dlp MP3 rather than a Soulseek FLAC. `SoulseekThenYouTube` is the middle setting: it tries for the FLAC first and only settles for the MP3 when no peer delivers.
+
+To stop downloading altogether, set `Subsonic__DownloadOnStar=false`. Hearting a song will still register the favorite, but won't trigger any download. You'll keep search and radio enrichment via YouTube preview, which is useful if you only want the discovery layer and prefer to acquire FLACs another way.
 
 ### Can it run on a Raspberry Pi?
 
@@ -272,7 +276,7 @@ Octo hijacks these endpoints; everything else proxies to Navidrome unchanged:
 | `stream` | YouTube proxy with Range support, mp4/m4a passthrough |
 | `getCoverArt` | Deezer → iTunes → Last.fm aggregator with Octo watermark |
 | `getAlbum` | external album tracklists, and fills in tracks you're missing from an album you own |
-| `star` | trigger Soulseek download (multi-peer retry, FLAC), or a whole album |
+| `star` | trigger a download of the track or a whole album, from whichever source `DOWNLOAD_SOURCE` selects (Soulseek multi-peer FLAC by default) |
 | `scrobble` | sliding-window prewarm of next 8 in queue |
 | `getTranscodeDecision` | OpenSubsonic — return direct-play for Octo IDs |
 
@@ -312,7 +316,7 @@ Yes — slskd downloads are full FLACs from peer libraries that already have ID3
 Octo throws an error and the star icon stays filled. Try again later or grab the file by hand. Real failures are rare.
 
 **Can it run without Soulseek?**
-Yes — set `Subsonic__DownloadOnStar=false`. Star fills the heart but won't trigger a download. Search and radio enrichment still work.
+Yes. Set `DOWNLOAD_SOURCE=YouTube` to keep downloading, as a yt-dlp MP3 instead of a FLAC, or `Subsonic__DownloadOnStar=false` to stop downloading entirely. Search and radio enrichment work either way.
 
 **Can it run without Last.fm?**
 Yes, but search and radio fall back to local-only — no discovery layer. The free Last.fm key takes 30 seconds.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,10 @@ services:
       URL_CACHE_TTL: ${YTDLP_URL_CACHE_TTL:-3600}
       # Root the /download endpoint may write under (matches the /music mount).
       DOWNLOAD_ROOT: /music
+      # Run yt-dlp from the volume below rather than the copy baked into the
+      # image, so a self-update survives the container being recreated. The
+      # image copy is still the floor: a rebuild re-seeds this on next start.
+      YTDLP_PATH: /opt/ytdlp/yt-dlp
       # Persistent duration cache (SQLite). On the named volume below so resolved
       # "artist - title -> {video_id, duration}" mappings survive container recreate.
       META_DB_PATH: /var/lib/ytshim/meta.db
@@ -110,6 +114,12 @@ services:
       # where Navidrome scans; same host dir Octo and slskd mount, so dest paths
       # line up across containers.
       - ${DOWNLOAD_PATH:-./downloads}:/music
+      # Writable home for the yt-dlp binary. YouTube rotates its player on its
+      # own schedule and YTDLP_VERSION=latest is resolved at BUILD time, so an
+      # image that is not rebuilt ships one frozen version forever. The shim
+      # self-updates when a 403 outlives a cache purge; this is what makes that
+      # update outlive the next `docker compose up -d`.
+      - ytdlp-bin:/opt/ytdlp
 
   # Soulseek client (slskd). Web UI on 5030, peer port 50300.
   # State (config, db, downloads-in-progress) persisted to ./slskd-state so the
@@ -144,3 +154,4 @@ services:
 volumes:
   ytdlp-cache:
   ytshim-cache:
+  ytdlp-bin:

--- a/octo.Tests/LocalLibraryServiceTests.cs
+++ b/octo.Tests/LocalLibraryServiceTests.cs
@@ -46,7 +46,7 @@ public class LocalLibraryServiceTests : IDisposable
         _mockHttpClientFactory = new Mock<IHttpClientFactory>();
         _mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
-        var subsonicSettings = Options.Create(new SubsonicSettings { Url = "http://localhost:4533" });
+        var subsonicSettings = TestOptions.Monitor(new SubsonicSettings { Url = "http://localhost:4533" });
         var mockLogger = new Mock<ILogger<LocalLibraryService>>();
 
         var idRegistry = new Octo.Services.Soulseek.ExternalIdRegistry();

--- a/octo.Tests/SubsonicProxyServiceTests.cs
+++ b/octo.Tests/SubsonicProxyServiceTests.cs
@@ -23,7 +23,7 @@ public class SubsonicProxyServiceTests
         _mockHttpClientFactory = new Mock<IHttpClientFactory>();
         _mockHttpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
-        var settings = Options.Create(new SubsonicSettings 
+        var settings = TestOptions.Monitor(new SubsonicSettings 
         { 
             Url = "http://localhost:4533" 
         });
@@ -100,6 +100,42 @@ public class SubsonicProxyServiceTests
         Assert.Contains("http://localhost:4533/rest/ping", capturedRequest!.RequestUri!.ToString());
         Assert.Contains("u=admin", capturedRequest.RequestUri.ToString());
         Assert.Contains("p=secret", capturedRequest.RequestUri.ToString());
+    }
+
+    [Fact]
+    public async Task RelayAsync_PicksUpASettingsChangeWithoutBeingRebuilt()
+    {
+        // Regression for the admin UI applying nothing until a restart. These
+        // services are singletons, so capturing IOptions.Value in the constructor
+        // froze settings at startup while the admin UI, reading through
+        // IOptionsMonitor, happily showed the new value as if it had taken effect.
+        HttpRequestMessage? capturedRequest = null;
+        var responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(Array.Empty<byte>())
+        };
+
+        _mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+            .ReturnsAsync(responseMessage);
+
+        var settings = TestOptions.Monitor(new SubsonicSettings { Url = "http://localhost:4533" });
+        var service = new SubsonicProxyService(
+            _mockHttpClientFactory.Object,
+            settings,
+            new HttpContextAccessor { HttpContext = new DefaultHttpContext() });
+
+        // Stand in for settings.json being rewritten by the admin UI and reloaded.
+        settings.Set(new SubsonicSettings { Url = "http://navidrome-moved:9999" });
+
+        await service.RelayAsync("rest/ping", new Dictionary<string, string> { { "u", "admin" } });
+
+        // The host is the point: the relay followed the new value with no rebuild.
+        Assert.Contains("http://navidrome-moved:9999/rest/ping", capturedRequest!.RequestUri!.ToString());
+        Assert.DoesNotContain("localhost:4533", capturedRequest.RequestUri.ToString());
     }
 
     [Fact]
@@ -353,7 +389,7 @@ public class SubsonicProxyServiceTests
         httpContext.Request.Headers["Range"] = "bytes=0-1023";
         var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
         var service = new SubsonicProxyService(_mockHttpClientFactory.Object, 
-            Options.Create(new SubsonicSettings { Url = "http://localhost:4533" }), 
+            TestOptions.Monitor(new SubsonicSettings { Url = "http://localhost:4533" }), 
             httpContextAccessor);
 
         var parameters = new Dictionary<string, string> { { "id", "song123" } };
@@ -389,7 +425,7 @@ public class SubsonicProxyServiceTests
         httpContext.Request.Headers["If-Range"] = "\"etag123\"";
         var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
         var service = new SubsonicProxyService(_mockHttpClientFactory.Object,
-            Options.Create(new SubsonicSettings { Url = "http://localhost:4533" }),
+            TestOptions.Monitor(new SubsonicSettings { Url = "http://localhost:4533" }),
             httpContextAccessor);
 
         var parameters = new Dictionary<string, string> { { "id", "song123" } };
@@ -408,7 +444,7 @@ public class SubsonicProxyServiceTests
         // Arrange
         var httpContextAccessor = new HttpContextAccessor { HttpContext = null };
         var service = new SubsonicProxyService(_mockHttpClientFactory.Object,
-            Options.Create(new SubsonicSettings { Url = "http://localhost:4533" }),
+            TestOptions.Monitor(new SubsonicSettings { Url = "http://localhost:4533" }),
             httpContextAccessor);
 
         var parameters = new Dictionary<string, string> { { "id", "song123" } };

--- a/octo.Tests/TestOptionsMonitor.cs
+++ b/octo.Tests/TestOptionsMonitor.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Options;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// Minimal IOptionsMonitor for tests. Options.Create only produces IOptions, and
+/// the services under test deliberately take a monitor so admin-UI settings
+/// changes reach them without a restart. Set() lets a test drive that reload.
+/// </summary>
+public sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+{
+    private readonly List<Action<T, string?>> _listeners = new();
+
+    public TestOptionsMonitor(T value) => CurrentValue = value;
+
+    public T CurrentValue { get; private set; }
+
+    public T Get(string? name) => CurrentValue;
+
+    public IDisposable? OnChange(Action<T, string?> listener)
+    {
+        _listeners.Add(listener);
+        return null;
+    }
+
+    /// <summary>Stand in for settings.json being rewritten and reloaded.</summary>
+    public void Set(T value)
+    {
+        CurrentValue = value;
+        foreach (var l in _listeners) l(value, null);
+    }
+}
+
+/// <summary>Factory so call sites keep type inference: TestOptions.Monitor(new X { ... }).</summary>
+public static class TestOptions
+{
+    public static TestOptionsMonitor<T> Monitor<T>(T value) => new(value);
+}

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -23,7 +23,13 @@ namespace Octo.Controllers;
 [Route("")]
 public class SubsonicController : ControllerBase
 {
-    private readonly SubsonicSettings _subsonicSettings;
+    // IOptionsMonitor, not IOptions: the admin UI writes settings.json and the
+    // config provider reloads it, but IOptions.Value is resolved once and this is a
+    // singleton, so a captured copy would serve startup values until a restart. The
+    // admin UI read through IOptionsMonitor and therefore SHOWED the new value while
+    // nothing acted on it.
+    private readonly IOptionsMonitor<SubsonicSettings> subsonicSettingsOptions;
+    private SubsonicSettings _subsonicSettings => subsonicSettingsOptions.CurrentValue;
     private readonly IMusicMetadataService _metadataService;
     private readonly ILocalLibraryService _localLibraryService;
     private readonly IDownloadService _downloadService;
@@ -44,7 +50,7 @@ public class SubsonicController : ControllerBase
     private readonly ILogger<SubsonicController> _logger;
 
     public SubsonicController(
-        IOptions<SubsonicSettings> subsonicSettings,
+        IOptionsMonitor<SubsonicSettings> subsonicSettings,
         IMusicMetadataService metadataService,
         ILocalLibraryService localLibraryService,
         IDownloadService downloadService,
@@ -64,7 +70,7 @@ public class SubsonicController : ControllerBase
         CoverArtService? coverArtService = null,
         CoverArtAggregator? coverArtAggregator = null)
     {
-        _subsonicSettings = subsonicSettings.Value;
+        subsonicSettingsOptions = subsonicSettings;
         _metadataService = metadataService;
         _localLibraryService = localLibraryService;
         _downloadService = downloadService;

--- a/octo/Services/Common/BaseDownloadService.cs
+++ b/octo/Services/Common/BaseDownloadService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
 using Octo.Models.Domain;
 using Octo.Models.Settings;
@@ -21,7 +22,12 @@ public abstract class BaseDownloadService : IDownloadService
     protected readonly IConfiguration Configuration;
     protected readonly ILocalLibraryService LocalLibraryService;
     protected readonly IMusicMetadataService MetadataService;
-    protected readonly SubsonicSettings SubsonicSettings;
+    // IOptionsMonitor, not a captured copy: this is a singleton, so the admin UI's
+    // Download source / storage mode / folder structure changes would otherwise not
+    // reach the download path until octorr restarted, while the admin UI itself
+    // (which already reads through IOptionsMonitor) showed them as applied.
+    private readonly IOptionsMonitor<SubsonicSettings> _subsonicOptions;
+    protected SubsonicSettings SubsonicSettings => _subsonicOptions.CurrentValue;
     protected readonly ILogger Logger;
     private readonly IServiceProvider _serviceProvider;
     private readonly NavidromeIdentityService _navIdentity;
@@ -71,7 +77,7 @@ public abstract class BaseDownloadService : IDownloadService
         IConfiguration configuration,
         ILocalLibraryService localLibraryService,
         IMusicMetadataService metadataService,
-        SubsonicSettings subsonicSettings,
+        IOptionsMonitor<SubsonicSettings> subsonicSettings,
         NavidromeIdentityService navIdentity,
         DownloadHistoryService history,
         Octo.Services.Notifications.NotificationService notifications,
@@ -81,7 +87,7 @@ public abstract class BaseDownloadService : IDownloadService
         Configuration = configuration;
         LocalLibraryService = localLibraryService;
         MetadataService = metadataService;
-        SubsonicSettings = subsonicSettings;
+        _subsonicOptions = subsonicSettings;
         _navIdentity = navIdentity;
         _history = history;
         Notifications = notifications;

--- a/octo/Services/Common/CacheCleanupService.cs
+++ b/octo/Services/Common/CacheCleanupService.cs
@@ -10,17 +10,23 @@ namespace Octo.Services.Common;
 public class CacheCleanupService : BackgroundService
 {
     private readonly IConfiguration _configuration;
-    private readonly SubsonicSettings _subsonicSettings;
+    // IOptionsMonitor, not IOptions: the admin UI writes settings.json and the
+    // config provider reloads it, but IOptions.Value is resolved once and this is a
+    // singleton, so a captured copy would serve startup values until a restart. The
+    // admin UI read through IOptionsMonitor and therefore SHOWED the new value while
+    // nothing acted on it.
+    private readonly IOptionsMonitor<SubsonicSettings> subsonicSettingsOptions;
+    private SubsonicSettings _subsonicSettings => subsonicSettingsOptions.CurrentValue;
     private readonly ILogger<CacheCleanupService> _logger;
     private readonly TimeSpan _cleanupInterval = TimeSpan.FromHours(1);
 
     public CacheCleanupService(
         IConfiguration configuration,
-        IOptions<SubsonicSettings> subsonicSettings,
+        IOptionsMonitor<SubsonicSettings> subsonicSettings,
         ILogger<CacheCleanupService> logger)
     {
         _configuration = configuration;
-        _subsonicSettings = subsonicSettings.Value;
+        subsonicSettingsOptions = subsonicSettings;
         _logger = logger;
     }
 

--- a/octo/Services/Local/LocalLibraryService.cs
+++ b/octo/Services/Local/LocalLibraryService.cs
@@ -20,7 +20,13 @@ public class LocalLibraryService : ILocalLibraryService
     private readonly string _mappingFilePath;
     private readonly string _downloadDirectory;
     private readonly HttpClient _httpClient;
-    private readonly SubsonicSettings _subsonicSettings;
+    // IOptionsMonitor, not IOptions: the admin UI writes settings.json and the
+    // config provider reloads it, but IOptions.Value is resolved once and this is a
+    // singleton, so a captured copy would serve startup values until a restart. The
+    // admin UI read through IOptionsMonitor and therefore SHOWED the new value while
+    // nothing acted on it.
+    private readonly IOptionsMonitor<SubsonicSettings> subsonicSettingsOptions;
+    private SubsonicSettings _subsonicSettings => subsonicSettingsOptions.CurrentValue;
     private readonly ExternalIdRegistry _idRegistry;
     private readonly NavidromeIdentityService _navIdentity;
     private readonly ILogger<LocalLibraryService> _logger;
@@ -34,7 +40,7 @@ public class LocalLibraryService : ILocalLibraryService
     public LocalLibraryService(
         IConfiguration configuration,
         IHttpClientFactory httpClientFactory,
-        IOptions<SubsonicSettings> subsonicSettings,
+        IOptionsMonitor<SubsonicSettings> subsonicSettings,
         ExternalIdRegistry idRegistry,
         NavidromeIdentityService navIdentity,
         ILogger<LocalLibraryService> logger)
@@ -42,7 +48,7 @@ public class LocalLibraryService : ILocalLibraryService
         _downloadDirectory = configuration["Library:DownloadPath"] ?? Path.Combine(Directory.GetCurrentDirectory(), "downloads");
         _mappingFilePath = Path.Combine(_downloadDirectory, ".mappings.json");
         _httpClient = httpClientFactory.CreateClient();
-        _subsonicSettings = subsonicSettings.Value;
+        subsonicSettingsOptions = subsonicSettings;
         _idRegistry = idRegistry;
         _navIdentity = navIdentity;
         _logger = logger;

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -32,7 +32,7 @@ public class SoulseekDownloadService : BaseDownloadService
         IConfiguration configuration,
         ILocalLibraryService localLibraryService,
         IMusicMetadataService metadataService,
-        IOptions<SubsonicSettings> subsonicSettings,
+        IOptionsMonitor<SubsonicSettings> subsonicSettings,
         IOptions<SoulseekSettings> soulseekSettings,
         SoulseekClient slskd,
         YouTubeResolver youtube,
@@ -43,7 +43,7 @@ public class SoulseekDownloadService : BaseDownloadService
         Octo.Services.Notifications.NotificationService notifications,
         IServiceProvider serviceProvider,
         ILogger<SoulseekDownloadService> logger)
-        : base(configuration, localLibraryService, metadataService, subsonicSettings.Value, navIdentity, history, notifications, serviceProvider, logger)
+        : base(configuration, localLibraryService, metadataService, subsonicSettings, navIdentity, history, notifications, serviceProvider, logger)
     {
         _slskd = slskd;
         _settings = soulseekSettings.Value;

--- a/octo/Services/Subsonic/NavidromeIdentityService.cs
+++ b/octo/Services/Subsonic/NavidromeIdentityService.cs
@@ -27,7 +27,13 @@ public record NavidromeLibrary(string? Id, string? Name, string Folder);
 /// </summary>
 public class NavidromeIdentityService
 {
-    private readonly SubsonicSettings _settings;
+    // IOptionsMonitor, not IOptions: the admin UI writes settings.json and the
+    // config provider reloads it, but IOptions.Value is resolved once and this is a
+    // singleton, so a captured copy would serve startup values until a restart. The
+    // admin UI read through IOptionsMonitor and therefore SHOWED the new value while
+    // nothing acted on it.
+    private readonly IOptionsMonitor<SubsonicSettings> settingsOptions;
+    private SubsonicSettings _settings => settingsOptions.CurrentValue;
     private readonly IHttpClientFactory _httpFactory;
     private readonly ILogger<NavidromeIdentityService> _logger;
 
@@ -44,11 +50,11 @@ public class NavidromeIdentityService
     private readonly SemaphoreSlim _detectGate = new(1, 1);
 
     public NavidromeIdentityService(
-        IOptions<SubsonicSettings> settings,
+        IOptionsMonitor<SubsonicSettings> settings,
         IHttpClientFactory httpFactory,
         ILogger<NavidromeIdentityService> logger)
     {
-        _settings = settings.Value;
+        settingsOptions = settings;
         _httpFactory = httpFactory;
         _logger = logger;
     }

--- a/octo/Services/Subsonic/PlaylistSyncService.cs
+++ b/octo/Services/Subsonic/PlaylistSyncService.cs
@@ -18,7 +18,13 @@ public class PlaylistSyncService
     private readonly IMusicMetadataService _qobuzMetadataService;
     private readonly IEnumerable<IDownloadService> _downloadServices;
     private readonly IConfiguration _configuration;
-    private readonly SubsonicSettings _subsonicSettings;
+    // IOptionsMonitor, not IOptions: the admin UI writes settings.json and the
+    // config provider reloads it, but IOptions.Value is resolved once and this is a
+    // singleton, so a captured copy would serve startup values until a restart. The
+    // admin UI read through IOptionsMonitor and therefore SHOWED the new value while
+    // nothing acted on it.
+    private readonly IOptionsMonitor<SubsonicSettings> subsonicSettingsOptions;
+    private SubsonicSettings _subsonicSettings => subsonicSettingsOptions.CurrentValue;
     private readonly ILogger<PlaylistSyncService> _logger;
     
     // In-memory cache to track which playlist a track belongs to
@@ -38,7 +44,7 @@ public class PlaylistSyncService
         IEnumerable<IMusicMetadataService> metadataServices,
         IEnumerable<IDownloadService> downloadServices,
         IConfiguration configuration,
-        IOptions<SubsonicSettings> subsonicSettings,
+        IOptionsMonitor<SubsonicSettings> subsonicSettings,
         ILogger<PlaylistSyncService> logger)
     {
         // Get Deezer and Qobuz metadata services
@@ -49,7 +55,7 @@ public class PlaylistSyncService
         
         _downloadServices = downloadServices;
         _configuration = configuration;
-        _subsonicSettings = subsonicSettings.Value;
+        subsonicSettingsOptions = subsonicSettings;
         _logger = logger;
         
         _musicDirectory = configuration["Library:DownloadPath"] ?? "./downloads";

--- a/octo/Services/Subsonic/SubsonicProxyService.cs
+++ b/octo/Services/Subsonic/SubsonicProxyService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Mvc;
 using Octo.Models.Settings;
 
@@ -9,16 +10,22 @@ namespace Octo.Services.Subsonic;
 public class SubsonicProxyService
 {
     private readonly HttpClient _httpClient;
-    private readonly SubsonicSettings _subsonicSettings;
+    // IOptionsMonitor, not IOptions: the admin UI writes settings.json and the
+    // config provider reloads it, but IOptions.Value is resolved once and this is a
+    // singleton, so a captured copy would serve startup values until a restart. The
+    // admin UI read through IOptionsMonitor and therefore SHOWED the new value while
+    // nothing acted on it.
+    private readonly IOptionsMonitor<SubsonicSettings> subsonicSettingsOptions;
+    private SubsonicSettings _subsonicSettings => subsonicSettingsOptions.CurrentValue;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public SubsonicProxyService(
         IHttpClientFactory httpClientFactory,
-        Microsoft.Extensions.Options.IOptions<SubsonicSettings> subsonicSettings,
+        IOptionsMonitor<SubsonicSettings> subsonicSettings,
         IHttpContextAccessor httpContextAccessor)
     {
         _httpClient = httpClientFactory.CreateClient();
-        _subsonicSettings = subsonicSettings.Value;
+        subsonicSettingsOptions = subsonicSettings;
         _httpContextAccessor = httpContextAccessor;
     }
 

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -334,7 +334,7 @@
             <div class="set-row stack">
               <div class="set-info">
                 <div class="set-info-t">Download source</div>
-                <div class="set-info-d">Soulseek gives lossless FLAC but depends on a peer having the file. YouTube always resolves but is lossy MP3. "Soulseek, then YouTube" tries FLAC first and falls back to MP3 only when no peer delivers.</div>
+                <div class="set-info-d">Soulseek gives lossless FLAC but depends on a peer having the file. YouTube always resolves but is lossy MP3, fetched through the yt-dlp shim. "Soulseek, then YouTube" tries FLAC first and falls back to MP3 only when no peer delivers. Same setting as <code>DOWNLOAD_SOURCE</code> in <code>.env</code> (<code>Soulseek</code> / <code>YouTube</code> / <code>SoulseekThenYouTube</code>); set it in either place, this one wins.</div>
               </div>
               <div class="set-ctrl">
                 <div class="seg" data-seg-for="f-download-source"><span class="seg-thumb"></span></div>
@@ -357,7 +357,7 @@
                 <div class="set-info-t">Download an album when starred</div>
                 <div class="set-info-d">Star a whole album to fetch every track. Downloads run one at a time, so a full album takes a while.</div>
               </div>
-              <label class="switch"><input type="checkbox" id="f-download-album-on-star" name="Subsonic.DownloadAlbumOnStar" data-restart="true" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
+              <label class="switch"><input type="checkbox" id="f-download-album-on-star" name="Subsonic.DownloadAlbumOnStar" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
             </div>
             <div class="set-row">
               <div class="set-info">
@@ -371,7 +371,7 @@
                 <div class="set-info-t">Lossless wait timeout <span class="set-opt">seconds</span></div>
                 <div class="set-info-d">Only with the wait on. 0 waits as long as the fetch needs. Above 0, playback falls back to the streaming preview after this many seconds while the download finishes in the background; some players refuse the preview on a track advertised lossless.</div>
               </div>
-              <input class="set-input" id="f-lossless-wait-timeout" name="Subsonic.LosslessWaitTimeoutSeconds" type="number" min="0" data-restart="true" />
+              <input class="set-input" id="f-lossless-wait-timeout" name="Subsonic.LosslessWaitTimeoutSeconds" type="number" min="0" />
             </div>
           </form>
         </div>
@@ -722,7 +722,7 @@
         <header class="page-header">
           <div>
             <h1>Config sources</h1>
-            <p>What value the app actually sees for each setting, after merging env vars and the settings file. Useful for figuring out why a UI change isn't taking effect — usually because something downstream captured the value at startup and needs a restart.</p>
+            <p>What value the app actually sees for each setting, after merging env vars and the settings file. Most settings now apply the moment you save. The few that cannot are marked <em>restart required</em> where you change them: the download path, the slskd connection, and the shim URL are all read once while the app starts.</p>
           </div>
         </header>
 

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -40,7 +40,13 @@ from flask import Flask, Response, abort, jsonify, request, stream_with_context
 
 from gate import TieredGate
 
-YTDLP = os.environ.get("YTDLP_PATH", "/usr/local/bin/yt-dlp")
+# The binary baked into the image. Never written to, so a rebuild is always a
+# clean floor to fall back to.
+YTDLP_DIST = os.environ.get("YTDLP_DIST_PATH", "/usr/local/bin/yt-dlp")
+# The binary actually executed. Compose points this at a volume so a self-update
+# survives `docker compose up -d` recreating the container; left at the dist path
+# the shim still works, it just re-updates after each recreate.
+YTDLP = os.environ.get("YTDLP_PATH", YTDLP_DIST)
 PORT = int(os.environ.get("PORT", "8080"))
 
 # Root the /download endpoint is allowed to write under (the shared music mount).
@@ -71,6 +77,17 @@ _UPSTREAM_UA = os.environ.get("UPSTREAM_USER_AGENT", "").strip()
 # Purging is the standard recovery, but doing it on every 403 would throw the
 # cache away during a burst and make things worse -- hence the interval.
 _CACHE_PURGE_MIN_INTERVAL_SEC = int(os.environ.get("CACHE_PURGE_MIN_INTERVAL_SEC", "900"))
+# A 403 that outlives both a re-resolve and a cache purge is usually a yt-dlp too
+# old for YouTube's current player. Updating is rate-limited hard: it is a
+# network fetch of a binary, and hammering it during an outage helps nobody.
+_SELF_UPDATE_ON_403 = os.environ.get("SELF_UPDATE_ON_403", "1").lower() not in ("0", "false", "no")
+_SELF_UPDATE_MIN_INTERVAL_SEC = int(os.environ.get("SELF_UPDATE_MIN_INTERVAL_SEC", "21600"))
+_SELF_UPDATE_LOCK = threading.Lock()
+# None means "never attempted". Not 0.0: time.monotonic() is time since boot on
+# Linux, so on a host up for less than the interval, `now - 0.0` is inside the
+# window and the very first self-update would be rate-limited away. That is
+# precisely the reboot-then-outage case this exists for.
+_last_self_update = None
 _CACHE_PURGE_LOCK = threading.Lock()
 _last_cache_purge = 0.0
 
@@ -183,8 +200,12 @@ log.info(
 
 
 def _run(args: list[str], timeout: int = 20, label: str = "ytdlp",
-         bg: bool = False) -> Optional[str]:
+         bg: bool = False, capture: bool = False):
     """Run yt-dlp with a hard timeout. Returns stdout or None on any failure.
+
+    With capture=True the CompletedProcess is returned instead, so a caller can
+    read stderr and tell a 403 apart from an unavailable video. Still None when
+    the gate is full or the run times out, since there is no process to report.
 
     Logs gate-wait and wall time so a real box can show whether interactive
     resolves are queuing behind background prewarm (grep `gate_wait_ms`), and
@@ -215,13 +236,21 @@ def _run(args: list[str], timeout: int = 20, label: str = "ytdlp",
         except subprocess.TimeoutExpired:
             log.warning("yt-dlp timed out (%s, gate_wait_ms=%.0f): %s", label, gate_ms, " ".join(args))
             return None
+        except OSError as e:
+            # Binary missing or not executable. Every caller already handles
+            # None, so degrade to "this run failed" rather than letting an
+            # exception escape: raised from the startup version probe it would
+            # abort module import and take the whole shim down, turning a bad
+            # YTDLP_PATH into total loss of playback instead of one log line.
+            log.warning("yt-dlp could not be executed at %s (%s): %s", YTDLP, label, e)
+            return None
         wall_ms = (time.monotonic() - t_run) * 1000.0
         log.info("ytdlp label=%s bg=%d gate_wait_ms=%.0f wall_ms=%.0f rc=%d",
                  label, int(bg), gate_ms, wall_ms, cp.returncode)
         if cp.returncode != 0:
             log.warning("yt-dlp exit %d (%s): %s", cp.returncode, label, cp.stderr.strip()[:300])
-            return None
-        return cp.stdout
+            return cp if capture else None
+        return cp if capture else cp.stdout
     finally:
         _GATE.release(bg)
 
@@ -591,6 +620,70 @@ def _purge_cache_contents() -> None:
     log.info("yt-dlp cache purged (%d entries)", removed)
 
 
+def _seed_writable_ytdlp() -> None:
+    """Copy the image's yt-dlp into the writable location when it is the newer one.
+
+    Runs only when YTDLP_PATH points somewhere other than the image copy. Seeds
+    on first boot, and re-seeds after an image rebuild so a freshly built version
+    wins over an older self-updated one on the volume. Any failure is logged and
+    ignored: falling back to whatever is already there beats refusing to start.
+    """
+    if YTDLP == YTDLP_DIST:
+        return
+    try:
+        if not os.path.isfile(YTDLP_DIST):
+            log.warning("no dist yt-dlp at %s to seed from", YTDLP_DIST)
+            return
+        os.makedirs(os.path.dirname(YTDLP) or ".", exist_ok=True)
+        if os.path.isfile(YTDLP) and os.path.getmtime(YTDLP) >= os.path.getmtime(YTDLP_DIST):
+            return
+        shutil.copy2(YTDLP_DIST, YTDLP)
+        os.chmod(YTDLP, 0o755)
+        log.info("seeded %s from %s", YTDLP, YTDLP_DIST)
+    except OSError as e:
+        log.warning("could not seed %s from %s: %s", YTDLP, YTDLP_DIST, e)
+
+
+def _ytdlp_version() -> str:
+    out = _run(["--version"], timeout=30, label="version", bg=False)
+    return (out or "").strip()
+
+
+def _maybe_self_update(reason: str) -> bool:
+    """Update yt-dlp in place. True only when the version actually changed.
+
+    This is the last rung of the 403 ladder. YouTube rotates its player on its
+    own schedule and the Dockerfile's YTDLP_VERSION=latest is resolved at build
+    time, so an image that is not rebuilt ships one frozen version forever. That
+    is exactly how the 2026-08-21 outage happened: previews and downloads were
+    refused for days on 2026.07.04 while the fix sat published in 2026.08.19.
+    """
+    if not _SELF_UPDATE_ON_403:
+        return False
+    global _last_self_update
+    with _SELF_UPDATE_LOCK:
+        now = time.monotonic()
+        if (_last_self_update is not None
+                and now - _last_self_update < _SELF_UPDATE_MIN_INTERVAL_SEC):
+            return False
+        _last_self_update = now
+
+    before = _ytdlp_version()
+    log.warning("%s: attempting yt-dlp self-update (current %s)", reason, before or "unknown")
+    _run(["-U"], timeout=180, label="self-update", bg=True)
+    after = _ytdlp_version()
+    if after and after != before:
+        # The old player cache belongs to the old binary; keep them together.
+        log.warning("yt-dlp self-updated %s -> %s, purging cache and retrying", before or "unknown", after)
+        _purge_cache_contents()
+        return True
+    log.warning(
+        "yt-dlp self-update left version at %s, so the refusal is not a stale binary",
+        after or before or "unknown",
+    )
+    return False
+
+
 def _open_upstream(url: str, headers: dict, video_id: str):
     try:
         return _SESSION.get(url, stream=True, timeout=(8, 30), headers=headers)
@@ -649,6 +742,14 @@ def stream():
         # most common remaining cause is a stale cached player.
         if upstream is not None and upstream.status_code in (403, 410):
             _purge_ytdlp_cache(video_id)
+            # Last rung: a refusal that outlives a fresh URL and a purged cache
+            # points at the binary, not at this play. Only retry when the update
+            # actually moved the version, so a healthy shim never pays for it.
+            if _maybe_self_update(f"stream {video_id}: 403 survived a cache purge"):
+                upstream.close()
+                _url_cache_evict_if(video_id, url)
+                url = _resolve_url(video_id)
+                upstream = _open_upstream(url, upstream_headers, video_id) if url else None
 
     if upstream is None or upstream.status_code not in (200, 206):
         code = upstream.status_code if upstream is not None else "n/a"
@@ -709,27 +810,20 @@ def download():
         abort(400, "dest outside download root")
     os.makedirs(os.path.dirname(full_dest) or ".", exist_ok=True)
 
-    out = _run(
-        [
-            "-x",
-            "-f", "141/140/bestaudio[ext=m4a]/bestaudio",
-            "--audio-format", "mp3",
-            "--audio-quality", "0",
-            "--embed-metadata",
-            "--embed-thumbnail",
-            "--convert-thumbnails", "jpg",
-            "-o", f"{full_dest}.%(ext)s",
-            f"https://www.youtube.com/watch?v={video_id}",
-        ],
-        timeout=300,
-        label="download",
-        # Background on purpose, regardless of what triggered it: this holds its
-        # slot for up to five minutes, and a single star-triggered download must
-        # never be able to sit in a slot a play is waiting for.
-        bg=True,
-    )
+    ytdlp_args = [
+        "-x",
+        "-f", "141/140/bestaudio[ext=m4a]/bestaudio",
+        "--audio-format", "mp3",
+        "--audio-quality", "0",
+        "--embed-metadata",
+        "--embed-thumbnail",
+        "--convert-thumbnails", "jpg",
+        "-o", f"{full_dest}.%(ext)s",
+        f"https://www.youtube.com/watch?v={video_id}",
+    ]
     path = f"{full_dest}.mp3"
-    if out is None or not os.path.exists(path):
+
+    def _sweep_partials() -> None:
         for ext in (".jpg", ".webp", ".png", ".mp3"):
             leftover = full_dest + ext
             if os.path.exists(leftover):
@@ -737,6 +831,27 @@ def download():
                     os.remove(leftover)
                 except OSError:
                     pass
+
+    def _attempt():
+        # Background on purpose, regardless of what triggered it: this holds its
+        # slot for up to five minutes, and a single star-triggered download must
+        # never be able to sit in a slot a play is waiting for.
+        return _run(ytdlp_args, timeout=300, label="download", bg=True, capture=True)
+
+    cp = _attempt()
+    if cp is None or cp.returncode != 0 or not os.path.exists(path):
+        # Downloads can be the only thing exercising YouTube on an instance with
+        # DownloadSource=YouTube, so this path needs its own rung of the ladder
+        # rather than waiting for a play to notice the binary went stale. Gated
+        # on a 403 in stderr so an unavailable or private video never triggers a
+        # binary fetch.
+        stderr = (cp.stderr if cp is not None else "") or ""
+        if "403" in stderr and _maybe_self_update("download: yt-dlp refused with 403"):
+            _sweep_partials()
+            cp = _attempt()
+
+    if cp is None or cp.returncode != 0 or not os.path.exists(path):
+        _sweep_partials()
         return jsonify(error="download_failed", expected=path), 502
 
     # Overwrite yt-dlp's video-derived title/artist with the clean values Octo
@@ -766,6 +881,14 @@ def download():
 
     log.info("downloaded %s -> %s", video_id, path)
     return jsonify(path=path)
+
+
+# Runs under gunicorn too, where __main__ never fires. Seeding must happen
+# before anything executes the binary. The version goes in the log because a
+# stale yt-dlp still answers /health with ok:true and still resolves metadata,
+# so "which version is this" needs to be answerable without docker exec.
+_seed_writable_ytdlp()
+log.info("yt-dlp %s at %s", _ytdlp_version() or "unknown", YTDLP)
 
 
 if __name__ == "__main__":

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import sqlite3
 import subprocess
 import threading
@@ -559,7 +560,35 @@ def _purge_ytdlp_cache(video_id: str) -> None:
         "stream %s: 403 survived a re-resolve, purging yt-dlp cache "
         "(rotated player is the usual cause)", video_id,
     )
-    _run(["--rm-cache-dir"], timeout=30, label="rm-cache", bg=True)
+    _purge_cache_contents()
+
+
+def _purge_cache_contents() -> None:
+    """Empty yt-dlp's cache without removing the directory itself.
+
+    yt-dlp --rm-cache-dir rmtree's the cache root, and compose mounts a named
+    volume at exactly that path. Removing a mount point from inside the
+    container is EBUSY, so the flag deletes the contents and then dies on the
+    final rmdir with exit 1. The purge looked like it failed and the log filled
+    with a traceback, when the part that mattered had already happened. Clearing
+    the contents directly does the same job and reports honestly.
+    """
+    root = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    cache_dir = os.path.join(root, "yt-dlp")
+    if not os.path.isdir(cache_dir):
+        return
+    removed = 0
+    for name in os.listdir(cache_dir):
+        target = os.path.join(cache_dir, name)
+        try:
+            if os.path.isdir(target) and not os.path.islink(target):
+                shutil.rmtree(target)
+            else:
+                os.remove(target)
+            removed += 1
+        except OSError as e:
+            log.warning("cache purge could not remove %s: %s", target, e)
+    log.info("yt-dlp cache purged (%d entries)", removed)
 
 
 def _open_upstream(url: str, headers: dict, video_id: str):

--- a/yt-dlp-shim/tests/test_cache_purge.py
+++ b/yt-dlp-shim/tests/test_cache_purge.py
@@ -1,0 +1,29 @@
+"""The 403 self-heal purges yt-dlp's cache. It must survive the cache root
+being a mount point, which is how compose runs it."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+app_module = pytest.importorskip("app")
+
+
+def test_purges_contents_but_keeps_the_directory(tmp_path, monkeypatch):
+    cache = tmp_path / "yt-dlp"
+    (cache / "nested").mkdir(parents=True)
+    (cache / "nested" / "player.js").write_text("stale")
+    (cache / "loose.json").write_text("stale")
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    app_module._purge_cache_contents()
+
+    # The directory itself survives: removing it would be EBUSY under a mount.
+    assert cache.is_dir()
+    assert list(cache.iterdir()) == []
+
+
+def test_is_a_no_op_when_there_is_no_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    app_module._purge_cache_contents()  # must not raise

--- a/yt-dlp-shim/tests/test_self_update.py
+++ b/yt-dlp-shim/tests/test_self_update.py
@@ -1,0 +1,128 @@
+"""The 403 ladder's last rung: update yt-dlp, and keep that update across a
+container recreate. YTDLP_VERSION=latest is resolved at image build time, so
+without this a stack that is never rebuilt runs one frozen version forever."""
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+app = pytest.importorskip("app")
+
+
+def _write(path, text, mtime=None):
+    with open(path, "w") as fh:
+        fh.write(text)
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
+class TestSeeding:
+    def test_seeds_when_the_volume_is_empty(self, tmp_path, monkeypatch):
+        dist = tmp_path / "dist" / "yt-dlp"
+        dist.parent.mkdir()
+        _write(dist, "image-copy")
+        live = tmp_path / "vol" / "yt-dlp"
+        monkeypatch.setattr(app, "YTDLP_DIST", str(dist))
+        monkeypatch.setattr(app, "YTDLP", str(live))
+
+        app._seed_writable_ytdlp()
+
+        assert live.read_text() == "image-copy"
+        assert os.access(live, os.X_OK) or os.name == "nt"
+
+    def test_a_rebuild_wins_over_an_older_self_update(self, tmp_path, monkeypatch):
+        """Image copy newer than the volume copy means someone rebuilt; take it."""
+        dist = tmp_path / "dist" / "yt-dlp"
+        dist.parent.mkdir()
+        live = tmp_path / "vol" / "yt-dlp"
+        live.parent.mkdir()
+        _write(live, "self-updated", mtime=time.time() - 600)
+        _write(dist, "freshly-built", mtime=time.time())
+        monkeypatch.setattr(app, "YTDLP_DIST", str(dist))
+        monkeypatch.setattr(app, "YTDLP", str(live))
+
+        app._seed_writable_ytdlp()
+
+        assert live.read_text() == "freshly-built"
+
+    def test_a_self_update_is_not_clobbered_by_an_older_image(self, tmp_path, monkeypatch):
+        """The common case on every restart: the volume is ahead, leave it be."""
+        dist = tmp_path / "dist" / "yt-dlp"
+        dist.parent.mkdir()
+        live = tmp_path / "vol" / "yt-dlp"
+        live.parent.mkdir()
+        _write(dist, "baked-old", mtime=time.time() - 600)
+        _write(live, "self-updated-new", mtime=time.time())
+        monkeypatch.setattr(app, "YTDLP_DIST", str(dist))
+        monkeypatch.setattr(app, "YTDLP", str(live))
+
+        app._seed_writable_ytdlp()
+
+        assert live.read_text() == "self-updated-new"
+
+    def test_is_a_no_op_without_a_separate_writable_path(self, tmp_path, monkeypatch):
+        same = tmp_path / "yt-dlp"
+        _write(same, "only-copy")
+        monkeypatch.setattr(app, "YTDLP_DIST", str(same))
+        monkeypatch.setattr(app, "YTDLP", str(same))
+
+        app._seed_writable_ytdlp()  # must not raise or truncate
+
+        assert same.read_text() == "only-copy"
+
+
+class TestSelfUpdate:
+    @pytest.fixture(autouse=True)
+    def _reset_rate_limit(self, monkeypatch):
+        monkeypatch.setattr(app, "_last_self_update", None)
+        monkeypatch.setattr(app, "_SELF_UPDATE_ON_403", True)
+        monkeypatch.setattr(app, "_SELF_UPDATE_MIN_INTERVAL_SEC", 21600)
+        monkeypatch.setattr(app, "_purge_cache_contents", lambda: None)
+
+    def test_reports_success_only_when_the_version_moves(self, monkeypatch):
+        versions = iter(["2026.07.04", "2026.08.19"])
+        monkeypatch.setattr(app, "_ytdlp_version", lambda: next(versions))
+        monkeypatch.setattr(app, "_run", lambda *a, **k: "")
+
+        assert app._maybe_self_update("test") is True
+
+    def test_reports_failure_when_already_current(self, monkeypatch):
+        monkeypatch.setattr(app, "_ytdlp_version", lambda: "2026.08.19")
+        monkeypatch.setattr(app, "_run", lambda *a, **k: "")
+
+        # Same version both sides means the refusal is something else, and the
+        # caller must not retry on the strength of an update that did nothing.
+        assert app._maybe_self_update("test") is False
+
+    def test_rate_limit_blocks_a_second_attempt(self, monkeypatch):
+        versions = iter(["a", "b", "c", "d"])
+        monkeypatch.setattr(app, "_ytdlp_version", lambda: next(versions))
+        monkeypatch.setattr(app, "_run", lambda *a, **k: "")
+
+        assert app._maybe_self_update("first") is True
+        # An outage means every play 403s; without this the shim would fetch a
+        # binary per request.
+        assert app._maybe_self_update("second") is False
+
+    def test_first_attempt_is_allowed_on_a_freshly_booted_host(self, monkeypatch):
+        """time.monotonic() is time since boot on Linux. A 0.0 sentinel would put
+        a host up for under the interval inside its own rate-limit window and
+        block the first update, which is the reboot-then-outage case."""
+        monkeypatch.setattr(app, "_last_self_update", None)
+        monkeypatch.setattr(app, "_SELF_UPDATE_MIN_INTERVAL_SEC", 10 ** 9)
+        versions = iter(["old", "new"])
+        monkeypatch.setattr(app, "_ytdlp_version", lambda: next(versions))
+        monkeypatch.setattr(app, "_run", lambda *a, **k: "")
+
+        assert app._maybe_self_update("first ever") is True
+
+    def test_can_be_switched_off(self, monkeypatch):
+        monkeypatch.setattr(app, "_SELF_UPDATE_ON_403", False)
+        called = []
+        monkeypatch.setattr(app, "_ytdlp_version", lambda: called.append(1) or "x")
+
+        assert app._maybe_self_update("test") is False
+        assert called == []


### PR DESCRIPTION
Started as a doc fix for #21 and turned up a live outage, an inert self-heal and a settings bug.

## The outage

Every YouTube media fetch was returning 403. Not just starred downloads: `/stream` was dead too, which takes previews, radio and search playback with it. It looked healthy from the outside because `/health` kept answering `ok:true` and search, resolve and metadata all still worked. Only the media fetch was refused.

Cause was a yt-dlp seven weeks stale. `ARG YTDLP_VERSION=latest` resolves when the image is **built**, and docker caches that `RUN` layer on its command string, which never changes. So even a deliberate `docker compose build` re-uses the cached layer and re-fetches nothing. It reads like a self-updating pin and behaves like a permanent freeze.

## What changed

**The 403 ladder gets a last rung.** It already re-resolved, then purged the player cache, then gave up. Now if the refusal outlives the purge it updates yt-dlp and retries, but only when the version actually moved, so a healthy shim never pays for it. Rate-limited to 6h and switchable off with `SELF_UPDATE_ON_403=0`. `/download` escalates too, gated on a 403 in stderr so an unavailable video never triggers a binary fetch, because an instance on `DownloadSource=YouTube` may never stream at all. The binary runs from a volume so an update survives recreate, with the image copy as the floor: a rebuild re-seeds and wins.

**The cache purge never worked.** It called `yt-dlp --rm-cache-dir`, which rmtree's the cache root, and compose mounts a named volume at exactly that path. Removing a mount point from inside a container is `EBUSY`, so it deleted the contents and then died on the final rmdir with a traceback, making a mostly-successful purge look like the failure. Inert since it shipped.

**Admin settings did not reach the services that act on them.** `AdminController` reads through `IOptionsMonitor`, so the UI re-rendered with the new value and looked applied, while every consumer took `IOptions<SubsonicSettings>` and captured `.Value` in its constructor as a singleton. Changing Download source in the UI did nothing until a restart, with no sign of it. Six consumers move to `IOptionsMonitor` and read `CurrentValue` at the point of use. Each keeps its field name as a property, so no call site changed. Startup validators keep `IOptions` deliberately, and `SubsonicResponseBuilder` keeps its captured copy on purpose, since it decides what every search result declares and must not shift under a client that already cached those rows.

**`DOWNLOAD_SOURCE` was undiscoverable, which is #21.** The setting has shipped for a while, with a three-way control in the admin UI, but the README never named it and the one FAQ entry someone with that question would find, "What if I don't want to use Soulseek?", answered only with `DownloadOnStar=false`. So the documented way to avoid Soulseek was to give up downloads entirely. Both FAQ entries now lead with the source setting, the `star` row no longer claims downloads are always FLAC, and the UI control names its env var the way the download path and slskd fields already do.

## Bugs found while writing this

- `_run` let an `OSError` escape, so a missing or non-executable binary aborted module import and took the whole shim down instead of failing one call.
- `0.0` was the wrong "never ran" sentinel for `time.monotonic()`, which is time since boot on Linux. On a host up for less than the interval the first self-update would be rate-limited away, which is exactly the reboot-then-outage case.

## Verification

Deployed to a live instance, then **downgraded the binary back to the broken version** and hit `/stream`. It walked the whole ladder unattended and served audio in 11.8s:

```
upstream 403
  -> 403 survived a re-resolve, purging yt-dlp cache -> cache purged (1 entries)
  -> 403 survived a cache purge: attempting yt-dlp self-update (current 2026.07.04)
  -> yt-dlp self-updated 2026.07.04 -> 2026.08.19, purging cache and retrying
  -> stream ttfb_ms=11759 status=200
```

Persistence checked on a real restart: no re-seed, version held. The MP3 path was then verified end to end through a real star, not just the shim: 6.7 MB, 229.8s, 245 kbps, correct tags, 1000x1000 cover, history entry, Navidrome rescan, playback.

Suites: .NET 246 -> 247, shim 6 -> 17, build clean at 0 warnings.
