### PR TITLE
feat: add first-class Lidarr support and ordered heart acquisition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@
 # local network and configures it automatically if it finds exactly one server.
 # Set it explicitly to skip the scan or when auto-detect can't see your LAN
 # (e.g. a Docker bridge network). Everything else has a working default;
-# Soulseek (downloads) and Last.fm (discovery/radio) are optional add-ons.
+# Soulseek or an existing Lidarr (downloads), and Last.fm (discovery/radio), are optional add-ons.
 #
 # NOTE: Use double-underscore (__) for nested properties in raw env keys.
 # Example: Subsonic__Url maps to { "Subsonic": { "Url": "..." } }
@@ -66,12 +66,17 @@ CACHE_DURATION_HOURS=1
 ENABLE_EXTERNAL_PLAYLISTS=false
 
 # Where downloaded FLACs land on the HOST. This directory is bind-mounted as
-# /music into the octo, yt-dlp-shim, and slskd containers, so star -> slskd
-# writes -> Navidrome scans -> Octo serves all see the same files. This is the
+# /music into the octo, yt-dlp-shim, and slskd containers, so downloaded files
+# and Navidrome scans all see the same library. This is the
 # only path you change to move the library; container-side settings (Octo's
 # Library__DownloadPath, slskd's downloads dir) stay /music and normally never
 # change. On Windows use forward slashes, e.g. DOWNLOAD_PATH=E:/Media/Music
 DOWNLOAD_PATH=./downloads
+
+# Acquisition source used when an external track or album is hearted. Soulseek is
+# the default. Lidarr uses an existing server and fetches the full album even for
+# a single-track heart. YouTube and SoulseekThenYouTube remain available.
+DOWNLOAD_SOURCE=Soulseek
 
 # ===== SOULSEEK (slskd) — permanent FLAC source on star =====
 # slskd web UI / API admin credentials. Octo authenticates against /api/v0/session
@@ -92,6 +97,19 @@ SLSKD_DOWNLOAD_TIMEOUT_SECONDS=180
 # connect to peers and download. Sign up at https://www.slsknet.org/ if needed.
 SLSKD_SOULSEEK_USERNAME=
 SLSKD_SOULSEEK_PASSWORD=
+
+# ===== LIDARR — optional existing-server alternative for hearts =====
+# Lidarr must already have indexers and a download client. Configure these two,
+# then choose its root folder and profiles from Octo's Lidarr admin page.
+LIDARR_URL=
+LIDARR_API_KEY=
+LIDARR_ROOT_FOLDER_PATH=
+LIDARR_QUALITY_PROFILE_ID=0
+LIDARR_METADATA_PROFILE_ID=0
+# Accepted: hand off and continue. Imported: completion/failure notifications
+# wait for files to appear. Both modes reconcile history and trigger a scan.
+LIDARR_COMPLETION_MODE=Accepted
+LIDARR_IMPORT_TIMEOUT_SECONDS=1800
 
 # ===== YT-DLP SHIM (preview-stream sidecar) — usually leave defaults =====
 YTDLP_MAX_CONCURRENT=5

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ SUBSONIC_ADMIN_PASSWORD=
 AUTO_DETECT_DOWNLOAD_PATH=true
 
 # ===== OPTIONAL: playback / download behavior (safe defaults below) =====
+# Legacy direct-download behavior retained for compatibility and playlist jobs.
+# Ordinary external playback is local-first, then YouTube.
 # Stream | Permanent | Cache
 STORAGE_MODE=Stream
 # Track | Album
@@ -45,11 +47,10 @@ DOWNLOAD_MODE=Track
 DOWNLOAD_ON_STAR=true
 # Star a whole album to fetch every track. Downloads run one at a time.
 DOWNLOAD_ALBUM_ON_STAR=true
-# Permanent mode only. Off: a track plays instantly from the preview source and the
-# lossless copy appears as its own library track once the scan picks it up. On: the
-# first play waits for the lossless file, which can take minutes and which most
-# clients will give up on. Restart required, since it also changes what searches
-# advertise for external tracks.
+# Off: missing tracks play immediately from YouTube and hearts acquire permanent
+# copies. On: the first play fetches and waits for a lossless copy, which can take
+# minutes and which most clients will give up on. Restart required, since it also
+# changes what searches advertise for external tracks.
 WAIT_FOR_LOSSLESS_ON_PLAY=false
 # With the wait on: 0 waits as long as the fetch needs; above 0, playback falls back
 # to the streaming preview after this many seconds while the download finishes in

--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,9 @@ AUTO_DETECT_DOWNLOAD_PATH=true
 STORAGE_MODE=Stream
 # Track | Album
 DOWNLOAD_MODE=Track
+# Initial defaults before a per-source heart matrix is saved in the admin UI.
 DOWNLOAD_ON_STAR=true
-# Star a whole album to fetch every track. Downloads run one at a time, so a full
-# album takes a while; set false to keep song-starring without the bigger job.
+# Star a whole album to fetch every track. Downloads run one at a time.
 DOWNLOAD_ALBUM_ON_STAR=true
 # Permanent mode only. Off: a track plays instantly from the preview source and the
 # lossless copy appears as its own library track once the scan picks it up. On: the
@@ -74,7 +74,7 @@ ENABLE_EXTERNAL_PLAYLISTS=false
 DOWNLOAD_PATH=./downloads
 
 # Initial heart-acquisition behavior for existing/env-only installs. The admin
-# Downloads page can replace this with an ordered, enabled/disabled source list.
+# Downloads page can replace this with an ordered per-heart-type source list.
 # Lidarr stays last by default and fetches a full album even for a track heart.
 DOWNLOAD_SOURCE=Soulseek
 

--- a/.env.example
+++ b/.env.example
@@ -73,9 +73,9 @@ ENABLE_EXTERNAL_PLAYLISTS=false
 # change. On Windows use forward slashes, e.g. DOWNLOAD_PATH=E:/Media/Music
 DOWNLOAD_PATH=./downloads
 
-# Acquisition source used when an external track or album is hearted. Soulseek is
-# the default. Lidarr uses an existing server and fetches the full album even for
-# a single-track heart. YouTube and SoulseekThenYouTube remain available.
+# Initial heart-acquisition behavior for existing/env-only installs. The admin
+# Downloads page can replace this with an ordered, enabled/disabled source list.
+# Lidarr stays last by default and fetches a full album even for a track heart.
 DOWNLOAD_SOURCE=Soulseek
 
 # ===== SOULSEEK (slskd) — permanent FLAC source on star =====

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,12 +2,6 @@ name: Docker Build & Push
 
 on:
   workflow_dispatch:
-    inputs:
-      publish_lidarr_test:
-        description: Build the pinned Lidarr-support commit with its immutable test tag
-        required: true
-        type: boolean
-        default: false
   push:
     # Dated releases (2026.07.29) as well as any future v-prefixed ones. Without the
     # second pattern a dated tag pushes silently and never builds an image.
@@ -33,16 +27,10 @@ concurrency:
   queue: max
   cancel-in-progress: false
 
-permissions:
-  contents: read
-
 env:
   DOTNET_VERSION: "9.0.x"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  LIDARR_TEST_COMMIT: 2fc43af36ff761a421f1aadd8863e71648e0d62d
-  LIDARR_TEST_IMAGE: ghcr.io/bingelsworth/octo
-  LIDARR_TEST_TAG: lidarr-test-2fc43af36ff7
 
 jobs:
   build-and-test:
@@ -51,12 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.publish_lidarr_test && env.LIDARR_TEST_COMMIT || github.sha }}
-
-      - name: Verify pinned Lidarr source
-        if: inputs.publish_lidarr_test
-        run: test "$(git rev-parse HEAD)" = "$LIDARR_TEST_COMMIT"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -86,12 +68,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.publish_lidarr_test && env.LIDARR_TEST_COMMIT || github.sha }}
-
-      - name: Verify pinned Lidarr source
-        if: inputs.publish_lidarr_test
-        run: test "$(git rev-parse HEAD)" = "$LIDARR_TEST_COMMIT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -106,36 +82,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Refuse to overwrite the immutable Lidarr tag
-        if: inputs.publish_lidarr_test
-        run: |
-          if docker buildx imagetools inspect "$LIDARR_TEST_IMAGE:$LIDARR_TEST_TAG" >/dev/null 2>&1; then
-            echo "::error::Image tag already exists: $LIDARR_TEST_IMAGE:$LIDARR_TEST_TAG"
-            exit 1
-          fi
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ inputs.publish_lidarr_test && env.LIDARR_TEST_IMAGE || format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ env.LIDARR_TEST_TAG }},enable=${{ inputs.publish_lidarr_test }}
-            type=ref,event=branch,enable=${{ !inputs.publish_lidarr_test }}
+            type=ref,event=branch
             # Tags the image with the release name verbatim, e.g. 2026.07.29. The semver
             # patterns below cannot match a dated tag (07 is not valid semver), so this
             # is what actually labels a release build.
-            type=ref,event=tag,enable=${{ !inputs.publish_lidarr_test }}
-            type=sha,prefix=,enable=${{ !inputs.publish_lidarr_test }}
-            type=semver,pattern={{version}},enable=${{ !inputs.publish_lidarr_test }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !inputs.publish_lidarr_test }}
-            type=semver,pattern={{major}},enable=${{ !inputs.publish_lidarr_test }}
+            type=ref,event=tag
+            type=sha,prefix=
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             # Was gated on refs/heads/dev, a branch this repo does not have, so `latest`
             # was never published at all and `docker pull ...:latest` failed for everyone.
-            type=raw,value=latest,enable=${{ !inputs.publish_lidarr_test && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -145,31 +111,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Verify published Lidarr manifest
-        if: inputs.publish_lidarr_test
-        run: |
-          image="$LIDARR_TEST_IMAGE:$LIDARR_TEST_TAG"
-          published_digest=$(docker buildx imagetools inspect "$image" | awk '$1 == "Digest:" { print $2; exit }')
-          if [ "$published_digest" != "${{ steps.build.outputs.digest }}" ]; then
-            echo "::error::Published digest $published_digest does not match build digest ${{ steps.build.outputs.digest }}"
-            exit 1
-          fi
-
-          platforms=$(docker buildx imagetools inspect --raw "$image" |
-            jq -r '[.manifests[].platform | select(.os != "unknown") | "\(.os)/\(.architecture)"] | unique | sort | join(",")')
-          if [ "$platforms" != "linux/amd64,linux/arm64" ]; then
-            echo "::error::Unexpected published platforms: $platforms"
-            exit 1
-          fi
-
-      - name: Record immutable Lidarr image
-        if: inputs.publish_lidarr_test
-        run: |
-          {
-            echo '### Lidarr test image'
-            echo
-            echo "- Repository: \`$LIDARR_TEST_IMAGE\`"
-            echo "- Tag: \`$LIDARR_TEST_TAG\`"
-            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,12 @@ name: Docker Build & Push
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_lidarr_test:
+        description: Build the pinned Lidarr-support commit with its immutable test tag
+        required: true
+        type: boolean
+        default: false
   push:
     # Dated releases (2026.07.29) as well as any future v-prefixed ones. Without the
     # second pattern a dated tag pushes silently and never builds an image.
@@ -27,10 +33,16 @@ concurrency:
   queue: max
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: "9.0.x"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  LIDARR_TEST_COMMIT: 2fc43af36ff761a421f1aadd8863e71648e0d62d
+  LIDARR_TEST_IMAGE: ghcr.io/bingelsworth/octo
+  LIDARR_TEST_TAG: lidarr-test-2fc43af36ff7
 
 jobs:
   build-and-test:
@@ -39,6 +51,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.publish_lidarr_test && env.LIDARR_TEST_COMMIT || github.sha }}
+
+      - name: Verify pinned Lidarr source
+        if: inputs.publish_lidarr_test
+        run: test "$(git rev-parse HEAD)" = "$LIDARR_TEST_COMMIT"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -68,6 +86,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.publish_lidarr_test && env.LIDARR_TEST_COMMIT || github.sha }}
+
+      - name: Verify pinned Lidarr source
+        if: inputs.publish_lidarr_test
+        run: test "$(git rev-parse HEAD)" = "$LIDARR_TEST_COMMIT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -82,26 +106,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Refuse to overwrite the immutable Lidarr tag
+        if: inputs.publish_lidarr_test
+        run: |
+          if docker buildx imagetools inspect "$LIDARR_TEST_IMAGE:$LIDARR_TEST_TAG" >/dev/null 2>&1; then
+            echo "::error::Image tag already exists: $LIDARR_TEST_IMAGE:$LIDARR_TEST_TAG"
+            exit 1
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ inputs.publish_lidarr_test && env.LIDARR_TEST_IMAGE || format('{0}/{1}', env.REGISTRY, env.IMAGE_NAME) }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=${{ env.LIDARR_TEST_TAG }},enable=${{ inputs.publish_lidarr_test }}
+            type=ref,event=branch,enable=${{ !inputs.publish_lidarr_test }}
             # Tags the image with the release name verbatim, e.g. 2026.07.29. The semver
             # patterns below cannot match a dated tag (07 is not valid semver), so this
             # is what actually labels a release build.
-            type=ref,event=tag
-            type=sha,prefix=
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=ref,event=tag,enable=${{ !inputs.publish_lidarr_test }}
+            type=sha,prefix=,enable=${{ !inputs.publish_lidarr_test }}
+            type=semver,pattern={{version}},enable=${{ !inputs.publish_lidarr_test }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !inputs.publish_lidarr_test }}
+            type=semver,pattern={{major}},enable=${{ !inputs.publish_lidarr_test }}
             # Was gated on refs/heads/dev, a branch this repo does not have, so `latest`
             # was never published at all and `docker pull ...:latest` failed for everyone.
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ !inputs.publish_lidarr_test && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -111,3 +145,31 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify published Lidarr manifest
+        if: inputs.publish_lidarr_test
+        run: |
+          image="$LIDARR_TEST_IMAGE:$LIDARR_TEST_TAG"
+          published_digest=$(docker buildx imagetools inspect "$image" | awk '$1 == "Digest:" { print $2; exit }')
+          if [ "$published_digest" != "${{ steps.build.outputs.digest }}" ]; then
+            echo "::error::Published digest $published_digest does not match build digest ${{ steps.build.outputs.digest }}"
+            exit 1
+          fi
+
+          platforms=$(docker buildx imagetools inspect --raw "$image" |
+            jq -r '[.manifests[].platform | select(.os != "unknown") | "\(.os)/\(.architecture)"] | unique | sort | join(",")')
+          if [ "$platforms" != "linux/amd64,linux/arm64" ]; then
+            echo "::error::Unexpected published platforms: $platforms"
+            exit 1
+          fi
+
+      - name: Record immutable Lidarr image
+        if: inputs.publish_lidarr_test
+        run: |
+          {
+            echo '### Lidarr test image'
+            echo
+            echo "- Repository: \`$LIDARR_TEST_IMAGE\`"
+            echo "- Tag: \`$LIDARR_TEST_TAG\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -261,13 +261,9 @@ The selected Lidarr root and Octo's effective Navidrome library root must expose
 
 `LIDARR_COMPLETION_MODE=Accepted` (default) returns control after Lidarr accepts the album search. `Imported` makes completion/failure notifications reflect the actual import, bounded by `LIDARR_IMPORT_TIMEOUT_SECONDS` (default 1800). Neither mode blocks playback or later hearts; imported files are reconciled into download history and trigger a Navidrome scan in the background.
 
-### Storage modes
+### Playback and acquisition
 
-- `Stream` *(default)* — preview-only. Heart a song to download.
-- `Permanent` — every song you play gets downloaded.
-- `Cache` — downloads expire after `CacheDurationHours`.
-
-In `Permanent` mode the download runs in the background and playback starts immediately from the preview source. The lossless copy lands in your library and shows up as its own track once your server scans it, so a track you have played appears twice for a while: the preview entry and the real file. **The star stays on the preview entry**, so re-star the library copy if you want it favourited there.
+Tracks already in your library play locally through Navidrome. Missing external results stream from YouTube. Playback does not acquire a permanent copy; heart the song or album to run the configured source priority.
 
 Set `WAIT_FOR_LOSSLESS_ON_PLAY=true` if you would rather the first play wait for the lossless file. It is off by default because a Soulseek fetch routinely takes minutes and most clients time out long before that, which looks like the play failing. The setting also changes what searches advertise for external tracks, so it needs a restart, and clients that cached earlier results should re-search after you change it.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Built for:
 - **Search finds music you don't own.** Tap a result to hear it instantly via YouTube preview.
 - **Radio works on every song.** Owned tracks play at full FLAC; missing ones preview from YouTube.
 - **Heart to keep.** Star a previewed song and Octo grabs the FLAC from Soulseek, adds it to your library, and tells Navidrome to rescan. Within a minute, the song is yours forever.
-- **Search and heart whole albums.** Albums you don't own show up in search with real cover art and tracklists. Star one and Octo fetches every track. Downloads run one at a time, so a full album takes a while — turn it off with `DOWNLOAD_ALBUM_ON_STAR=false`.
+- **Search and heart whole albums.** Albums you don't own show up in search with real cover art and tracklists. Star one and Octo fetches every track. Downloads run one at a time, so a full album takes a while — album-heart sources can be disabled independently in the admin UI.
 
 Plug Octo in front of your Navidrome. Point your Subsonic apps (Feishin, Arpeggi, Narjo, etc.) at Octo instead. Nothing else changes.
 
@@ -180,11 +180,11 @@ Yes. Soulseek peers share full FLAC files with their existing ID3 tags intact. O
 
 You can use YouTube or an existing Lidarr server, or disable automatic acquisition entirely.
 
-Use **Downloads → Heart download priority** in the admin UI to enable and order Soulseek, YouTube, and Lidarr. Octo tries each enabled source from top to bottom and stops at the first success. Disabled sources keep their position. `DOWNLOAD_SOURCE` remains the initial fallback for existing and env-only installations.
+Use **Downloads → Heart download priority** in the admin UI to order Soulseek, YouTube, and Lidarr and independently choose whether each handles song hearts, album hearts, or both. Octo tries eligible sources from top to bottom and stops at the first success. `DOWNLOAD_SOURCE`, `DOWNLOAD_ON_STAR`, and `DOWNLOAD_ALBUM_ON_STAR` remain migration defaults for existing and env-only installations.
 
-Lidarr works at album level, so hearting one track fetches its full album. It is last and disabled by default; configure its URL, API key, root folder, and profiles on the Lidarr page, then enable it in the priority list.
+Lidarr works at album level, so enabling it for song hearts still fetches the song's full album. It is last and disabled by default; configure its URL, API key, root folder, and profiles on the Lidarr page, then enable the heart types you want in the priority list.
 
-To stop downloading altogether, set `Subsonic__DownloadOnStar=false`. Hearting a song will still register the favorite, but won't trigger any download. You'll keep search and radio enrichment via YouTube preview, which is useful if you only want the discovery layer and prefer to acquire FLACs another way.
+To stop downloading altogether, turn off both heart types for every source. On an env-only installation, set `Subsonic__DownloadOnStar=false` and `Subsonic__DownloadAlbumOnStar=false`. Hearts still register as favorites without acquiring files.
 
 ### Can it run on a Raspberry Pi?
 
@@ -327,7 +327,7 @@ Yes — slskd downloads are full FLACs from peer libraries that already have ID3
 Octo throws an error and the star icon stays filled. Try again later or grab the file by hand. Real failures are rare.
 
 **Can it run without Soulseek?**
-Yes. Select YouTube for MP3 downloads, Lidarr for album-level heart acquisition, or set `DOWNLOAD_ON_STAR=false` to keep discovery without automatic acquisition.
+Yes. Enable YouTube for MP3 downloads, Lidarr for album-level heart acquisition, or disable every song-heart source to keep discovery without automatic acquisition.
 
 **Can it run without Last.fm?**
 Yes, but search and radio fall back to local-only — no discovery layer. The free Last.fm key takes 30 seconds.
@@ -339,6 +339,14 @@ dotnet restore
 dotnet build
 dotnet test
 ```
+
+To build and preview the admin UI locally in an isolated Docker container:
+
+```bash
+./scripts/preview-admin.sh
+```
+
+The script opens `http://localhost:5277/admin/index.html` and uses temporary in-container settings and music directories. Run `./scripts/preview-admin.sh stop` when finished. Pass a different port as the first argument if needed.
 
 Project layout:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ So setup is two steps: **tell Octo where Navidrome is**, and **point your app at
 
 - A free [Last.fm API key](https://www.last.fm/api/account/create) — enables radio / discovery.
 - A free [Soulseek account](https://www.slsknet.org/news/node/1) — enables lossless FLAC downloads when you star a song.
+- An existing Lidarr server — an alternative heart source when it already has indexers and a download client configured.
 
 Then:
 
@@ -177,7 +178,7 @@ Yes. Soulseek peers share full FLAC files with their existing ID3 tags intact. O
 
 ### What if I don't want to use Soulseek?
 
-Set `Subsonic__DownloadOnStar=false` in `.env`. Hearting a song will still register the favorite, but won't trigger any download. You'll keep search and radio enrichment via YouTube preview — useful if you only want the discovery layer and prefer to acquire FLACs another way.
+Set `DOWNLOAD_SOURCE=Lidarr`, then configure the Lidarr URL, API key, root folder, and profiles on Octo's Lidarr admin page. Lidarr works at album level, so a single-track heart fetches the full release. To disable acquisition entirely, set `DOWNLOAD_ON_STAR=false`.
 
 ### Can it run on a Raspberry Pi?
 
@@ -246,6 +247,14 @@ The admin UI's "Config sources" tab shows the merged effective value for every k
 - **Windows (Docker Desktop)**: use forward slashes, e.g. `DOWNLOAD_PATH=E:/Media/Music`. Do not put a drive-letter path in the admin UI's download path field; that field is a path inside the container.
 - **Manual installs** (not using the bundled compose file): slskd's `directories.downloads` must resolve to the same directory Octo's `Library:DownloadPath` points at, or Octo will never see finished downloads. Set it with the `SLSKD_DOWNLOADS_DIR` environment variable, and note that a value set in `slskd.yml` overrides that env var (slskd precedence: env vars < yaml).
 
+### Existing Lidarr setup
+
+Set `DOWNLOAD_SOURCE=Lidarr`, `LIDARR_URL`, and `LIDARR_API_KEY`, restart Octo, then open the **Lidarr** admin tab and load its root-folder and profile choices. Octo does not install or configure Lidarr's indexers or download client.
+
+The selected Lidarr root and Octo's effective Navidrome library root must expose the same underlying files. Their container paths may differ: Octo translates the imported path relative to the selected Lidarr root. For example, Lidarr `/data/music/Artist/Album/file.flac` can map to Octo `/music/Artist/Album/file.flac` when both mounts point at the same host directory.
+
+`LIDARR_COMPLETION_MODE=Accepted` (default) returns control after Lidarr accepts the album search. `Imported` makes completion/failure notifications reflect the actual import, bounded by `LIDARR_IMPORT_TIMEOUT_SECONDS` (default 1800). Neither mode blocks playback or later hearts; imported files are reconciled into download history and trigger a Navidrome scan in the background.
+
 ### Storage modes
 
 - `Stream` *(default)* — preview-only. Heart a song to download.
@@ -272,7 +281,7 @@ Octo hijacks these endpoints; everything else proxies to Navidrome unchanged:
 | `stream` | YouTube proxy with Range support, mp4/m4a passthrough |
 | `getCoverArt` | Deezer → iTunes → Last.fm aggregator with Octo watermark |
 | `getAlbum` | external album tracklists, and fills in tracks you're missing from an album you own |
-| `star` | trigger Soulseek download (multi-peer retry, FLAC), or a whole album |
+| `star` | trigger the selected Soulseek/YouTube source, or submit the full album to Lidarr |
 | `scrobble` | sliding-window prewarm of next 8 in queue |
 | `getTranscodeDecision` | OpenSubsonic — return direct-play for Octo IDs |
 
@@ -312,7 +321,7 @@ Yes — slskd downloads are full FLACs from peer libraries that already have ID3
 Octo throws an error and the star icon stays filled. Try again later or grab the file by hand. Real failures are rare.
 
 **Can it run without Soulseek?**
-Yes — set `Subsonic__DownloadOnStar=false`. Star fills the heart but won't trigger a download. Search and radio enrichment still work.
+Yes — select Lidarr for hearts, or set `DOWNLOAD_ON_STAR=false` to keep discovery without automatic acquisition.
 
 **Can it run without Last.fm?**
 Yes, but search and radio fall back to local-only — no discovery layer. The free Last.fm key takes 30 seconds.
@@ -331,6 +340,7 @@ Project layout:
 |---|---|
 | `octo/Controllers/` | Subsonic API surface, admin API |
 | `octo/Services/Soulseek/` | slskd client, multi-peer download logic |
+| `octo/Services/Lidarr/` | Lidarr API, album submission, import reconciliation |
 | `octo/Services/YouTube/` | shim HTTP client |
 | `octo/Services/CoverArt/` | Deezer / iTunes / Last.fm aggregator |
 | `octo/Services/Subsonic/` | request parsing, response building |
@@ -350,6 +360,7 @@ Project layout:
 
 - [**Navidrome**](https://www.navidrome.org/) — the music server Octo proxies.
 - [**slskd**](https://github.com/slskd/slskd) — Soulseek with a REST API.
+- [**Lidarr**](https://github.com/Lidarr/Lidarr) — optional album acquisition and import manager.
 - [**yt-dlp**](https://github.com/yt-dlp/yt-dlp) — makes YouTube preview feasible.
 - [**Last.fm**](https://www.last.fm/api) — similar-tracks API.
 - [**V1ck3s/octo-fiesta**](https://github.com/V1ck3s/octo-fiesta) — the upstream root of this lineage. The Qobuz/Deezer/Yandex Subsonic-proxy concept that Octo eventually rebuilt around YouTube + Soulseek started here.

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ Yes. Soulseek peers share full FLAC files with their existing ID3 tags intact. O
 
 You can use YouTube or an existing Lidarr server, or disable automatic acquisition entirely.
 
-To keep downloading but pull from YouTube instead, set `DOWNLOAD_SOURCE=YouTube` in `.env`, or pick it under **Downloads → Source** in the admin UI. Starring then saves a yt-dlp MP3 rather than a Soulseek FLAC. `SoulseekThenYouTube` is the middle setting: it tries for the FLAC first and only settles for the MP3 when no peer delivers.
+Use **Downloads → Heart download priority** in the admin UI to enable and order Soulseek, YouTube, and Lidarr. Octo tries each enabled source from top to bottom and stops at the first success. Disabled sources keep their position. `DOWNLOAD_SOURCE` remains the initial fallback for existing and env-only installations.
 
-To hand hearts to Lidarr, set `DOWNLOAD_SOURCE=Lidarr`, then configure its URL, API key, root folder, and profiles on Octo's Lidarr admin page. Lidarr works at album level, so hearting one track fetches its full album.
+Lidarr works at album level, so hearting one track fetches its full album. It is last and disabled by default; configure its URL, API key, root folder, and profiles on the Lidarr page, then enable it in the priority list.
 
 To stop downloading altogether, set `Subsonic__DownloadOnStar=false`. Hearting a song will still register the favorite, but won't trigger any download. You'll keep search and radio enrichment via YouTube preview, which is useful if you only want the discovery layer and prefer to acquire FLACs another way.
 
@@ -255,7 +255,7 @@ The admin UI's "Config sources" tab shows the merged effective value for every k
 
 ### Existing Lidarr setup
 
-Set `DOWNLOAD_SOURCE=Lidarr`, `LIDARR_URL`, and `LIDARR_API_KEY`, restart Octo, then open the **Lidarr** admin tab and load its root-folder and profile choices. Octo does not install or configure Lidarr's indexers or download client.
+Set `LIDARR_URL` and `LIDARR_API_KEY`, restart Octo, then open the **Lidarr** admin tab to test the connection and choose its root folder and profiles. Enable and position Lidarr under **Downloads → Heart download priority**. Octo does not install or configure Lidarr's indexers or download client.
 
 The selected Lidarr root and Octo's effective Navidrome library root must expose the same underlying files. Their container paths may differ: Octo translates the imported path relative to the selected Lidarr root. For example, Lidarr `/data/music/Artist/Album/file.flac` can map to Octo `/music/Artist/Album/file.flac` when both mounts point at the same host directory.
 
@@ -287,7 +287,7 @@ Octo hijacks these endpoints; everything else proxies to Navidrome unchanged:
 | `stream` | YouTube proxy with Range support, mp4/m4a passthrough |
 | `getCoverArt` | Deezer → iTunes → Last.fm aggregator with Octo watermark |
 | `getAlbum` | external album tracklists, and fills in tracks you're missing from an album you own |
-| `star` | trigger a download of the track or a whole album, from whichever source `DOWNLOAD_SOURCE` selects (Soulseek multi-peer FLAC by default) |
+| `star` | try enabled heart sources in priority order and stop after the first successful track/album acquisition |
 | `scrobble` | sliding-window prewarm of next 8 in queue |
 | `getTranscodeDecision` | OpenSubsonic — return direct-play for Octo IDs |
 

--- a/README.md
+++ b/README.md
@@ -178,9 +178,11 @@ Yes. Soulseek peers share full FLAC files with their existing ID3 tags intact. O
 
 ### What if I don't want to use Soulseek?
 
-You have two options, depending on whether you still want a file.
+You can use YouTube or an existing Lidarr server, or disable automatic acquisition entirely.
 
 To keep downloading but pull from YouTube instead, set `DOWNLOAD_SOURCE=YouTube` in `.env`, or pick it under **Downloads → Source** in the admin UI. Starring then saves a yt-dlp MP3 rather than a Soulseek FLAC. `SoulseekThenYouTube` is the middle setting: it tries for the FLAC first and only settles for the MP3 when no peer delivers.
+
+To hand hearts to Lidarr, set `DOWNLOAD_SOURCE=Lidarr`, then configure its URL, API key, root folder, and profiles on Octo's Lidarr admin page. Lidarr works at album level, so hearting one track fetches its full album.
 
 To stop downloading altogether, set `Subsonic__DownloadOnStar=false`. Hearting a song will still register the favorite, but won't trigger any download. You'll keep search and radio enrichment via YouTube preview, which is useful if you only want the discovery layer and prefer to acquire FLACs another way.
 
@@ -325,7 +327,7 @@ Yes — slskd downloads are full FLACs from peer libraries that already have ID3
 Octo throws an error and the star icon stays filled. Try again later or grab the file by hand. Real failures are rare.
 
 **Can it run without Soulseek?**
-Yes — select Lidarr for hearts, or set `DOWNLOAD_ON_STAR=false` to keep discovery without automatic acquisition.
+Yes. Select YouTube for MP3 downloads, Lidarr for album-level heart acquisition, or set `DOWNLOAD_ON_STAR=false` to keep discovery without automatic acquisition.
 
 **Can it run without Last.fm?**
 Yes, but search and radio fall back to local-only — no discovery layer. The free Last.fm key takes 30 seconds.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,15 @@ services:
       Soulseek__PreferredExtension: ${SLSKD_PREFERRED_EXTENSION:-flac}
       Soulseek__DownloadTimeoutSeconds: ${SLSKD_DOWNLOAD_TIMEOUT_SECONDS:-180}
 
+      # ----- existing Lidarr (optional heart-download source) -----
+      Lidarr__BaseUrl: ${LIDARR_URL:-}
+      Lidarr__ApiKey: ${LIDARR_API_KEY:-}
+      Lidarr__RootFolderPath: ${LIDARR_ROOT_FOLDER_PATH:-}
+      Lidarr__QualityProfileId: ${LIDARR_QUALITY_PROFILE_ID:-0}
+      Lidarr__MetadataProfileId: ${LIDARR_METADATA_PROFILE_ID:-0}
+      Lidarr__CompletionMode: ${LIDARR_COMPLETION_MODE:-Accepted}
+      Lidarr__ImportTimeoutSeconds: ${LIDARR_IMPORT_TIMEOUT_SECONDS:-1800}
+
       # ----- Last.fm radio -----
       LastFm__ApiKey: ${LASTFM_API_KEY:-}
       LastFm__EnableRadio: ${LASTFM_ENABLE_RADIO:-true}

--- a/install.sh
+++ b/install.sh
@@ -163,6 +163,7 @@ echo "What you'll need handy:"
 echo "  • A Navidrome server URL (running already)"
 echo "  • A free Last.fm API key — https://www.last.fm/api/account/create"
 echo "  • A free Soulseek (slsknet.org) account"
+echo "  • Optionally, an existing Lidarr server"
 echo
 require_docker
 green "✓ Docker + Compose v2 ready"
@@ -228,6 +229,28 @@ SLSKD_SOULSEEK_PASSWORD=$(ask_secret "Your Soulseek password" "$(existing SLSKD_
 echo
 
 # ─────────────────────────────────────────────────────────────────
+# Optional Lidarr heart source
+# ─────────────────────────────────────────────────────────────────
+bold "─── Heart download source ──────────────────────────────────"
+echo "  Soulseek — individual lossless tracks (default)"
+echo "  Lidarr   — your existing Lidarr server; always fetches the full album"
+DOWNLOAD_SOURCE=$(ask "Heart download source" "$(existing DOWNLOAD_SOURCE || echo "Soulseek")")
+LIDARR_URL="$(existing LIDARR_URL)"
+LIDARR_API_KEY="$(existing LIDARR_API_KEY)"
+LIDARR_ROOT_FOLDER_PATH="$(existing LIDARR_ROOT_FOLDER_PATH)"
+LIDARR_QUALITY_PROFILE_ID="$(existing LIDARR_QUALITY_PROFILE_ID || echo "0")"
+LIDARR_METADATA_PROFILE_ID="$(existing LIDARR_METADATA_PROFILE_ID || echo "0")"
+LIDARR_COMPLETION_MODE="$(existing LIDARR_COMPLETION_MODE || echo "Accepted")"
+LIDARR_IMPORT_TIMEOUT_SECONDS="$(existing LIDARR_IMPORT_TIMEOUT_SECONDS || echo "1800")"
+if [ "${DOWNLOAD_SOURCE,,}" = "lidarr" ]; then
+  echo "  Lidarr must already have working indexers and a download client."
+  LIDARR_URL=$(ask "Lidarr URL (reachable from the Octo container)" "$LIDARR_URL")
+  LIDARR_API_KEY=$(ask_secret "Lidarr API key" "$LIDARR_API_KEY")
+  dim "  Choose the Lidarr root folder and profiles in Octo's admin UI after startup."
+fi
+echo
+
+# ─────────────────────────────────────────────────────────────────
 # Storage / layout (keep the simple defaults visible)
 # ─────────────────────────────────────────────────────────────────
 bold "─── Storage / layout ───────────────────────────────────────"
@@ -278,9 +301,19 @@ SLSKD_DOWNLOAD_TIMEOUT_SECONDS=180
 SLSKD_SOULSEEK_USERNAME=$SLSKD_SOULSEEK_USERNAME
 SLSKD_SOULSEEK_PASSWORD="$SLSKD_SOULSEEK_PASSWORD"
 
+# === Existing Lidarr (optional) ===
+LIDARR_URL=$LIDARR_URL
+LIDARR_API_KEY=$LIDARR_API_KEY
+LIDARR_ROOT_FOLDER_PATH=$LIDARR_ROOT_FOLDER_PATH
+LIDARR_QUALITY_PROFILE_ID=$LIDARR_QUALITY_PROFILE_ID
+LIDARR_METADATA_PROFILE_ID=$LIDARR_METADATA_PROFILE_ID
+LIDARR_COMPLETION_MODE=$LIDARR_COMPLETION_MODE
+LIDARR_IMPORT_TIMEOUT_SECONDS=$LIDARR_IMPORT_TIMEOUT_SECONDS
+
 # === Storage / layout ===
 STORAGE_MODE=$STORAGE_MODE
 DOWNLOAD_MODE=Track
+DOWNLOAD_SOURCE=$DOWNLOAD_SOURCE
 DOWNLOAD_ON_STAR=true
 DOWNLOAD_ALBUM_ON_STAR=true
 WAIT_FOR_LOSSLESS_ON_PLAY=false
@@ -353,6 +386,9 @@ check_svc "Navidrome"  "navidrome"
 check_svc "Last.fm"    "lastfm"
 check_svc "yt-dlp shim" "ytDlpShim"
 check_svc "slskd"      "slskd"
+if [ "${DOWNLOAD_SOURCE,,}" = "lidarr" ]; then
+  check_svc "Lidarr" "lidarr"
+fi
 
 # ─────────────────────────────────────────────────────────────────
 # Done
@@ -370,7 +406,11 @@ echo "     Use your existing Navidrome credentials — Octo just proxies."
 echo
 echo "  3. Test it: search for an artist you don't fully own. Owned tracks come"
 echo "     up first; recommendations from Last.fm fill the rest. Tap one to hear"
-echo "     the YouTube preview. Heart it to download via Soulseek."
+if [ "${DOWNLOAD_SOURCE,,}" = "lidarr" ]; then
+  echo "     the YouTube preview. Heart it to send its full album to Lidarr."
+else
+  echo "     the YouTube preview. Heart it to download via Soulseek."
+fi
 echo
 dim "  slskd web UI:    http://<this-host>:5030    (admin / shown above)"
 dim "  Stop:            docker compose down"

--- a/octo.Tests/CachePlaybackTests.cs
+++ b/octo.Tests/CachePlaybackTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Octo.Models.Settings;
+using Octo.Services;
+using Octo.Services.Common;
+using Octo.Services.Local;
+
+namespace Octo.Tests;
+
+public sealed class ExternalPlaybackTests
+{
+    [Fact]
+    public async Task ExternalPlaybackUsesYouTubeRegardlessOfLegacyStorageMode()
+    {
+        var downloads = new Mock<IDownloadService>();
+        downloads.Setup(service => service.GetDirectStreamAsync(
+                "soulseek", "track-id", null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DirectStreamInfo
+            {
+                AudioStream = new MemoryStream([1, 2, 3]),
+                ContentType = "audio/mp4",
+                ContentLength = 3,
+                StatusCode = 200,
+            });
+        var library = new Mock<ILocalLibraryService>();
+        library.Setup(service => service.ParseSongId("external-track"))
+            .Returns((true, "soulseek", "track-id"));
+
+        await using var factory = CreateFactory(downloads, library, waitForLossless: false);
+
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/rest/stream?id=external-track&f=json");
+
+        response.EnsureSuccessStatusCode();
+        Assert.Equal([1, 2, 3], await response.Content.ReadAsByteArrayAsync());
+        downloads.Verify(service => service.GetDirectStreamAsync(
+            "soulseek", "track-id", null,
+            It.IsAny<CancellationToken>()), Times.Once);
+        downloads.Verify(service => service.DownloadAndStreamAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WaitForLosslessStillAcquiresBeforePlaybackWhenEnabled()
+    {
+        var downloads = new Mock<IDownloadService>();
+        var library = new Mock<ILocalLibraryService>();
+        library.Setup(service => service.ParseSongId("external-track"))
+            .Returns((true, "soulseek", "track-id"));
+
+        await using var factory = CreateFactory(downloads, library, waitForLossless: true);
+        using var client = factory.CreateClient();
+        var responseTask = client.GetAsync("/rest/stream?id=external-track&f=json");
+
+        var queue = factory.Services.GetRequiredService<TrackAcquisitionQueue>();
+        using var dequeueTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var request = await queue.DequeueAsync(dequeueTimeout.Token);
+        Assert.NotNull(request);
+        Assert.False(request.IsStar);
+        Assert.False(request.TriggerAlbumDownload);
+        Assert.True(request.ForcePermanent);
+
+        var path = Path.Combine(Path.GetTempPath(), $"octo-playback-{Guid.NewGuid():N}.flac");
+        try
+        {
+            await File.WriteAllBytesAsync(path, [4, 5, 6]);
+            request.Completion.TrySetResult(path);
+            queue.Release(request);
+
+            using var response = await responseTask;
+            response.EnsureSuccessStatusCode();
+            Assert.Equal([4, 5, 6], await response.Content.ReadAsByteArrayAsync());
+            downloads.Verify(service => service.GetDirectStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(
+        Mock<IDownloadService> downloads,
+        Mock<ILocalLibraryService> library,
+        bool waitForLossless)
+    {
+        return new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, config) =>
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Subsonic:Url"] = "http://navidrome.invalid",
+                        ["Subsonic:StorageMode"] = "Cache",
+                        ["Subsonic:DownloadSource"] = "Soulseek",
+                        ["Subsonic:WaitForLosslessOnPlay"] = waitForLossless.ToString(),
+                        ["Library:DownloadPath"] = Path.GetTempPath(),
+                    }));
+                builder.ConfigureServices(services =>
+                {
+                    services.RemoveAll<IHostedService>();
+                    services.RemoveAll<IDownloadService>();
+                    services.RemoveAll<ILocalLibraryService>();
+                    services.AddSingleton(downloads.Object);
+                    services.AddSingleton(library.Object);
+                });
+            });
+    }
+}

--- a/octo.Tests/HeartAcquisitionCoordinatorTests.cs
+++ b/octo.Tests/HeartAcquisitionCoordinatorTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Octo.Models.Settings;
+using Octo.Services;
+using Octo.Services.Common;
+using Octo.Services.Lidarr;
+
+namespace Octo.Tests;
+
+public class HeartAcquisitionCoordinatorTests
+{
+    [Fact]
+    public void LidarrSourceRoutesTrackAndAlbumWithoutCallingDirectDownloader()
+    {
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        var direct = new Mock<IDownloadService>();
+        var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
+        var coordinator = new HeartAcquisitionCoordinator(
+            Options.Create(new SubsonicSettings { DownloadSource = DownloadSource.Lidarr }),
+            queue, direct.Object, lidarr.Object);
+
+        coordinator.QueueTrack("soulseek", "track-id");
+        coordinator.QueueAlbum("soulseek", "album-id");
+
+        lidarr.Verify(x => x.QueueTrack("soulseek", "track-id"), Times.Once);
+        lidarr.Verify(x => x.QueueAlbum("soulseek", "album-id"), Times.Once);
+        direct.Verify(x => x.DownloadRemainingAlbumTracksInBackground(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void SoulseekSourceKeepsAlbumOnExistingDirectPath()
+    {
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        var direct = new Mock<IDownloadService>();
+        var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
+        var coordinator = new HeartAcquisitionCoordinator(
+            Options.Create(new SubsonicSettings { DownloadSource = DownloadSource.Soulseek }),
+            queue, direct.Object, lidarr.Object);
+
+        coordinator.QueueAlbum("soulseek", "album-id");
+
+        direct.Verify(x => x.DownloadRemainingAlbumTracksInBackground("soulseek", "album-id", ""), Times.Once);
+        lidarr.VerifyNoOtherCalls();
+    }
+}

--- a/octo.Tests/HeartAcquisitionCoordinatorTests.cs
+++ b/octo.Tests/HeartAcquisitionCoordinatorTests.cs
@@ -179,9 +179,9 @@ public class HeartAcquisitionCoordinatorTests
         var steps = settings.EffectiveHeartDownloadSources();
 
         Assert.Collection(steps,
-            step => { Assert.Equal(HeartDownloadSource.Soulseek, step.Source); Assert.True(step.Enabled); },
-            step => { Assert.Equal(HeartDownloadSource.YouTube, step.Source); Assert.True(step.Enabled); },
-            step => { Assert.Equal(HeartDownloadSource.Lidarr, step.Source); Assert.False(step.Enabled); });
+            step => { Assert.Equal(HeartDownloadSource.Soulseek, step.Source); Assert.True(step.SongEnabled); Assert.True(step.AlbumEnabled); },
+            step => { Assert.Equal(HeartDownloadSource.YouTube, step.Source); Assert.True(step.SongEnabled); Assert.True(step.AlbumEnabled); },
+            step => { Assert.Equal(HeartDownloadSource.Lidarr, step.Source); Assert.False(step.SongEnabled); Assert.False(step.AlbumEnabled); });
     }
 
     [Fact]
@@ -232,6 +232,39 @@ public class HeartAcquisitionCoordinatorTests
         Assert.Collection(steps,
             step => Assert.Equal(HeartDownloadSource.Lidarr, step.Source),
             step => Assert.Equal(HeartDownloadSource.YouTube, step.Source),
-            step => { Assert.Equal(HeartDownloadSource.Soulseek, step.Source); Assert.False(step.Enabled); });
+            step => { Assert.Equal(HeartDownloadSource.Soulseek, step.Source); Assert.False(step.SongEnabled); Assert.False(step.AlbumEnabled); });
+    }
+
+    [Fact]
+    public async Task SongAndAlbumHeartsUseTheirOwnPerSourceSwitches()
+    {
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        lidarr.Setup(x => x.TryAcquireAlbumAsync("soulseek", "album-id", true))
+            .ReturnsAsync(true);
+        var direct = new Mock<IDownloadService>();
+        var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
+        var settings = TestOptions.Monitor(new SubsonicSettings
+        {
+            HeartDownloadSources =
+            [
+                new() { Source = HeartDownloadSource.Soulseek, SongEnabled = true, AlbumEnabled = false },
+                new() { Source = HeartDownloadSource.Lidarr, SongEnabled = false, AlbumEnabled = true },
+                new() { Source = HeartDownloadSource.YouTube, SongEnabled = false, AlbumEnabled = false },
+            ],
+        });
+        var coordinator = new HeartAcquisitionCoordinator(settings, queue, direct.Object, lidarr.Object);
+
+        var trackAcquisition = coordinator.AcquireTrackAsync("soulseek", "track-id");
+        var request = await queue.DequeueAsync(CancellationToken.None);
+        Assert.NotNull(request);
+        Assert.Equal(DownloadSource.Soulseek, request.SourceOverride);
+        request.Completion.TrySetResult("/music/track.flac");
+        queue.Release(request);
+        await trackAcquisition;
+        await coordinator.AcquireAlbumAsync("soulseek", "album-id");
+
+        lidarr.Verify(x => x.TryAcquireTrackAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+        lidarr.Verify(x => x.TryAcquireAlbumAsync("soulseek", "album-id", true), Times.Once);
     }
 }

--- a/octo.Tests/HeartAcquisitionCoordinatorTests.cs
+++ b/octo.Tests/HeartAcquisitionCoordinatorTests.cs
@@ -10,56 +10,228 @@ namespace Octo.Tests;
 public class HeartAcquisitionCoordinatorTests
 {
     [Fact]
-    public void LidarrSourceRoutesTrackAndAlbumWithoutCallingDirectDownloader()
+    public async Task LidarrSourceRoutesTrackAndAlbumWithoutCallingDirectDownloader()
     {
         var lidarr = new Mock<ILidarrHeartAcquisitionService>();
         var direct = new Mock<IDownloadService>();
+        lidarr.Setup(x => x.TryAcquireTrackAsync("soulseek", "track-id", true))
+            .ReturnsAsync(true);
+        lidarr.Setup(x => x.TryAcquireAlbumAsync("soulseek", "album-id", true))
+            .ReturnsAsync(true);
         var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
         var coordinator = new HeartAcquisitionCoordinator(
             TestOptions.Monitor(new SubsonicSettings { DownloadSource = DownloadSource.Lidarr }),
             queue, direct.Object, lidarr.Object);
 
-        coordinator.QueueTrack("soulseek", "track-id");
-        coordinator.QueueAlbum("soulseek", "album-id");
+        await coordinator.AcquireTrackAsync("soulseek", "track-id");
+        await coordinator.AcquireAlbumAsync("soulseek", "album-id");
 
-        lidarr.Verify(x => x.QueueTrack("soulseek", "track-id"), Times.Once);
-        lidarr.Verify(x => x.QueueAlbum("soulseek", "album-id"), Times.Once);
+        lidarr.Verify(x => x.TryAcquireTrackAsync("soulseek", "track-id", true), Times.Once);
+        lidarr.Verify(x => x.TryAcquireAlbumAsync("soulseek", "album-id", true), Times.Once);
         direct.Verify(x => x.DownloadRemainingAlbumTracksInBackground(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
-    public void SoulseekSourceKeepsAlbumOnExistingDirectPath()
+    public async Task SoulseekSourceKeepsAlbumOnExistingDirectPath()
     {
         var lidarr = new Mock<ILidarrHeartAcquisitionService>();
         var direct = new Mock<IDownloadService>();
+        direct.Setup(x => x.DownloadAlbumWithSourceAsync(
+                "soulseek", "album-id", DownloadSource.Soulseek, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
         var coordinator = new HeartAcquisitionCoordinator(
             TestOptions.Monitor(new SubsonicSettings { DownloadSource = DownloadSource.Soulseek }),
             queue, direct.Object, lidarr.Object);
 
-        coordinator.QueueAlbum("soulseek", "album-id");
+        await coordinator.AcquireAlbumAsync("soulseek", "album-id");
 
-        direct.Verify(x => x.DownloadRemainingAlbumTracksInBackground("soulseek", "album-id", ""), Times.Once);
+        direct.Verify(x => x.DownloadAlbumWithSourceAsync(
+            "soulseek", "album-id", DownloadSource.Soulseek, false,
+            It.IsAny<CancellationToken>()), Times.Once);
         lidarr.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public void DownloadSourceChangeTakesEffectWithoutRebuildingCoordinator()
+    public async Task DownloadSourceChangeTakesEffectWithoutRebuildingCoordinator()
     {
         var lidarr = new Mock<ILidarrHeartAcquisitionService>();
         var direct = new Mock<IDownloadService>();
+        direct.Setup(x => x.DownloadAlbumWithSourceAsync(
+                "soulseek", "first-album", DownloadSource.Soulseek, false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        lidarr.Setup(x => x.TryAcquireAlbumAsync("soulseek", "second-album", true))
+            .ReturnsAsync(true);
         var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
         var settings = TestOptions.Monitor(
             new SubsonicSettings { DownloadSource = DownloadSource.Soulseek });
         var coordinator = new HeartAcquisitionCoordinator(settings, queue, direct.Object, lidarr.Object);
 
-        coordinator.QueueAlbum("soulseek", "first-album");
+        await coordinator.AcquireAlbumAsync("soulseek", "first-album");
         settings.Set(new SubsonicSettings { DownloadSource = DownloadSource.Lidarr });
-        coordinator.QueueAlbum("soulseek", "second-album");
+        await coordinator.AcquireAlbumAsync("soulseek", "second-album");
 
-        direct.Verify(x => x.DownloadRemainingAlbumTracksInBackground(
-            "soulseek", "first-album", ""), Times.Once);
-        lidarr.Verify(x => x.QueueAlbum("soulseek", "second-album"), Times.Once);
+        direct.Verify(x => x.DownloadAlbumWithSourceAsync(
+            "soulseek", "first-album", DownloadSource.Soulseek, false,
+            It.IsAny<CancellationToken>()), Times.Once);
+        lidarr.Verify(x => x.TryAcquireAlbumAsync("soulseek", "second-album", true), Times.Once);
+    }
+
+    [Fact]
+    public async Task AlbumPriorityStopsAtFirstSuccessfulSource()
+    {
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        var direct = new Mock<IDownloadService>();
+        direct.Setup(x => x.DownloadAlbumWithSourceAsync(
+                "soulseek", "album-id", DownloadSource.Soulseek, true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var settings = TestOptions.Monitor(new SubsonicSettings
+        {
+            HeartDownloadSources =
+            [
+                new() { Source = HeartDownloadSource.YouTube, Enabled = false },
+                new() { Source = HeartDownloadSource.Soulseek, Enabled = true },
+                new() { Source = HeartDownloadSource.Lidarr, Enabled = true },
+            ],
+        });
+        var coordinator = new HeartAcquisitionCoordinator(settings,
+            new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object),
+            direct.Object, lidarr.Object);
+
+        await coordinator.AcquireAlbumAsync("soulseek", "album-id");
+
+        lidarr.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task AlbumPriorityFallsThroughToLidarrAfterDirectFailure()
+    {
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        var direct = new Mock<IDownloadService>();
+        direct.Setup(x => x.DownloadAlbumWithSourceAsync(
+                "soulseek", "album-id", DownloadSource.Soulseek, true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        lidarr.Setup(x => x.TryAcquireAlbumAsync("soulseek", "album-id", true))
+            .ReturnsAsync(true);
+        var settings = TestOptions.Monitor(new SubsonicSettings
+        {
+            HeartDownloadSources =
+            [
+                new() { Source = HeartDownloadSource.Soulseek, Enabled = true },
+                new() { Source = HeartDownloadSource.YouTube, Enabled = false },
+                new() { Source = HeartDownloadSource.Lidarr, Enabled = true },
+            ],
+        });
+        var coordinator = new HeartAcquisitionCoordinator(settings,
+            new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object),
+            direct.Object, lidarr.Object);
+
+        await coordinator.AcquireAlbumAsync("soulseek", "album-id");
+
+        lidarr.Verify(x => x.TryAcquireAlbumAsync("soulseek", "album-id", true), Times.Once);
+        direct.Verify(x => x.DownloadAlbumWithSourceAsync(
+            It.IsAny<string>(), It.IsAny<string>(), DownloadSource.YouTube,
+            It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AlbumPriorityTriesDirectSourcesInOrderAndStopsOnSuccess()
+    {
+        var attempts = new List<DownloadSource>();
+        var direct = new Mock<IDownloadService>();
+        direct.Setup(x => x.DownloadAlbumWithSourceAsync(
+                "soulseek", "album-id", It.IsAny<DownloadSource>(),
+                It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string _, DownloadSource source, bool _, CancellationToken _) =>
+            {
+                attempts.Add(source);
+                return source == DownloadSource.YouTube;
+            });
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        var settings = TestOptions.Monitor(new SubsonicSettings
+        {
+            HeartDownloadSources =
+            [
+                new() { Source = HeartDownloadSource.Soulseek, Enabled = true },
+                new() { Source = HeartDownloadSource.YouTube, Enabled = true },
+                new() { Source = HeartDownloadSource.Lidarr, Enabled = true },
+            ],
+        });
+        var coordinator = new HeartAcquisitionCoordinator(settings,
+            new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object),
+            direct.Object, lidarr.Object);
+
+        await coordinator.AcquireAlbumAsync("soulseek", "album-id");
+
+        Assert.Equal([DownloadSource.Soulseek, DownloadSource.YouTube], attempts);
+        lidarr.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void LegacyFallbackMapsToOrderedSourcesWithLidarrLast()
+    {
+        var settings = new SubsonicSettings { DownloadSource = DownloadSource.SoulseekThenYouTube };
+
+        var steps = settings.EffectiveHeartDownloadSources();
+
+        Assert.Collection(steps,
+            step => { Assert.Equal(HeartDownloadSource.Soulseek, step.Source); Assert.True(step.Enabled); },
+            step => { Assert.Equal(HeartDownloadSource.YouTube, step.Source); Assert.True(step.Enabled); },
+            step => { Assert.Equal(HeartDownloadSource.Lidarr, step.Source); Assert.False(step.Enabled); });
+    }
+
+    [Fact]
+    public async Task TrackPriorityFallsThroughFromSoulseekToLidarr()
+    {
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        lidarr.Setup(x => x.TryAcquireTrackAsync("soulseek", "track-id", true))
+            .ReturnsAsync(true);
+        var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
+        var settings = TestOptions.Monitor(new SubsonicSettings
+        {
+            HeartDownloadSources =
+            [
+                new() { Source = HeartDownloadSource.Soulseek, Enabled = true },
+                new() { Source = HeartDownloadSource.YouTube, Enabled = false },
+                new() { Source = HeartDownloadSource.Lidarr, Enabled = true },
+            ],
+        });
+        var coordinator = new HeartAcquisitionCoordinator(
+            settings, queue, new Mock<IDownloadService>().Object, lidarr.Object);
+
+        var acquisition = coordinator.AcquireTrackAsync("soulseek", "track-id");
+        var request = await queue.DequeueAsync(CancellationToken.None);
+        Assert.NotNull(request);
+        Assert.Equal(DownloadSource.Soulseek, request.SourceOverride);
+        Assert.False(request.NotifyOnFailure);
+        queue.Release(request);
+        request.Completion.TrySetException(new InvalidOperationException("no peer"));
+        await acquisition;
+
+        lidarr.Verify(x => x.TryAcquireTrackAsync("soulseek", "track-id", true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfiguredOrderIsPreservedAndMissingSourcesAreAppendedDisabled()
+    {
+        var settings = new SubsonicSettings
+        {
+            HeartDownloadSources =
+            [
+                new() { Source = HeartDownloadSource.Lidarr, Enabled = true },
+                new() { Source = HeartDownloadSource.YouTube, Enabled = true },
+            ],
+        };
+
+        var steps = settings.EffectiveHeartDownloadSources();
+
+        Assert.Collection(steps,
+            step => Assert.Equal(HeartDownloadSource.Lidarr, step.Source),
+            step => Assert.Equal(HeartDownloadSource.YouTube, step.Source),
+            step => { Assert.Equal(HeartDownloadSource.Soulseek, step.Source); Assert.False(step.Enabled); });
     }
 }

--- a/octo.Tests/HeartAcquisitionCoordinatorTests.cs
+++ b/octo.Tests/HeartAcquisitionCoordinatorTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 using Octo.Models.Settings;
 using Octo.Services;
@@ -17,7 +16,7 @@ public class HeartAcquisitionCoordinatorTests
         var direct = new Mock<IDownloadService>();
         var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
         var coordinator = new HeartAcquisitionCoordinator(
-            Options.Create(new SubsonicSettings { DownloadSource = DownloadSource.Lidarr }),
+            TestOptions.Monitor(new SubsonicSettings { DownloadSource = DownloadSource.Lidarr }),
             queue, direct.Object, lidarr.Object);
 
         coordinator.QueueTrack("soulseek", "track-id");
@@ -36,12 +35,31 @@ public class HeartAcquisitionCoordinatorTests
         var direct = new Mock<IDownloadService>();
         var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
         var coordinator = new HeartAcquisitionCoordinator(
-            Options.Create(new SubsonicSettings { DownloadSource = DownloadSource.Soulseek }),
+            TestOptions.Monitor(new SubsonicSettings { DownloadSource = DownloadSource.Soulseek }),
             queue, direct.Object, lidarr.Object);
 
         coordinator.QueueAlbum("soulseek", "album-id");
 
         direct.Verify(x => x.DownloadRemainingAlbumTracksInBackground("soulseek", "album-id", ""), Times.Once);
         lidarr.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void DownloadSourceChangeTakesEffectWithoutRebuildingCoordinator()
+    {
+        var lidarr = new Mock<ILidarrHeartAcquisitionService>();
+        var direct = new Mock<IDownloadService>();
+        var queue = new TrackAcquisitionQueue(new Mock<ILogger<TrackAcquisitionQueue>>().Object);
+        var settings = TestOptions.Monitor(
+            new SubsonicSettings { DownloadSource = DownloadSource.Soulseek });
+        var coordinator = new HeartAcquisitionCoordinator(settings, queue, direct.Object, lidarr.Object);
+
+        coordinator.QueueAlbum("soulseek", "first-album");
+        settings.Set(new SubsonicSettings { DownloadSource = DownloadSource.Lidarr });
+        coordinator.QueueAlbum("soulseek", "second-album");
+
+        direct.Verify(x => x.DownloadRemainingAlbumTracksInBackground(
+            "soulseek", "first-album", ""), Times.Once);
+        lidarr.Verify(x => x.QueueAlbum("soulseek", "second-album"), Times.Once);
     }
 }

--- a/octo.Tests/LidarrClientTests.cs
+++ b/octo.Tests/LidarrClientTests.cs
@@ -1,0 +1,233 @@
+using System.Net;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Options;
+using Moq;
+using Octo.Models.Settings;
+using Octo.Services.Lidarr;
+
+namespace Octo.Tests;
+
+public class LidarrClientTests
+{
+    private sealed class Handler : HttpMessageHandler
+    {
+        public List<(HttpMethod Method, string Path, string? ApiKey, string? Body)> Requests { get; } = new();
+        public required Func<HttpRequestMessage, string> Respond { get; init; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var body = request.Content is null ? null : await request.Content.ReadAsStringAsync(ct);
+            Requests.Add((request.Method, request.RequestUri!.PathAndQuery,
+                request.Headers.TryGetValues("X-Api-Key", out var values) ? values.Single() : null, body));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(Respond(request)),
+            };
+        }
+    }
+
+    private static LidarrClient Build(Handler handler, LidarrSettings? settings = null)
+    {
+        settings ??= new LidarrSettings
+        {
+            BaseUrl = "http://lidarr:8686",
+            ApiKey = "secret",
+            RootFolderPath = "/data/music",
+            QualityProfileId = 3,
+            MetadataProfileId = 4,
+        };
+        var monitor = new Mock<IOptionsMonitor<LidarrSettings>>();
+        monitor.SetupGet(x => x.CurrentValue).Returns(settings);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(() => new HttpClient(handler));
+        return new LidarrClient(factory.Object, monitor.Object);
+    }
+
+    [Fact]
+    public async Task OptionsUseApiKeyAndMapServerChoices()
+    {
+        var handler = new Handler
+        {
+            Respond = req => req.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/rootfolder" => "[{\"id\":1,\"path\":\"/data/music\"}]",
+                "/api/v1/qualityprofile" => "[{\"id\":2,\"name\":\"Lossless\"}]",
+                "/api/v1/metadataprofile" => "[{\"id\":3,\"name\":\"Standard\"}]",
+                _ => "[]",
+            },
+        };
+
+        var result = await Build(handler).GetOptionsAsync();
+
+        Assert.Equal("/data/music", Assert.Single(result.RootFolders).Path);
+        Assert.Equal("Lossless", Assert.Single(result.QualityProfiles).Name);
+        Assert.Equal("Standard", Assert.Single(result.MetadataProfiles).Name);
+        Assert.All(handler.Requests, r => Assert.Equal("secret", r.ApiKey));
+    }
+
+    [Fact]
+    public void AlbumSelectionRequiresExactIdentityAndUsesYearToDisambiguate()
+    {
+        var candidates = new[]
+        {
+            Candidate("a", "In Rainbows", "Radiohead", 2007),
+            Candidate("b", "In Rainbows", "Radiohead", 2025),
+        };
+
+        Assert.Equal("a", LidarrClient.SelectBestAlbum(candidates, "RADIOHEAD", "In-Rainbows", 2007)!.ForeignAlbumId);
+        Assert.Null(LidarrClient.SelectBestAlbum(candidates, "Radiohead", "In Rainbows", null));
+        Assert.Null(LidarrClient.SelectBestAlbum(candidates, "Other", "In Rainbows", 2007));
+    }
+
+    [Fact]
+    public async Task NewAlbumUsesChosenDefaultsAndDoesNotMonitorFutureReleases()
+    {
+        var handler = new Handler
+        {
+            Respond = req => (req.Method.Method, req.RequestUri!.AbsolutePath) switch
+            {
+                ("GET", "/api/v1/album") => "[]",
+                ("GET", "/api/v1/artist") => "[]",
+                ("POST", "/api/v1/album") => "{\"id\":42}",
+                ("POST", "/api/v1/command") => "{\"id\":9}",
+                _ => "[]",
+            },
+        };
+
+        var id = await Build(handler).EnsureAlbumAndSearchAsync(Candidate("mbid", "Album", "Artist", 2020));
+
+        Assert.Equal(42, id);
+        var add = JsonNode.Parse(handler.Requests.Single(r => r.Method == HttpMethod.Post && r.Path == "/api/v1/album").Body!)!;
+        Assert.Equal("/data/music", add["artist"]!["rootFolderPath"]!.GetValue<string>());
+        Assert.Equal(3, add["artist"]!["qualityProfileId"]!.GetValue<int>());
+        Assert.Equal(4, add["artist"]!["metadataProfileId"]!.GetValue<int>());
+        Assert.Equal("none", add["artist"]!["monitorNewItems"]!.GetValue<string>());
+        var command = handler.Requests.Single(r => r.Method == HttpMethod.Post && r.Path == "/api/v1/command").Body!;
+        Assert.Contains("AlbumSearch", command);
+        Assert.Contains("42", command);
+    }
+
+    [Fact]
+    public async Task ExistingArtistSettingsArePreservedWhenAddingAlbum()
+    {
+        var handler = new Handler
+        {
+            Respond = req => (req.Method.Method, req.RequestUri!.AbsolutePath) switch
+            {
+                ("GET", "/api/v1/album") => "[]",
+                ("GET", "/api/v1/artist") =>
+                    "[{\"id\":7,\"foreignArtistId\":\"artist-mbid\",\"path\":\"/existing/Artist\",\"qualityProfileId\":9,\"metadataProfileId\":10}]",
+                ("POST", "/api/v1/album") => "{\"id\":42}",
+                ("POST", "/api/v1/command") => "{\"id\":9}",
+                _ => "[]",
+            },
+        };
+
+        await Build(handler).EnsureAlbumAndSearchAsync(Candidate("mbid", "Album", "Artist", 2020));
+
+        var add = JsonNode.Parse(handler.Requests.Single(r =>
+            r.Method == HttpMethod.Post && r.Path == "/api/v1/album").Body!)!;
+        Assert.Equal(7, add["artistId"]!.GetValue<int>());
+        Assert.Equal("/existing/Artist", add["artist"]!["path"]!.GetValue<string>());
+        Assert.Equal(9, add["artist"]!["qualityProfileId"]!.GetValue<int>());
+        Assert.Equal(10, add["artist"]!["metadataProfileId"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public async Task ExistingAlbumIsMonitoredWithoutChangingItsArtist()
+    {
+        var handler = new Handler
+        {
+            Respond = req => (req.Method.Method, req.RequestUri!.AbsolutePath) switch
+            {
+                ("GET", "/api/v1/album") =>
+                    "[{\"id\":12,\"foreignAlbumId\":\"mbid\",\"monitored\":false,\"artist\":{\"id\":7,\"qualityProfileId\":9}}]",
+                ("PUT", "/api/v1/album/12") => "{\"id\":12,\"monitored\":true}",
+                ("POST", "/api/v1/command") => "{\"id\":9}",
+                _ => "[]",
+            },
+        };
+
+        var id = await Build(handler).EnsureAlbumAndSearchAsync(Candidate("mbid", "Album", "Artist", 2020));
+
+        Assert.Equal(12, id);
+        var update = JsonNode.Parse(handler.Requests.Single(r => r.Method == HttpMethod.Put).Body!)!;
+        Assert.True(update["monitored"]!.GetValue<bool>());
+        Assert.Equal(9, update["artist"]!["qualityProfileId"]!.GetValue<int>());
+        Assert.DoesNotContain(handler.Requests, r => r.Path == "/api/v1/artist");
+    }
+
+    [Fact]
+    public async Task AlbumTracksJoinTrackFilesReturnedBySeparateEndpoint()
+    {
+        var handler = new Handler
+        {
+            Respond = req => req.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/track" =>
+                    "[{\"id\":1,\"title\":\"Song\",\"trackNumber\":\"1\",\"duration\":123000,\"hasFile\":true,\"trackFileId\":8}]",
+                "/api/v1/trackFile" =>
+                    "[{\"id\":8,\"path\":\"/data/music/Artist/Album/01.flac\",\"size\":456}]",
+                _ => "[]",
+            },
+        };
+
+        var track = Assert.Single(await Build(handler).GetAlbumTracksAsync(42));
+
+        Assert.True(track.HasFile);
+        Assert.Equal("/data/music/Artist/Album/01.flac", track.Path);
+        Assert.Equal(456, track.SizeBytes);
+        Assert.Contains(handler.Requests, r => r.Path == "/api/v1/track?albumId=42");
+        Assert.Contains(handler.Requests, r => r.Path == "/api/v1/trackFile?albumId=42");
+    }
+
+    [Fact]
+    public async Task ImportCompletionUsesAlbumStatisticsNotAlternateReleaseRows()
+    {
+        var handler = new Handler
+        {
+            Respond = req => req.RequestUri!.AbsolutePath switch
+            {
+                "/api/v1/album/42" =>
+                    "{\"id\":42,\"statistics\":{\"trackCount\":1,\"trackFileCount\":1}}",
+                "/api/v1/track" =>
+                    "[{\"id\":1,\"title\":\"Song\",\"hasFile\":true,\"trackFileId\":8},{\"id\":2,\"title\":\"Alternate release bonus\",\"hasFile\":false,\"trackFileId\":0}]",
+                "/api/v1/trackFile" =>
+                    "[{\"id\":8,\"path\":\"/data/music/Artist/Album/01.flac\",\"size\":456}]",
+                _ => "[]",
+            },
+        };
+
+        var state = await Build(handler).GetAlbumImportStateAsync(42);
+
+        Assert.True(state.IsComplete);
+        Assert.Equal(1, state.TrackCount);
+        Assert.Equal(2, state.Tracks.Count);
+    }
+
+    [Fact]
+    public void ImportedPathsTranslateRelativeToSelectedRootAndRejectEscapes()
+    {
+        var translated = LidarrHeartAcquisitionService.TranslateImportedPath(
+            "/data/music/Radiohead/In Rainbows/01.flac", "/data/music", "/music");
+        Assert.Equal(Path.GetFullPath("/music/Radiohead/In Rainbows/01.flac"), translated);
+        Assert.Throws<InvalidOperationException>(() =>
+            LidarrHeartAcquisitionService.TranslateImportedPath("/downloads/other.flac", "/data/music", "/music"));
+    }
+
+    private static LidarrAlbumCandidate Candidate(string foreignId, string title, string artist, int? year)
+    {
+        var resource = new JsonObject
+        {
+            ["foreignAlbumId"] = foreignId,
+            ["title"] = title,
+            ["releaseDate"] = year is null ? null : $"{year}-01-01T00:00:00Z",
+            ["artist"] = new JsonObject
+            {
+                ["artistName"] = artist,
+                ["foreignArtistId"] = "artist-mbid",
+            },
+        };
+        return new LidarrAlbumCandidate(0, foreignId, title, artist, year, resource);
+    }
+}

--- a/octo.Tests/LidarrClientTests.cs
+++ b/octo.Tests/LidarrClientTests.cs
@@ -11,13 +11,13 @@ public class LidarrClientTests
 {
     private sealed class Handler : HttpMessageHandler
     {
-        public List<(HttpMethod Method, string Path, string? ApiKey, string? Body)> Requests { get; } = new();
+        public List<(HttpMethod Method, string Path, string Url, string? ApiKey, string? Body)> Requests { get; } = new();
         public required Func<HttpRequestMessage, string> Respond { get; init; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
             var body = request.Content is null ? null : await request.Content.ReadAsStringAsync(ct);
-            Requests.Add((request.Method, request.RequestUri!.PathAndQuery,
+            Requests.Add((request.Method, request.RequestUri!.PathAndQuery, request.RequestUri.ToString(),
                 request.Headers.TryGetValues("X-Api-Key", out var values) ? values.Single() : null, body));
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -63,6 +63,25 @@ public class LidarrClientTests
         Assert.Equal("Lossless", Assert.Single(result.QualityProfiles).Name);
         Assert.Equal("Standard", Assert.Single(result.MetadataProfiles).Name);
         Assert.All(handler.Requests, r => Assert.Equal("secret", r.ApiKey));
+    }
+
+    [Fact]
+    public async Task ConnectionTestUsesEnteredUrlAndApiKeyWithoutSaving()
+    {
+        var handler = new Handler
+        {
+            Respond = request => request.RequestUri!.AbsolutePath == "/api/v1/system/status" ? "{}" : "[]",
+        };
+
+        await Build(handler).TestConnectionAsync("http://new-lidarr:8686/", "entered-key");
+
+        Assert.Contains(handler.Requests, request =>
+            request.Path == "/api/v1/system/status"
+            && request.Url == "http://new-lidarr:8686/api/v1/system/status");
+        Assert.All(handler.Requests, request => Assert.Equal("entered-key", request.ApiKey));
+        Assert.Contains(handler.Requests, request => request.Path == "/api/v1/rootfolder");
+        Assert.Contains(handler.Requests, request => request.Path == "/api/v1/qualityprofile");
+        Assert.Contains(handler.Requests, request => request.Path == "/api/v1/metadataprofile");
     }
 
     [Fact]

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Octo.Models.Settings;
 using Octo.Services.Admin;
 using Octo.Services.LastFm;
+using Octo.Services.Lidarr;
 using Octo.Services.Soulseek;
 using Octo.Services.Subsonic;
 
@@ -28,11 +29,13 @@ public class AdminController : ControllerBase
     private readonly SettingsFileWriter _settings;
     private readonly IOptionsMonitor<SubsonicSettings> _subsonicOpts;
     private readonly IOptionsMonitor<SoulseekSettings> _soulseekOpts;
+    private readonly IOptionsMonitor<LidarrSettings> _lidarrOpts;
     private readonly IOptionsMonitor<LastFmSettings> _lastFmOpts;
     private readonly IOptionsMonitor<NotificationSettings> _notificationOpts;
     private readonly Octo.Services.Notifications.NotificationService _notifications;
     private readonly IConfiguration _config;
     private readonly SoulseekClient _slskd;
+    private readonly LidarrClient _lidarr;
     private readonly SubsonicProxyService _proxy;
     private readonly SubsonicDiscoveryService _discovery;
     private readonly NavidromeIdentityService _navIdentity;
@@ -49,11 +52,13 @@ public class AdminController : ControllerBase
         SettingsFileWriter settings,
         IOptionsMonitor<SubsonicSettings> subsonicOpts,
         IOptionsMonitor<SoulseekSettings> soulseekOpts,
+        IOptionsMonitor<LidarrSettings> lidarrOpts,
         IOptionsMonitor<LastFmSettings> lastFmOpts,
         IOptionsMonitor<NotificationSettings> notificationOpts,
         Octo.Services.Notifications.NotificationService notifications,
         IConfiguration config,
         SoulseekClient slskd,
+        LidarrClient lidarr,
         SubsonicProxyService proxy,
         SubsonicDiscoveryService discovery,
         NavidromeIdentityService navIdentity,
@@ -71,11 +76,13 @@ public class AdminController : ControllerBase
         _settings = settings;
         _subsonicOpts = subsonicOpts;
         _soulseekOpts = soulseekOpts;
+        _lidarrOpts = lidarrOpts;
         _lastFmOpts = lastFmOpts;
         _notificationOpts = notificationOpts;
         _notifications = notifications;
         _config = config;
         _slskd = slskd;
+        _lidarr = lidarr;
         _proxy = proxy;
         _discovery = discovery;
         _navIdentity = navIdentity;
@@ -287,6 +294,7 @@ public class AdminController : ControllerBase
     {
         var subsonic = _subsonicOpts.CurrentValue;
         var soulseek = _soulseekOpts.CurrentValue;
+        var lidarr = _lidarrOpts.CurrentValue;
         var lastfm = _lastFmOpts.CurrentValue;
         var notif = _notificationOpts.CurrentValue;
 
@@ -330,6 +338,16 @@ public class AdminController : ControllerBase
                 ["MinFileSizeBytes"] = soulseek.MinFileSizeBytes,
                 ["PreferredExtension"] = soulseek.PreferredExtension,
                 ["DownloadTimeoutSeconds"] = soulseek.DownloadTimeoutSeconds,
+            },
+            ["Lidarr"] = new Dictionary<string, object>
+            {
+                ["BaseUrl"] = lidarr.BaseUrl ?? "",
+                ["ApiKey"] = lidarr.ApiKey ?? "",
+                ["RootFolderPath"] = lidarr.RootFolderPath ?? "",
+                ["QualityProfileId"] = lidarr.QualityProfileId,
+                ["MetadataProfileId"] = lidarr.MetadataProfileId,
+                ["CompletionMode"] = lidarr.CompletionMode.ToString(),
+                ["ImportTimeoutSeconds"] = lidarr.ImportTimeoutSeconds,
             },
             ["YouTube"] = new Dictionary<string, object>
             {
@@ -426,6 +444,7 @@ public class AdminController : ControllerBase
     {
         var subsonic = _subsonicOpts.CurrentValue;
         var soulseek = _soulseekOpts.CurrentValue;
+        var lidarr = _lidarrOpts.CurrentValue;
         var lastfm = _lastFmOpts.CurrentValue;
         var notif = _notificationOpts.CurrentValue;
 
@@ -463,6 +482,16 @@ public class AdminController : ControllerBase
                 ["MinFileSizeBytes"] = soulseek.MinFileSizeBytes,
                 ["PreferredExtension"] = soulseek.PreferredExtension,
                 ["DownloadTimeoutSeconds"] = soulseek.DownloadTimeoutSeconds,
+            },
+            ["Lidarr"] = new JsonObject
+            {
+                ["BaseUrl"] = lidarr.BaseUrl ?? "",
+                ["ApiKey"] = lidarr.ApiKey ?? "",
+                ["RootFolderPath"] = lidarr.RootFolderPath ?? "",
+                ["QualityProfileId"] = lidarr.QualityProfileId,
+                ["MetadataProfileId"] = lidarr.MetadataProfileId,
+                ["CompletionMode"] = lidarr.CompletionMode.ToString(),
+                ["ImportTimeoutSeconds"] = lidarr.ImportTimeoutSeconds,
             },
             ["YouTube"] = new JsonObject
             {
@@ -564,6 +593,9 @@ public class AdminController : ControllerBase
             "Soulseek:BaseUrl", "Soulseek:Username", "Soulseek:Password",
             "Soulseek:SearchWaitSeconds", "Soulseek:MinFileSizeBytes",
             "Soulseek:PreferredExtension", "Soulseek:DownloadTimeoutSeconds",
+            "Lidarr:BaseUrl", "Lidarr:ApiKey", "Lidarr:RootFolderPath",
+            "Lidarr:QualityProfileId", "Lidarr:MetadataProfileId",
+            "Lidarr:CompletionMode", "Lidarr:ImportTimeoutSeconds",
             "YouTube:ShimUrl",
             "LastFm:ApiKey", "LastFm:EnableRadio", "LastFm:RadioTrackCount",
             "LastFm:RadioCacheDurationHours",
@@ -601,7 +633,7 @@ public class AdminController : ControllerBase
     /// <summary>
     /// Quick health snapshot for each backing service. The UI shows a status
     /// dot per service; the user can tell at a glance whether Octo can reach
-    /// Navidrome, slskd, the yt-dlp shim, and Last.fm.
+    /// Navidrome, slskd, Lidarr, the yt-dlp shim, and Last.fm.
     /// </summary>
     [HttpGet("status")]
     public async Task<IActionResult> GetStatus(CancellationToken ct)
@@ -611,6 +643,7 @@ public class AdminController : ControllerBase
         {
             ["navidrome"] = ProbeNavidromeAsync(ct),
             ["slskd"] = ProbeSlskdAsync(ct),
+            ["lidarr"] = ProbeLidarrAsync(ct),
             ["ytDlpShim"] = ProbeYouTubeShimAsync(ct),
             ["lastfm"] = ProbeLastFmAsync(ct),
         };
@@ -626,6 +659,14 @@ public class AdminController : ControllerBase
             services = results,
             time = DateTimeOffset.UtcNow.ToString("O"),
         });
+    }
+
+    /// <summary>Choices owned by the connected Lidarr instance for add-album defaults.</summary>
+    [HttpGet("lidarr/options")]
+    public async Task<IActionResult> GetLidarrOptions(CancellationToken ct)
+    {
+        try { return new JsonResult(await _lidarr.GetOptionsAsync(ct)); }
+        catch (Exception ex) { return BadRequest(new { error = ex.Message }); }
     }
 
     /// <summary>
@@ -673,6 +714,25 @@ public class AdminController : ControllerBase
         {
             var ok = await _slskd.IsReachableAsync(ct);
             return new ServiceProbe(ok, ok ? "reachable" : "unreachable / auth failed");
+        }
+        catch (Exception ex) { return new ServiceProbe(false, ex.Message); }
+    }
+
+    private async Task<ServiceProbe> ProbeLidarrAsync(CancellationToken ct)
+    {
+        var settings = _lidarrOpts.CurrentValue;
+        if (string.IsNullOrWhiteSpace(settings.BaseUrl) || string.IsNullOrWhiteSpace(settings.ApiKey))
+            return _subsonicOpts.CurrentValue.DownloadSource == DownloadSource.Lidarr
+                ? new ServiceProbe(false, "selected but not configured")
+                : new ServiceProbe(true, "not configured (optional)");
+        if (_subsonicOpts.CurrentValue.DownloadSource == DownloadSource.Lidarr
+            && (string.IsNullOrWhiteSpace(settings.RootFolderPath)
+                || settings.QualityProfileId <= 0 || settings.MetadataProfileId <= 0))
+            return new ServiceProbe(false, "select a root folder and profiles");
+        try
+        {
+            var ok = await _lidarr.IsReachableAsync(ct);
+            return new ServiceProbe(ok, ok ? "reachable" : "unreachable / API key invalid");
         }
         catch (Exception ex) { return new ServiceProbe(false, ex.Message); }
     }

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -320,7 +320,8 @@ public class AdminController : ControllerBase
                     .Select(step => new Dictionary<string, object>
                     {
                         ["Source"] = step.Source.ToString(),
-                        ["Enabled"] = step.Enabled,
+                        ["SongEnabled"] = step.SongEnabled == true,
+                        ["AlbumEnabled"] = step.AlbumEnabled == true,
                     }).ToList(),
                 ["AutoDetectDownloadPath"] = subsonic.AutoDetectDownloadPath,
                 ["LibraryPath"] = subsonic.LibraryPath,
@@ -471,7 +472,8 @@ public class AdminController : ControllerBase
                         .Select(step => (JsonNode)new JsonObject
                         {
                             ["Source"] = step.Source.ToString(),
-                            ["Enabled"] = step.Enabled,
+                            ["SongEnabled"] = step.SongEnabled == true,
+                            ["AlbumEnabled"] = step.AlbumEnabled == true,
                         }).ToArray()),
                 ["AutoDetectDownloadPath"] = subsonic.AutoDetectDownloadPath,
                 ["LibraryPath"] = subsonic.LibraryPath,
@@ -751,7 +753,8 @@ public class AdminController : ControllerBase
     {
         var settings = _lidarrOpts.CurrentValue;
         var lidarrEnabled = _subsonicOpts.CurrentValue.EffectiveHeartDownloadSources()
-            .Any(step => step.Enabled && step.Source == HeartDownloadSource.Lidarr);
+            .Any(step => step.Source == HeartDownloadSource.Lidarr
+                         && (step.SongEnabled == true || step.AlbumEnabled == true));
         if (string.IsNullOrWhiteSpace(settings.BaseUrl) || string.IsNullOrWhiteSpace(settings.ApiKey))
             return lidarrEnabled
                 ? new ServiceProbe(false, "selected but not configured")

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -316,6 +316,12 @@ public class AdminController : ControllerBase
                 // These two are rendered by the dashboard but were missing here, so their
                 // fields never pre-filled with the saved value.
                 ["DownloadSource"] = subsonic.DownloadSource.ToString(),
+                ["HeartDownloadSources"] = subsonic.EffectiveHeartDownloadSources()
+                    .Select(step => new Dictionary<string, object>
+                    {
+                        ["Source"] = step.Source.ToString(),
+                        ["Enabled"] = step.Enabled,
+                    }).ToList(),
                 ["AutoDetectDownloadPath"] = subsonic.AutoDetectDownloadPath,
                 ["LibraryPath"] = subsonic.LibraryPath,
                 ["FolderStructure"] = subsonic.FolderStructure.ToString(),
@@ -460,6 +466,13 @@ public class AdminController : ControllerBase
                 ["WaitForLosslessOnPlay"] = subsonic.WaitForLosslessOnPlay,
                 ["LosslessWaitTimeoutSeconds"] = subsonic.LosslessWaitTimeoutSeconds,
                 ["DownloadSource"] = subsonic.DownloadSource.ToString(),
+                ["HeartDownloadSources"] = new JsonArray(
+                    subsonic.EffectiveHeartDownloadSources()
+                        .Select(step => (JsonNode)new JsonObject
+                        {
+                            ["Source"] = step.Source.ToString(),
+                            ["Enabled"] = step.Enabled,
+                        }).ToArray()),
                 ["AutoDetectDownloadPath"] = subsonic.AutoDetectDownloadPath,
                 ["LibraryPath"] = subsonic.LibraryPath,
                 ["FolderStructure"] = subsonic.FolderStructure.ToString(),
@@ -669,6 +682,22 @@ public class AdminController : ControllerBase
         catch (Exception ex) { return BadRequest(new { error = ex.Message }); }
     }
 
+    public record LidarrConnectionTestRequest(string? BaseUrl, string? ApiKey);
+
+    /// <summary>Tests entered credentials without persisting them.</summary>
+    [HttpPost("lidarr/test")]
+    public async Task<IActionResult> TestLidarrConnection(
+        [FromBody] LidarrConnectionTestRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var options = await _lidarr.TestConnectionAsync(
+                request.BaseUrl ?? "", request.ApiKey ?? "", ct);
+            return Ok(new { ok = true, message = "Connected to Lidarr. Choices loaded.", options });
+        }
+        catch (Exception ex) { return BadRequest(new { ok = false, error = ex.Message }); }
+    }
+
     /// <summary>
     /// Exit the process with code 1 so docker compose's restart policy brings
     /// the container back up with refreshed config. The caller gets an empty
@@ -721,11 +750,13 @@ public class AdminController : ControllerBase
     private async Task<ServiceProbe> ProbeLidarrAsync(CancellationToken ct)
     {
         var settings = _lidarrOpts.CurrentValue;
+        var lidarrEnabled = _subsonicOpts.CurrentValue.EffectiveHeartDownloadSources()
+            .Any(step => step.Enabled && step.Source == HeartDownloadSource.Lidarr);
         if (string.IsNullOrWhiteSpace(settings.BaseUrl) || string.IsNullOrWhiteSpace(settings.ApiKey))
-            return _subsonicOpts.CurrentValue.DownloadSource == DownloadSource.Lidarr
+            return lidarrEnabled
                 ? new ServiceProbe(false, "selected but not configured")
-                : new ServiceProbe(true, "not configured (optional)");
-        if (_subsonicOpts.CurrentValue.DownloadSource == DownloadSource.Lidarr
+                : new ServiceProbe(true, "not configured (optional)", Warning: true);
+        if (lidarrEnabled
             && (string.IsNullOrWhiteSpace(settings.RootFolderPath)
                 || settings.QualityProfileId <= 0 || settings.MetadataProfileId <= 0))
             return new ServiceProbe(false, "select a root folder and profiles");
@@ -767,7 +798,7 @@ public class AdminController : ControllerBase
         catch (Exception ex) { return new ServiceProbe(false, ex.Message); }
     }
 
-    private record ServiceProbe(bool Ok, string Detail);
+    private record ServiceProbe(bool Ok, string Detail, bool Warning = false);
 
     /// <summary>The release this build came from, e.g. "2026.07.29". Falls back to the
     /// assembly version if the informational version was not stamped.</summary>

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -1379,9 +1379,10 @@ public class SubsonicController : ControllerBase
         if (!string.IsNullOrEmpty(albumCandidate)
             && _idRegistry.Lookup(albumCandidate)?.Kind == RoutingKind.Album)
         {
-            if (!_subsonicSettings.DownloadAlbumOnStar)
+            if (!_subsonicSettings.EffectiveHeartDownloadSources()
+                    .Any(step => step.AlbumEnabled == true))
             {
-                _logger.LogInformation("Starred album {AlbumId} but DownloadAlbumOnStar is off; ignoring", albumCandidate);
+                _logger.LogInformation("Starred album {AlbumId} but no album-heart source is enabled; ignoring", albumCandidate);
                 return _responseBuilder.CreateResponse(format, "starred", new { });
             }
 
@@ -1421,7 +1422,8 @@ public class SubsonicController : ControllerBase
         // Check if this is an external song (enables download-on-star)
         var (isExternal, provider, externalId) = _localLibraryService.ParseSongId(itemId);
         
-        if (isExternal && _subsonicSettings.DownloadOnStar)
+        if (isExternal && _subsonicSettings.EffectiveHeartDownloadSources()
+                .Any(step => step.SongEnabled == true))
         {
             // No storage-mode gate any more. It used to exclude Permanent on the grounds
             // that playing a track there already downloads it, but that was only ever true

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -579,43 +579,21 @@ public class SubsonicController : ControllerBase
 
         try
         {
-            // Permanent mode keeps a copy of anything played. Queue it and carry on: the
-            // fetch runs on the acquisition worker, on a token that has nothing to do with
-            // this request, so the client hanging up can no longer destroy it.
-            Task<string>? acquisition = null;
-            if (_subsonicSettings.StorageMode == StorageMode.Permanent)
+            // Lossless-on-play remains an explicit opt-in. Normal playback never starts
+            // acquisition: owned ids already went to Navidrome above, and missing ids
+            // stream from YouTube below. Hearts are the normal permanent-copy gesture.
+            if (_subsonicSettings.WaitForLosslessOnPlay)
             {
-                acquisition = _acquisitions.Enqueue(provider!, externalId!, isStar: false,
+                var acquisition = _acquisitions.Enqueue(provider!, externalId!, isStar: false,
                     triggerAlbumDownload: false, forcePermanent: true);
-            }
-
-            if (acquisition is not null && _subsonicSettings.WaitForLosslessOnPlay)
-            {
                 return await ServeAcquiredAsync(acquisition, provider!, externalId!, id, format,
                     allowPreviewFallback: true);
-            }
-
-            // Cache mode is deliberately left on its original path. It skips library
-            // registration, so routing it through the queue would make every play
-            // re-download the same track forever.
-            if (_subsonicSettings.StorageMode == StorageMode.Cache)
-            {
-                var downloadStream = await _downloadService.DownloadAndStreamAsync(provider!, externalId!, HttpContext.RequestAborted);
-                return File(downloadStream, "audio/mpeg", enableRangeProcessing: true);
             }
 
             var direct = await TryDirectStreamAsync(provider!, externalId!, id);
             if (direct is not null) return direct;
 
             _logger.LogWarning("Direct stream not available for {Id}", id);
-
-            // No YouTube match. Wait on the SAME queued acquisition rather than starting a
-            // second one; without a lossless copy on the way there is nothing to serve.
-            // The preview already failed above, so a timeout fallback has nothing to serve.
-            if (acquisition is not null)
-                return await ServeAcquiredAsync(acquisition, provider!, externalId!, id, format,
-                    allowPreviewFallback: false);
-
             return _responseBuilder.CreateError(format, 70, "No playable source found for this track");
         }
         catch (OperationCanceledException)

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -38,6 +38,7 @@ public class SubsonicController : ControllerBase
     private readonly CoverArtAggregator? _coverArtAggregator;
     private readonly ExternalIdRegistry _idRegistry;
     private readonly Octo.Services.Common.TrackAcquisitionQueue _acquisitions;
+    private readonly HeartAcquisitionCoordinator _heartAcquisitions;
     private readonly Octo.Services.Common.ExternalSearchService _externalSearch;
     private readonly RadioQueueStore _radioQueueStore;
     private readonly NavidromeIdentityService _navIdentity;
@@ -54,6 +55,7 @@ public class SubsonicController : ControllerBase
         SubsonicProxyService proxyService,
         ExternalIdRegistry idRegistry,
         Octo.Services.Common.TrackAcquisitionQueue acquisitions,
+        HeartAcquisitionCoordinator heartAcquisitions,
         Octo.Services.Common.ExternalSearchService externalSearch,
         RadioQueueStore radioQueueStore,
         NavidromeIdentityService navIdentity,
@@ -74,6 +76,7 @@ public class SubsonicController : ControllerBase
         _proxyService = proxyService;
         _idRegistry = idRegistry;
         _acquisitions = acquisitions;
+        _heartAcquisitions = heartAcquisitions;
         _externalSearch = externalSearch;
         _radioQueueStore = radioQueueStore;
         _navIdentity = navIdentity;
@@ -1403,7 +1406,7 @@ public class SubsonicController : ControllerBase
 
             // An empty exclude means "download every track". The engine already skips
             // tracks that are downloaded or in flight and isolates per-track failures.
-            _downloadService.DownloadRemainingAlbumTracksInBackground(albumProviderName, albumCandidate, "");
+            _heartAcquisitions.QueueAlbum(albumProviderName, albumCandidate);
 
             // Navidrome has never seen this id, so relaying the star would just error.
             return _responseBuilder.CreateResponse(format, "starred", new { });
@@ -1424,8 +1427,7 @@ public class SubsonicController : ControllerBase
             // than inheriting whatever a concurrent play happened to ask for.
             _logger.LogInformation("Starring external song {SongId}, queueing permanent download", itemId);
 
-            _ = _acquisitions.Enqueue(provider!, externalId!, isStar: true,
-                triggerAlbumDownload: true, forcePermanent: true);
+            _heartAcquisitions.QueueTrack(provider!, externalId!);
 
             // Return success response immediately
             return _responseBuilder.CreateResponse(format, "starred", new { });

--- a/octo/Models/Settings/LidarrSettings.cs
+++ b/octo/Models/Settings/LidarrSettings.cs
@@ -1,0 +1,22 @@
+namespace Octo.Models.Settings;
+
+public enum LidarrCompletionMode
+{
+    /// <summary>The heart is considered handed off once Lidarr accepts AlbumSearch.</summary>
+    Accepted,
+
+    /// <summary>Completion/failure notifications follow the actual import or timeout.</summary>
+    Imported,
+}
+
+/// <summary>Connection and add-album defaults for an existing Lidarr server.</summary>
+public sealed class LidarrSettings
+{
+    public string? BaseUrl { get; set; }
+    public string? ApiKey { get; set; }
+    public string? RootFolderPath { get; set; }
+    public int QualityProfileId { get; set; }
+    public int MetadataProfileId { get; set; }
+    public LidarrCompletionMode CompletionMode { get; set; } = LidarrCompletionMode.Accepted;
+    public int ImportTimeoutSeconds { get; set; } = 1800;
+}

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -103,6 +103,20 @@ public enum DownloadSource
     Lidarr
 }
 
+/// <summary>A source that can participate in the ordered heart-acquisition chain.</summary>
+public enum HeartDownloadSource
+{
+    Soulseek,
+    YouTube,
+    Lidarr,
+}
+
+public sealed class HeartDownloadStep
+{
+    public HeartDownloadSource Source { get; set; }
+    public bool Enabled { get; set; }
+}
+
 public class SubsonicSettings
 {
     public string? Url { get; set; }
@@ -248,6 +262,44 @@ public class SubsonicSettings
     /// (FLAC with MP3 fallback), or "Lidarr" (heart-only, full album).
     /// </summary>
     public DownloadSource DownloadSource { get; set; } = DownloadSource.Soulseek;
+
+    /// <summary>
+    /// Ordered sources for explicit track and album hearts. Empty keeps older
+    /// DOWNLOAD_SOURCE configurations working; Lidarr remains last by default.
+    /// </summary>
+    public List<HeartDownloadStep> HeartDownloadSources { get; set; } = [];
+
+    public IReadOnlyList<HeartDownloadStep> EffectiveHeartDownloadSources()
+    {
+        var configured = HeartDownloadSources
+            .Where(step => Enum.IsDefined(step.Source))
+            .GroupBy(step => step.Source)
+            .Select(group => group.First())
+            .ToList();
+        if (configured.Count > 0)
+        {
+            foreach (var source in Enum.GetValues<HeartDownloadSource>())
+                if (configured.All(step => step.Source != source))
+                    configured.Add(new HeartDownloadStep { Source = source, Enabled = false });
+            return configured;
+        }
+
+        return DownloadSource switch
+        {
+            DownloadSource.YouTube => DefaultHeartSources(false, true, false),
+            DownloadSource.SoulseekThenYouTube => DefaultHeartSources(true, true, false),
+            DownloadSource.Lidarr => DefaultHeartSources(false, false, true),
+            _ => DefaultHeartSources(true, false, false),
+        };
+    }
+
+    private static IReadOnlyList<HeartDownloadStep> DefaultHeartSources(
+        bool soulseek, bool youtube, bool lidarr) =>
+        [
+            new() { Source = HeartDownloadSource.Soulseek, Enabled = soulseek },
+            new() { Source = HeartDownloadSource.YouTube, Enabled = youtube },
+            new() { Source = HeartDownloadSource.Lidarr, Enabled = lidarr },
+        ];
     
     /// <summary>
     /// Use local staging for cloud storage mounts (default: false)

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -169,16 +169,16 @@ public class SubsonicSettings
     public ExplicitFilter ExplicitFilter { get; set; } = ExplicitFilter.All;
     
     /// <summary>
-    /// Download mode for tracks (default: Track)
+    /// Legacy direct-download mode (default: Track), retained for playlist jobs.
     /// Environment variable: DOWNLOAD_MODE
-    /// Values: "Track" (download only played track), "Album" (download full album when playing a track)
+    /// Values: "Track" or "Album"
     /// </summary>
     public DownloadMode DownloadMode { get; set; } = DownloadMode.Track;
     
     /// <summary>
-    /// Storage mode for downloaded files (default: Permanent)
+    /// Legacy storage mode for direct-download jobs (default: Permanent).
     /// Environment variable: STORAGE_MODE
-    /// Values: "Permanent" (files saved to library), "Cache" (temporary files, auto-cleanup)
+    /// Ordinary external playback always streams from YouTube unless lossless waiting is enabled.
     /// </summary>
     public StorageMode StorageMode { get; set; } = StorageMode.Permanent;
     

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -93,7 +93,14 @@ public enum DownloadSource
     YouTube,
 
     /// <summary>Try Soulseek FLAC first; fall back to YouTube MP3 if it fails.</summary>
-    SoulseekThenYouTube
+    SoulseekThenYouTube,
+
+    /// <summary>
+    /// Submit external track/album hearts to an existing Lidarr instance. Lidarr is
+    /// album-oriented, so a track heart acquires the track's full album. Non-heart
+    /// permanent downloads continue to use Soulseek.
+    /// </summary>
+    Lidarr
 }
 
 public class SubsonicSettings
@@ -235,9 +242,10 @@ public class SubsonicSettings
     public FolderStructure FolderStructure { get; set; } = FolderStructure.Flat;
 
     /// <summary>
-    /// Source for permanent downloads (default: Soulseek).
+    /// Download source (default: Soulseek). Lidarr applies to hearts only.
     /// Environment variable: DOWNLOAD_SOURCE
-    /// Values: "Soulseek" (FLAC), "YouTube" (MP3), "SoulseekThenYouTube" (FLAC with MP3 fallback)
+    /// Values: "Soulseek" (FLAC), "YouTube" (MP3), "SoulseekThenYouTube"
+    /// (FLAC with MP3 fallback), or "Lidarr" (heart-only, full album).
     /// </summary>
     public DownloadSource DownloadSource { get; set; } = DownloadSource.Soulseek;
     

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -114,7 +114,10 @@ public enum HeartDownloadSource
 public sealed class HeartDownloadStep
 {
     public HeartDownloadSource Source { get; set; }
-    public bool Enabled { get; set; }
+    /// <summary>Legacy single switch; used only when the per-heart switches are absent.</summary>
+    public bool? Enabled { get; set; }
+    public bool? SongEnabled { get; set; }
+    public bool? AlbumEnabled { get; set; }
 }
 
 public class SubsonicSettings
@@ -274,13 +277,27 @@ public class SubsonicSettings
         var configured = HeartDownloadSources
             .Where(step => Enum.IsDefined(step.Source))
             .GroupBy(step => step.Source)
-            .Select(group => group.First())
+            .Select(group =>
+            {
+                var step = group.First();
+                return new HeartDownloadStep
+                {
+                    Source = step.Source,
+                    SongEnabled = step.SongEnabled ?? step.Enabled ?? false,
+                    AlbumEnabled = step.AlbumEnabled ?? step.Enabled ?? false,
+                };
+            })
             .ToList();
         if (configured.Count > 0)
         {
             foreach (var source in Enum.GetValues<HeartDownloadSource>())
                 if (configured.All(step => step.Source != source))
-                    configured.Add(new HeartDownloadStep { Source = source, Enabled = false });
+                    configured.Add(new HeartDownloadStep
+                    {
+                        Source = source,
+                        SongEnabled = false,
+                        AlbumEnabled = false,
+                    });
             return configured;
         }
 
@@ -293,12 +310,12 @@ public class SubsonicSettings
         };
     }
 
-    private static IReadOnlyList<HeartDownloadStep> DefaultHeartSources(
+    private IReadOnlyList<HeartDownloadStep> DefaultHeartSources(
         bool soulseek, bool youtube, bool lidarr) =>
         [
-            new() { Source = HeartDownloadSource.Soulseek, Enabled = soulseek },
-            new() { Source = HeartDownloadSource.YouTube, Enabled = youtube },
-            new() { Source = HeartDownloadSource.Lidarr, Enabled = lidarr },
+            new() { Source = HeartDownloadSource.Soulseek, SongEnabled = soulseek && DownloadOnStar, AlbumEnabled = soulseek && DownloadAlbumOnStar },
+            new() { Source = HeartDownloadSource.YouTube, SongEnabled = youtube && DownloadOnStar, AlbumEnabled = youtube && DownloadAlbumOnStar },
+            new() { Source = HeartDownloadSource.Lidarr, SongEnabled = lidarr && DownloadOnStar, AlbumEnabled = lidarr && DownloadAlbumOnStar },
         ];
     
     /// <summary>

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -7,6 +7,7 @@ using Octo.Services.Validation;
 using Octo.Services.Subsonic;
 using Octo.Services.Common;
 using Octo.Services.LastFm;
+using Octo.Services.Lidarr;
 using Octo.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -40,6 +41,8 @@ builder.Services.Configure<SubsonicSettings>(
     builder.Configuration.GetSection("Subsonic"));
 builder.Services.Configure<SoulseekSettings>(
     builder.Configuration.GetSection("Soulseek"));
+builder.Services.Configure<LidarrSettings>(
+    builder.Configuration.GetSection("Lidarr"));
 builder.Services.Configure<LastFmSettings>(
     builder.Configuration.GetSection("LastFm"));
 builder.Services.Configure<NotificationSettings>(
@@ -98,6 +101,9 @@ builder.Services.AddHttpClient(Octo.Services.Metadata.DeezerRateLimiter.ClientNa
 
 builder.Services.AddSingleton<IMusicMetadataService, SoulseekMetadataService>();
 builder.Services.AddSingleton<IDownloadService, SoulseekDownloadService>();
+builder.Services.AddSingleton<LidarrClient>();
+builder.Services.AddSingleton<ILidarrHeartAcquisitionService, LidarrHeartAcquisitionService>();
+builder.Services.AddSingleton<HeartAcquisitionCoordinator>();
 
 // Discovery results are built once per query and shared. Clients fire several search
 // calls for one typed query, and they all resolve to the same routing objects, so without

--- a/octo/Services/Common/AcquisitionWorker.cs
+++ b/octo/Services/Common/AcquisitionWorker.cs
@@ -58,6 +58,7 @@ public sealed class AcquisitionWorker : BackgroundService
                 var path = await _downloads.ExecuteAcquisitionAsync(
                     request.Provider, request.ExternalId,
                     request.TriggerAlbumDownload, request.ForcePermanent,
+                    request.SourceOverride,
                     CancellationToken.None);
 
                 request.Completion.TrySetResult(path);
@@ -73,7 +74,10 @@ public sealed class AcquisitionWorker : BackgroundService
                 // a terminal failure surfaces exactly once per gesture (album-walk
                 // per-track failures are caught inside the walk and aggregate into
                 // its summary instead).
-                if (request.IsStar) NotifyFailed(request, ex);
+                if (request.IsStar && request.NotifyOnFailure) NotifyFailed(request, ex);
+                // Release before completing the task: an ordered heart fallback may
+                // immediately enqueue the same track for its next source.
+                _queue.Release(request);
                 request.Completion.TrySetException(ex);
             }
             finally

--- a/octo/Services/Common/BaseDownloadService.cs
+++ b/octo/Services/Common/BaseDownloadService.cs
@@ -134,8 +134,19 @@ public abstract class BaseDownloadService : IDownloadService
     }
     
     public Task<string> ExecuteAcquisitionAsync(string externalProvider, string externalId,
-        bool triggerAlbumDownload, bool forcePermanent, CancellationToken cancellationToken) =>
-        DownloadSongInternalAsync(externalProvider, externalId, triggerAlbumDownload, cancellationToken, forcePermanent);
+        bool triggerAlbumDownload, bool forcePermanent, DownloadSource? sourceOverride,
+        CancellationToken cancellationToken) =>
+        DownloadSongInternalAsync(externalProvider, externalId, triggerAlbumDownload,
+            cancellationToken, forcePermanent, sourceOverride: sourceOverride);
+
+    public Task<bool> DownloadAlbumWithSourceAsync(string externalProvider, string albumExternalId,
+        DownloadSource source, bool suppressSummary, CancellationToken cancellationToken = default)
+    {
+        if (externalProvider != ProviderName)
+            return Task.FromResult(false);
+        return DownloadRemainingAlbumTracksAsync(albumExternalId, "", source, suppressSummary,
+            cancellationToken);
+    }
 
     public DownloadInfo? GetDownloadStatus(string songId)
     {
@@ -212,7 +223,8 @@ public abstract class BaseDownloadService : IDownloadService
     /// <param name="suppressNotify">Mute per-track notifications (album walk, cache fills)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Local file path where the track was saved</returns>
-    protected abstract Task<string> DownloadTrackAsync(string trackId, Song song, bool suppressNotify, CancellationToken cancellationToken);
+    protected abstract Task<string> DownloadTrackAsync(string trackId, Song song, bool suppressNotify,
+        DownloadSource? sourceOverride, CancellationToken cancellationToken);
 
     /// <summary>Record a completed download in the fetched-songs log. Best-effort:
     /// format + source are derived from the file extension (flac -> Soulseek/lossless,
@@ -319,7 +331,10 @@ public abstract class BaseDownloadService : IDownloadService
     /// Mute per-track notifications. Set by the album walk, which fires one summary
     /// at the end instead of a ping per track.
     /// </param>
-    protected async Task<string> DownloadSongInternalAsync(string externalProvider, string externalId, bool triggerAlbumDownload, CancellationToken cancellationToken = default, bool forcePermanent = false, bool suppressNotify = false)
+    protected async Task<string> DownloadSongInternalAsync(string externalProvider, string externalId,
+        bool triggerAlbumDownload, CancellationToken cancellationToken = default,
+        bool forcePermanent = false, bool suppressNotify = false,
+        DownloadSource? sourceOverride = null)
     {
         if (externalProvider != ProviderName)
         {
@@ -437,7 +452,8 @@ public abstract class BaseDownloadService : IDownloadService
             // orphan that Octo has no record of. A client giving up on a slow
             // download used to abort exactly here, which is why a completed
             // download could never be played.
-            var localPath = await DownloadTrackAsync(externalId, song, silence, cancellationToken);
+            var localPath = await DownloadTrackAsync(
+                externalId, song, silence, sourceOverride, cancellationToken);
 
             downloadInfo.Status = DownloadStatus.Completed;
             downloadInfo.LocalPath = localPath;
@@ -495,7 +511,20 @@ public abstract class BaseDownloadService : IDownloadService
                     if (!string.IsNullOrEmpty(albumExternalId))
                     {
                         Logger.LogInformation("Download mode is Album, triggering background download for album {AlbumId}", albumExternalId);
-                        DownloadRemainingAlbumTracksInBackground(externalProvider, albumExternalId, externalId);
+                        _ = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                await DownloadRemainingAlbumTracksAsync(
+                                    albumExternalId, externalId, sourceOverride);
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.LogError(ex,
+                                    "Failed to download remaining album tracks for album {AlbumId}",
+                                    albumExternalId);
+                            }
+                        });
                     }
                 }
             }
@@ -523,7 +552,10 @@ public abstract class BaseDownloadService : IDownloadService
         }
     }
 
-    protected async Task DownloadRemainingAlbumTracksAsync(string albumExternalId, string excludeTrackExternalId)
+    protected async Task<bool> DownloadRemainingAlbumTracksAsync(
+        string albumExternalId, string excludeTrackExternalId,
+        DownloadSource? sourceOverride = null, bool suppressSummary = false,
+        CancellationToken cancellationToken = default)
     {
         Logger.LogInformation("Starting background download for album {AlbumId} (excluding track {TrackId})", 
             albumExternalId, excludeTrackExternalId);
@@ -532,7 +564,7 @@ public abstract class BaseDownloadService : IDownloadService
         if (album == null)
         {
             Logger.LogWarning("Album {AlbumId} not found, cannot download remaining tracks", albumExternalId);
-            return;
+            return false;
         }
 
         var tracksToDownload = album.Songs
@@ -576,7 +608,10 @@ public abstract class BaseDownloadService : IDownloadService
                 }
 
                 Logger.LogInformation("Downloading track '{Title}' from album '{Album}'", track.Title, album.Title);
-                var path = await DownloadSongInternalAsync(ProviderName, track.ExternalId!, triggerAlbumDownload: false, CancellationToken.None, forcePermanent: true, suppressNotify: true);
+                var path = await DownloadSongInternalAsync(
+                    ProviderName, track.ExternalId!, triggerAlbumDownload: false,
+                    cancellationToken, forcePermanent: true, suppressNotify: true,
+                    sourceOverride: sourceOverride);
                 succeeded++;
                 if (path.EndsWith(".flac", StringComparison.OrdinalIgnoreCase)) lossless++;
 
@@ -596,7 +631,10 @@ public abstract class BaseDownloadService : IDownloadService
         Logger.LogInformation("Completed background download for album '{AlbumTitle}'", album.Title);
 
         var summary = BuildAlbumSummary(album, succeeded, lossless, failed);
-        if (summary is not null) Notifications.Notify(summary);
+        // Hide an intermediate failure while another source remains, but still report
+        // success when an earlier priority step completes the album acquisition.
+        if ((!suppressSummary || failed == 0) && summary is not null) Notifications.Notify(summary);
+        return failed == 0;
     }
 
     /// <summary>

--- a/octo/Services/Common/HeartAcquisitionCoordinator.cs
+++ b/octo/Services/Common/HeartAcquisitionCoordinator.cs
@@ -24,18 +24,77 @@ public sealed class HeartAcquisitionCoordinator
 
     public void QueueTrack(string provider, string externalId)
     {
-        if (_settings.CurrentValue.DownloadSource == DownloadSource.Lidarr)
-            _lidarr.QueueTrack(provider, externalId);
-        else
-            _ = _directQueue.Enqueue(provider, externalId, isStar: true,
-                triggerAlbumDownload: true, forcePermanent: true);
+        _ = AcquireTrackAsync(provider, externalId);
     }
 
     public void QueueAlbum(string provider, string albumExternalId)
     {
-        if (_settings.CurrentValue.DownloadSource == DownloadSource.Lidarr)
-            _lidarr.QueueAlbum(provider, albumExternalId);
-        else
-            _directDownloads.DownloadRemainingAlbumTracksInBackground(provider, albumExternalId, "");
+        _ = AcquireAlbumAsync(provider, albumExternalId);
     }
+
+    internal async Task AcquireTrackAsync(string provider, string externalId)
+    {
+        var steps = EnabledSteps();
+        for (var index = 0; index < steps.Count; index++)
+        {
+            var isLast = index == steps.Count - 1;
+            if (steps[index] == HeartDownloadSource.Lidarr)
+            {
+                if (await _lidarr.TryAcquireTrackAsync(provider, externalId, isLast)) return;
+                continue;
+            }
+
+            try
+            {
+                await _directQueue.Enqueue(provider, externalId, isStar: true,
+                    triggerAlbumDownload: true, forcePermanent: true,
+                    sourceOverride: ToDirectSource(steps[index]), notifyOnFailure: isLast);
+                return;
+            }
+            catch
+            {
+                if (isLast) return;
+                // The next enabled source owns the fallback.
+            }
+        }
+    }
+
+    internal async Task AcquireAlbumAsync(string provider, string albumExternalId)
+    {
+        var steps = EnabledSteps();
+        for (var index = 0; index < steps.Count; index++)
+        {
+            var isLast = index == steps.Count - 1;
+            if (steps[index] == HeartDownloadSource.Lidarr)
+            {
+                if (await _lidarr.TryAcquireAlbumAsync(provider, albumExternalId, isLast)) return;
+                continue;
+            }
+
+            try
+            {
+                if (await _directDownloads.DownloadAlbumWithSourceAsync(
+                        provider, albumExternalId, ToDirectSource(steps[index]),
+                        suppressSummary: !isLast))
+                    return;
+            }
+            catch
+            {
+                if (isLast) return;
+                // Continue down the configured priority list.
+            }
+        }
+    }
+
+    private List<HeartDownloadSource> EnabledSteps() =>
+        _settings.CurrentValue.EffectiveHeartDownloadSources()
+            .Where(step => step.Enabled)
+            .Select(step => step.Source)
+            .ToList();
+
+    private static DownloadSource ToDirectSource(HeartDownloadSource source) => source switch
+    {
+        HeartDownloadSource.YouTube => DownloadSource.YouTube,
+        _ => DownloadSource.Soulseek,
+    };
 }

--- a/octo/Services/Common/HeartAcquisitionCoordinator.cs
+++ b/octo/Services/Common/HeartAcquisitionCoordinator.cs
@@ -34,7 +34,7 @@ public sealed class HeartAcquisitionCoordinator
 
     internal async Task AcquireTrackAsync(string provider, string externalId)
     {
-        var steps = EnabledSteps();
+        var steps = EnabledSteps(albumHeart: false);
         for (var index = 0; index < steps.Count; index++)
         {
             var isLast = index == steps.Count - 1;
@@ -61,7 +61,7 @@ public sealed class HeartAcquisitionCoordinator
 
     internal async Task AcquireAlbumAsync(string provider, string albumExternalId)
     {
-        var steps = EnabledSteps();
+        var steps = EnabledSteps(albumHeart: true);
         for (var index = 0; index < steps.Count; index++)
         {
             var isLast = index == steps.Count - 1;
@@ -86,9 +86,9 @@ public sealed class HeartAcquisitionCoordinator
         }
     }
 
-    private List<HeartDownloadSource> EnabledSteps() =>
+    private List<HeartDownloadSource> EnabledSteps(bool albumHeart) =>
         _settings.CurrentValue.EffectiveHeartDownloadSources()
-            .Where(step => step.Enabled)
+            .Where(step => albumHeart ? step.AlbumEnabled == true : step.SongEnabled == true)
             .Select(step => step.Source)
             .ToList();
 

--- a/octo/Services/Common/HeartAcquisitionCoordinator.cs
+++ b/octo/Services/Common/HeartAcquisitionCoordinator.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
+using Octo.Services.Lidarr;
+
+namespace Octo.Services.Common;
+
+/// <summary>Routes explicit heart gestures without changing playback acquisition.</summary>
+public sealed class HeartAcquisitionCoordinator
+{
+    private readonly SubsonicSettings _settings;
+    private readonly TrackAcquisitionQueue _directQueue;
+    private readonly IDownloadService _directDownloads;
+    private readonly ILidarrHeartAcquisitionService _lidarr;
+
+    public HeartAcquisitionCoordinator(IOptions<SubsonicSettings> settings,
+        TrackAcquisitionQueue directQueue, IDownloadService directDownloads,
+        ILidarrHeartAcquisitionService lidarr)
+    {
+        _settings = settings.Value;
+        _directQueue = directQueue;
+        _directDownloads = directDownloads;
+        _lidarr = lidarr;
+    }
+
+    public void QueueTrack(string provider, string externalId)
+    {
+        if (_settings.DownloadSource == DownloadSource.Lidarr)
+            _lidarr.QueueTrack(provider, externalId);
+        else
+            _ = _directQueue.Enqueue(provider, externalId, isStar: true,
+                triggerAlbumDownload: true, forcePermanent: true);
+    }
+
+    public void QueueAlbum(string provider, string albumExternalId)
+    {
+        if (_settings.DownloadSource == DownloadSource.Lidarr)
+            _lidarr.QueueAlbum(provider, albumExternalId);
+        else
+            _directDownloads.DownloadRemainingAlbumTracksInBackground(provider, albumExternalId, "");
+    }
+}

--- a/octo/Services/Common/HeartAcquisitionCoordinator.cs
+++ b/octo/Services/Common/HeartAcquisitionCoordinator.cs
@@ -47,7 +47,7 @@ public sealed class HeartAcquisitionCoordinator
             try
             {
                 await _directQueue.Enqueue(provider, externalId, isStar: true,
-                    triggerAlbumDownload: true, forcePermanent: true,
+                    triggerAlbumDownload: false, forcePermanent: true,
                     sourceOverride: ToDirectSource(steps[index]), notifyOnFailure: isLast);
                 return;
             }

--- a/octo/Services/Common/HeartAcquisitionCoordinator.cs
+++ b/octo/Services/Common/HeartAcquisitionCoordinator.cs
@@ -7,16 +7,16 @@ namespace Octo.Services.Common;
 /// <summary>Routes explicit heart gestures without changing playback acquisition.</summary>
 public sealed class HeartAcquisitionCoordinator
 {
-    private readonly SubsonicSettings _settings;
+    private readonly IOptionsMonitor<SubsonicSettings> _settings;
     private readonly TrackAcquisitionQueue _directQueue;
     private readonly IDownloadService _directDownloads;
     private readonly ILidarrHeartAcquisitionService _lidarr;
 
-    public HeartAcquisitionCoordinator(IOptions<SubsonicSettings> settings,
+    public HeartAcquisitionCoordinator(IOptionsMonitor<SubsonicSettings> settings,
         TrackAcquisitionQueue directQueue, IDownloadService directDownloads,
         ILidarrHeartAcquisitionService lidarr)
     {
-        _settings = settings.Value;
+        _settings = settings;
         _directQueue = directQueue;
         _directDownloads = directDownloads;
         _lidarr = lidarr;
@@ -24,7 +24,7 @@ public sealed class HeartAcquisitionCoordinator
 
     public void QueueTrack(string provider, string externalId)
     {
-        if (_settings.DownloadSource == DownloadSource.Lidarr)
+        if (_settings.CurrentValue.DownloadSource == DownloadSource.Lidarr)
             _lidarr.QueueTrack(provider, externalId);
         else
             _ = _directQueue.Enqueue(provider, externalId, isStar: true,
@@ -33,7 +33,7 @@ public sealed class HeartAcquisitionCoordinator
 
     public void QueueAlbum(string provider, string albumExternalId)
     {
-        if (_settings.DownloadSource == DownloadSource.Lidarr)
+        if (_settings.CurrentValue.DownloadSource == DownloadSource.Lidarr)
             _lidarr.QueueAlbum(provider, albumExternalId);
         else
             _directDownloads.DownloadRemainingAlbumTracksInBackground(provider, albumExternalId, "");

--- a/octo/Services/Common/TrackAcquisitionQueue.cs
+++ b/octo/Services/Common/TrackAcquisitionQueue.cs
@@ -11,7 +11,7 @@ public sealed class AcquisitionRequest
     public required string ExternalId { get; init; }
 
     /// <summary>Carried per request rather than inferred from whoever won a race:
-    /// a star wants the album walk and a forced permanent copy, a play does not.</summary>
+    /// heart routing decides song-versus-album scope, while playback never expands to an album.</summary>
     public bool TriggerAlbumDownload { get; init; }
     public bool ForcePermanent { get; init; }
     public bool IsStar { get; init; }

--- a/octo/Services/Common/TrackAcquisitionQueue.cs
+++ b/octo/Services/Common/TrackAcquisitionQueue.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Threading.Channels;
+using Octo.Models.Settings;
 
 namespace Octo.Services.Common;
 
@@ -14,6 +15,8 @@ public sealed class AcquisitionRequest
     public bool TriggerAlbumDownload { get; init; }
     public bool ForcePermanent { get; init; }
     public bool IsStar { get; init; }
+    public DownloadSource? SourceOverride { get; init; }
+    public bool NotifyOnFailure { get; init; } = true;
 
     /// <summary>
     /// RunContinuationsAsynchronously is required. Without it, completing this runs the
@@ -74,7 +77,8 @@ public sealed class TrackAcquisitionQueue
     /// care may ignore it entirely.
     /// </summary>
     public Task<string> Enqueue(string provider, string externalId, bool isStar,
-        bool triggerAlbumDownload, bool forcePermanent)
+        bool triggerAlbumDownload, bool forcePermanent,
+        DownloadSource? sourceOverride = null, bool notifyOnFailure = true)
     {
         var request = new AcquisitionRequest
         {
@@ -83,6 +87,8 @@ public sealed class TrackAcquisitionQueue
             IsStar = isStar,
             TriggerAlbumDownload = triggerAlbumDownload,
             ForcePermanent = forcePermanent,
+            SourceOverride = sourceOverride,
+            NotifyOnFailure = notifyOnFailure,
         };
 
         var existing = _inFlight.GetOrAdd(request.Key, request);

--- a/octo/Services/IDownloadService.cs
+++ b/octo/Services/IDownloadService.cs
@@ -43,7 +43,12 @@ public interface IDownloadService
     /// point, since a client giving up must never cancel a transfer slskd will finish.
     /// </summary>
     Task<string> ExecuteAcquisitionAsync(string externalProvider, string externalId,
-        bool triggerAlbumDownload, bool forcePermanent, CancellationToken cancellationToken);
+        bool triggerAlbumDownload, bool forcePermanent, DownloadSource? sourceOverride,
+        CancellationToken cancellationToken);
+
+    /// <summary>Runs one direct source for every missing track in an album.</summary>
+    Task<bool> DownloadAlbumWithSourceAsync(string externalProvider, string albumExternalId,
+        DownloadSource source, bool suppressSummary, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Checks if a song is currently being downloaded

--- a/octo/Services/Lidarr/LidarrClient.cs
+++ b/octo/Services/Lidarr/LidarrClient.cs
@@ -1,0 +1,294 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
+
+namespace Octo.Services.Lidarr;
+
+public sealed record LidarrChoice(int Id, string Name);
+public sealed record LidarrRootFolder(int Id, string Path);
+public sealed record LidarrOptions(
+    IReadOnlyList<LidarrRootFolder> RootFolders,
+    IReadOnlyList<LidarrChoice> QualityProfiles,
+    IReadOnlyList<LidarrChoice> MetadataProfiles);
+
+public sealed record LidarrAlbumCandidate(
+    int Id, string ForeignAlbumId, string Title, string Artist, int? Year, JsonObject Resource);
+
+public sealed record LidarrImportedTrack(
+    int Id, string Title, int? TrackNumber, int? DurationSeconds, bool HasFile,
+    string? Path, long SizeBytes, string? Artist);
+
+public sealed record LidarrAlbumImportState(
+    IReadOnlyList<LidarrImportedTrack> Tracks, int TrackCount, int TrackFileCount)
+{
+    public bool IsComplete => TrackCount > 0 && TrackFileCount >= TrackCount;
+}
+
+/// <summary>Small, purpose-built client for the Lidarr v1 endpoints Octo needs.</summary>
+public sealed class LidarrClient
+{
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly IOptionsMonitor<LidarrSettings> _settings;
+
+    public LidarrClient(IHttpClientFactory httpFactory, IOptionsMonitor<LidarrSettings> settings)
+    {
+        _httpFactory = httpFactory;
+        _settings = settings;
+    }
+
+    public async Task<bool> IsReachableAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var request = CreateRequest(HttpMethod.Get, "/ping");
+            using var response = await SendAsync(request, ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch { return false; }
+    }
+
+    public async Task<LidarrOptions> GetOptionsAsync(CancellationToken ct = default)
+    {
+        var rootsTask = GetArrayAsync("/api/v1/rootfolder", ct);
+        var qualityTask = GetArrayAsync("/api/v1/qualityprofile", ct);
+        var metadataTask = GetArrayAsync("/api/v1/metadataprofile", ct);
+        await Task.WhenAll(rootsTask, qualityTask, metadataTask);
+
+        return new LidarrOptions(
+            rootsTask.Result.Select(x => new LidarrRootFolder(Int(x, "id"), Str(x, "path"))).ToList(),
+            qualityTask.Result.Select(x => new LidarrChoice(Int(x, "id"), Str(x, "name"))).ToList(),
+            metadataTask.Result.Select(x => new LidarrChoice(Int(x, "id"), Str(x, "name"))).ToList());
+    }
+
+    public async Task<LidarrAlbumCandidate> ResolveAlbumAsync(
+        string artist, string album, int? year, CancellationToken ct = default)
+    {
+        var term = Uri.EscapeDataString($"{artist} {album}");
+        var rows = await GetArrayAsync($"/api/v1/album/lookup?term={term}", ct);
+        var candidates = rows.Select(ParseAlbum).Where(x => !string.IsNullOrEmpty(x.ForeignAlbumId)).ToList();
+        return SelectBestAlbum(candidates, artist, album, year)
+            ?? throw new InvalidOperationException($"Lidarr could not unambiguously match '{artist} - {album}'.");
+    }
+
+    internal static LidarrAlbumCandidate? SelectBestAlbum(
+        IReadOnlyList<LidarrAlbumCandidate> candidates, string artist, string album, int? year)
+    {
+        var wantedArtist = Normalize(artist);
+        var wantedAlbum = Normalize(album);
+        var exact = candidates
+            .Where(c => Normalize(c.Artist) == wantedArtist && Normalize(c.Title) == wantedAlbum)
+            .GroupBy(c => c.ForeignAlbumId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
+        if (exact.Count == 1) return exact[0];
+        if (exact.Count == 0) return null;
+
+        if (year is int y)
+        {
+            var sameYear = exact.Where(c => c.Year == y).ToList();
+            if (sameYear.Count == 1) return sameYear[0];
+        }
+
+        // Multiple releases with the same display identity are unsafe to choose
+        // automatically. A wrong album is much worse than an actionable failure.
+        return null;
+    }
+
+    public async Task<int> EnsureAlbumAndSearchAsync(LidarrAlbumCandidate candidate, CancellationToken ct = default)
+    {
+        var settings = RequireSettings(requireProfiles: true);
+        var existing = await GetArrayAsync(
+            $"/api/v1/album?foreignAlbumId={Uri.EscapeDataString(candidate.ForeignAlbumId)}", ct);
+
+        int albumId;
+        if (existing.Count > 0)
+        {
+            var resource = existing[0];
+            albumId = Int(resource, "id");
+            if (!(resource["monitored"]?.GetValue<bool>() ?? false))
+            {
+                resource["monitored"] = true;
+                await SendJsonAsync(HttpMethod.Put, $"/api/v1/album/{albumId}", resource, ct);
+            }
+        }
+        else
+        {
+            var resource = (JsonObject)candidate.Resource.DeepClone();
+            resource.Remove("id");
+            resource["monitored"] = true;
+            resource["addOptions"] = new JsonObject { ["searchForNewAlbum"] = false };
+
+            var artist = resource["artist"] as JsonObject
+                ?? throw new InvalidOperationException("Lidarr album lookup returned no artist resource.");
+            var foreignArtistId = NullableStr(artist, "foreignArtistId") ?? NullableStr(artist, "mbId");
+            var existingArtists = await GetArrayAsync("/api/v1/artist", ct);
+            var existingArtist = existingArtists.FirstOrDefault(a =>
+                !string.IsNullOrEmpty(foreignArtistId)
+                && string.Equals(NullableStr(a, "foreignArtistId") ?? NullableStr(a, "mbId"),
+                    foreignArtistId, StringComparison.OrdinalIgnoreCase));
+            if (existingArtist is not null)
+            {
+                resource["artistId"] = Int(existingArtist, "id");
+                resource["artist"] = existingArtist.DeepClone();
+            }
+            else
+            {
+                artist.Remove("id");
+                artist["rootFolderPath"] = settings.RootFolderPath;
+                artist["qualityProfileId"] = settings.QualityProfileId;
+                artist["metadataProfileId"] = settings.MetadataProfileId;
+                artist["monitored"] = true;
+                artist["monitorNewItems"] = "none";
+                artist["tags"] = new JsonArray();
+                artist["addOptions"] = new JsonObject
+                {
+                    ["monitor"] = "none",
+                    ["searchForMissingAlbums"] = false,
+                };
+            }
+
+            var added = await SendJsonAsync(HttpMethod.Post, "/api/v1/album", resource, ct);
+            albumId = Int(added, "id");
+        }
+
+        await SendJsonAsync(HttpMethod.Post, "/api/v1/command", new JsonObject
+        {
+            ["name"] = "AlbumSearch",
+            ["albumIds"] = new JsonArray(albumId),
+        }, ct);
+        return albumId;
+    }
+
+    public async Task<IReadOnlyList<LidarrImportedTrack>> GetAlbumTracksAsync(int albumId, CancellationToken ct = default)
+    {
+        // Lidarr deliberately omits the nested trackFile resource from album track
+        // list responses, so load the album's files separately and join by id.
+        var tracksTask = GetArrayAsync($"/api/v1/track?albumId={albumId}", ct);
+        var filesTask = GetArrayAsync($"/api/v1/trackFile?albumId={albumId}", ct);
+        await Task.WhenAll(tracksTask, filesTask);
+        var files = filesTask.Result.ToDictionary(file => Int(file, "id"));
+
+        return tracksTask.Result.Select(row =>
+        {
+            var trackFileId = NullableInt(row, "trackFileId") ?? 0;
+            files.TryGetValue(trackFileId, out var file);
+            var artist = row["artist"] as JsonObject;
+            return new LidarrImportedTrack(
+                Int(row, "id"), Str(row, "title"), ParseTrackNumber(Str(row, "trackNumber")),
+                NullableInt(row, "duration") is int ms ? ms / 1000 : null,
+                row["hasFile"]?.GetValue<bool>() ?? false,
+                file is null ? null : NullableStr(file, "path"),
+                file is null ? 0 : NullableLong(file, "size") ?? 0,
+                artist is null ? null : NullableStr(artist, "artistName"));
+        }).ToList();
+    }
+
+    public async Task<LidarrAlbumImportState> GetAlbumImportStateAsync(
+        int albumId, CancellationToken ct = default)
+    {
+        var albumTask = GetObjectAsync($"/api/v1/album/{albumId}", ct);
+        var tracksTask = GetAlbumTracksAsync(albumId, ct);
+        await Task.WhenAll(albumTask, tracksTask);
+        var statistics = albumTask.Result["statistics"] as JsonObject;
+        return new LidarrAlbumImportState(
+            tracksTask.Result,
+            statistics is null ? tracksTask.Result.Count : Int(statistics, "trackCount"),
+            statistics is null ? tracksTask.Result.Count(t => t.HasFile) : Int(statistics, "trackFileCount"));
+    }
+
+    private LidarrSettings RequireSettings(bool requireProfiles = false)
+    {
+        var value = _settings.CurrentValue;
+        if (string.IsNullOrWhiteSpace(value.BaseUrl) || string.IsNullOrWhiteSpace(value.ApiKey))
+            throw new InvalidOperationException("Lidarr URL and API key are required.");
+        if (requireProfiles && (string.IsNullOrWhiteSpace(value.RootFolderPath)
+                                || value.QualityProfileId <= 0 || value.MetadataProfileId <= 0))
+            throw new InvalidOperationException("Choose a Lidarr root folder, quality profile, and metadata profile.");
+        return value;
+    }
+
+    private HttpRequestMessage CreateRequest(HttpMethod method, string path)
+    {
+        var settings = RequireSettings();
+        var request = new HttpRequestMessage(method,
+            $"{settings.BaseUrl!.TrimEnd('/')}{path}");
+        request.Headers.TryAddWithoutValidation("X-Api-Key", settings.ApiKey);
+        return request;
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+    {
+        var client = _httpFactory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(20);
+        var response = await client.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            response.Dispose();
+            throw new HttpRequestException(
+                $"Lidarr returned HTTP {(int)response.StatusCode}: {Truncate(body, 300)}");
+        }
+        return response;
+    }
+
+    private async Task<List<JsonObject>> GetArrayAsync(string path, CancellationToken ct)
+    {
+        using var request = CreateRequest(HttpMethod.Get, path);
+        using var response = await SendAsync(request, ct);
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        var node = await JsonNode.ParseAsync(stream, cancellationToken: ct) as JsonArray
+            ?? throw new InvalidOperationException("Lidarr returned an invalid array response.");
+        return node.OfType<JsonObject>().ToList();
+    }
+
+    private async Task<JsonObject> GetObjectAsync(string path, CancellationToken ct)
+    {
+        using var request = CreateRequest(HttpMethod.Get, path);
+        using var response = await SendAsync(request, ct);
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        return await JsonNode.ParseAsync(stream, cancellationToken: ct) as JsonObject
+            ?? throw new InvalidOperationException("Lidarr returned an invalid object response.");
+    }
+
+    private async Task<JsonObject> SendJsonAsync(HttpMethod method, string path, JsonObject body, CancellationToken ct)
+    {
+        using var request = CreateRequest(method, path);
+        request.Content = JsonContent.Create(body);
+        using var response = await SendAsync(request, ct);
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        return await JsonNode.ParseAsync(stream, cancellationToken: ct) as JsonObject
+            ?? throw new InvalidOperationException("Lidarr returned an invalid object response.");
+    }
+
+    private static LidarrAlbumCandidate ParseAlbum(JsonObject row)
+    {
+        var artist = row["artist"] as JsonObject;
+        var date = NullableStr(row, "releaseDate");
+        int? year = date?.Length >= 4 && int.TryParse(date[..4], out var parsed) ? parsed : null;
+        return new LidarrAlbumCandidate(
+            NullableInt(row, "id") ?? 0,
+            NullableStr(row, "foreignAlbumId") ?? "",
+            NullableStr(row, "title") ?? "",
+            artist is null ? "" : NullableStr(artist, "artistName") ?? "",
+            year,
+            (JsonObject)row.DeepClone());
+    }
+
+    internal static string Normalize(string value) =>
+        new(value.Normalize().ToLowerInvariant().Where(char.IsLetterOrDigit).ToArray());
+
+    private static int? ParseTrackNumber(string value)
+    {
+        var head = value.Split('-', '/', '.')[0];
+        return int.TryParse(head, out var parsed) ? parsed : null;
+    }
+
+    private static string Truncate(string value, int max) => value.Length <= max ? value : value[..max];
+    private static int Int(JsonObject o, string key) => NullableInt(o, key) ?? 0;
+    private static string Str(JsonObject o, string key) => NullableStr(o, key) ?? "";
+    private static string? NullableStr(JsonObject o, string key) => o[key]?.GetValue<string>();
+    private static int? NullableInt(JsonObject o, string key) => o[key]?.GetValue<int>();
+    private static long? NullableLong(JsonObject o, string key) => o[key]?.GetValue<long>();
+}

--- a/octo/Services/Lidarr/LidarrClient.cs
+++ b/octo/Services/Lidarr/LidarrClient.cs
@@ -49,6 +49,21 @@ public sealed class LidarrClient
         catch { return false; }
     }
 
+    public async Task<LidarrOptions> TestConnectionAsync(
+        string baseUrl, string apiKey, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl) || string.IsNullOrWhiteSpace(apiKey))
+            throw new InvalidOperationException("Lidarr URL and API key are required.");
+        using var request = CreateRequest(HttpMethod.Get, "/api/v1/system/status", baseUrl, apiKey);
+        using var response = await SendAsync(request, ct);
+
+        var rootsTask = GetArrayAsync("/api/v1/rootfolder", baseUrl, apiKey, ct);
+        var qualityTask = GetArrayAsync("/api/v1/qualityprofile", baseUrl, apiKey, ct);
+        var metadataTask = GetArrayAsync("/api/v1/metadataprofile", baseUrl, apiKey, ct);
+        await Task.WhenAll(rootsTask, qualityTask, metadataTask);
+        return MapOptions(rootsTask.Result, qualityTask.Result, metadataTask.Result);
+    }
+
     public async Task<LidarrOptions> GetOptionsAsync(CancellationToken ct = default)
     {
         var rootsTask = GetArrayAsync("/api/v1/rootfolder", ct);
@@ -56,11 +71,17 @@ public sealed class LidarrClient
         var metadataTask = GetArrayAsync("/api/v1/metadataprofile", ct);
         await Task.WhenAll(rootsTask, qualityTask, metadataTask);
 
-        return new LidarrOptions(
-            rootsTask.Result.Select(x => new LidarrRootFolder(Int(x, "id"), Str(x, "path"))).ToList(),
-            qualityTask.Result.Select(x => new LidarrChoice(Int(x, "id"), Str(x, "name"))).ToList(),
-            metadataTask.Result.Select(x => new LidarrChoice(Int(x, "id"), Str(x, "name"))).ToList());
+        return MapOptions(rootsTask.Result, qualityTask.Result, metadataTask.Result);
     }
+
+    private static LidarrOptions MapOptions(
+        IReadOnlyList<JsonObject> roots,
+        IReadOnlyList<JsonObject> quality,
+        IReadOnlyList<JsonObject> metadata) =>
+        new(
+            roots.Select(x => new LidarrRootFolder(Int(x, "id"), Str(x, "path"))).ToList(),
+            quality.Select(x => new LidarrChoice(Int(x, "id"), Str(x, "name"))).ToList(),
+            metadata.Select(x => new LidarrChoice(Int(x, "id"), Str(x, "name"))).ToList());
 
     public async Task<LidarrAlbumCandidate> ResolveAlbumAsync(
         string artist, string album, int? year, CancellationToken ct = default)
@@ -212,9 +233,14 @@ public sealed class LidarrClient
     private HttpRequestMessage CreateRequest(HttpMethod method, string path)
     {
         var settings = RequireSettings();
-        var request = new HttpRequestMessage(method,
-            $"{settings.BaseUrl!.TrimEnd('/')}{path}");
-        request.Headers.TryAddWithoutValidation("X-Api-Key", settings.ApiKey);
+        return CreateRequest(method, path, settings.BaseUrl!, settings.ApiKey!);
+    }
+
+    private static HttpRequestMessage CreateRequest(
+        HttpMethod method, string path, string baseUrl, string apiKey)
+    {
+        var request = new HttpRequestMessage(method, $"{baseUrl.TrimEnd('/')}{path}");
+        request.Headers.TryAddWithoutValidation("X-Api-Key", apiKey);
         return request;
     }
 
@@ -236,6 +262,18 @@ public sealed class LidarrClient
     private async Task<List<JsonObject>> GetArrayAsync(string path, CancellationToken ct)
     {
         using var request = CreateRequest(HttpMethod.Get, path);
+        return await GetArrayAsync(request, ct);
+    }
+
+    private async Task<List<JsonObject>> GetArrayAsync(
+        string path, string baseUrl, string apiKey, CancellationToken ct)
+    {
+        using var request = CreateRequest(HttpMethod.Get, path, baseUrl, apiKey);
+        return await GetArrayAsync(request, ct);
+    }
+
+    private async Task<List<JsonObject>> GetArrayAsync(HttpRequestMessage request, CancellationToken ct)
+    {
         using var response = await SendAsync(request, ct);
         await using var stream = await response.Content.ReadAsStreamAsync(ct);
         var node = await JsonNode.ParseAsync(stream, cancellationToken: ct) as JsonArray

--- a/octo/Services/Lidarr/LidarrHeartAcquisitionService.cs
+++ b/octo/Services/Lidarr/LidarrHeartAcquisitionService.cs
@@ -1,0 +1,314 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Options;
+using Octo.Models.Domain;
+using Octo.Models.Download;
+using Octo.Models.Settings;
+using Octo.Services.Local;
+using Octo.Services.Metadata;
+using Octo.Services.Notifications;
+using Octo.Services.Subsonic;
+
+namespace Octo.Services.Lidarr;
+
+public interface ILidarrHeartAcquisitionService
+{
+    void QueueTrack(string provider, string externalId);
+    void QueueAlbum(string provider, string externalId);
+}
+
+/// <summary>
+/// Submits Lidarr album searches without occupying Octo's serialized direct-download
+/// worker, then reconciles imported files independently.
+/// </summary>
+public sealed class LidarrHeartAcquisitionService : ILidarrHeartAcquisitionService
+{
+    private readonly LidarrClient _client;
+    private readonly IMusicMetadataService _metadata;
+    private readonly DeezerMetadataService _deezer;
+    private readonly IOptionsMonitor<LidarrSettings> _settings;
+    private readonly IConfiguration _configuration;
+    private readonly NavidromeIdentityService _navIdentity;
+    private readonly ILocalLibraryService _library;
+    private readonly DownloadHistoryService _history;
+    private readonly NotificationService _notifications;
+    private readonly ILogger<LidarrHeartAcquisitionService> _logger;
+    private readonly ConcurrentDictionary<string, Lazy<Task>> _albumJobs = new();
+    private readonly ConcurrentDictionary<string, byte> _recordedPaths = new(StringComparer.OrdinalIgnoreCase);
+
+    public LidarrHeartAcquisitionService(
+        LidarrClient client,
+        IMusicMetadataService metadata,
+        DeezerMetadataService deezer,
+        IOptionsMonitor<LidarrSettings> settings,
+        IConfiguration configuration,
+        NavidromeIdentityService navIdentity,
+        ILocalLibraryService library,
+        DownloadHistoryService history,
+        NotificationService notifications,
+        ILogger<LidarrHeartAcquisitionService> logger)
+    {
+        _client = client;
+        _metadata = metadata;
+        _deezer = deezer;
+        _settings = settings;
+        _configuration = configuration;
+        _navIdentity = navIdentity;
+        _library = library;
+        _history = history;
+        _notifications = notifications;
+        _logger = logger;
+        foreach (var entry in history.GetRecent(int.MaxValue))
+            if (!string.IsNullOrWhiteSpace(entry.Path)) _recordedPaths.TryAdd(entry.Path, 0);
+    }
+
+    public void QueueTrack(string provider, string externalId) =>
+        _ = RunDetachedAsync(async () =>
+        {
+            var song = await _metadata.GetSongAsync(provider, externalId)
+                ?? throw new InvalidOperationException("The starred external track is no longer available.");
+            var enriched = await _deezer.EnrichTrackAsync(song.Artist, song.Title, includeYear: true);
+            var albumTitle = enriched?.AlbumTitle;
+            if (string.IsNullOrWhiteSpace(albumTitle)) albumTitle = song.Album;
+            if (string.IsNullOrWhiteSpace(albumTitle))
+                throw new InvalidOperationException($"Could not resolve an album for '{song.Artist} - {song.Title}'.");
+
+            song.Album = albumTitle;
+            song.CoverArtUrl ??= enriched?.AlbumCoverUrl;
+            song.Year ??= enriched?.Year;
+            var album = new Album
+            {
+                Title = albumTitle,
+                Artist = enriched?.ArtistName ?? song.Artist,
+                Year = enriched?.Year,
+                CoverArtUrl = enriched?.AlbumCoverUrl,
+                Songs = new List<Song> { song },
+            };
+            await QueueResolvedAlbumAsync(album);
+        }, "track", externalId);
+
+    public void QueueAlbum(string provider, string externalId) =>
+        _ = RunDetachedAsync(async () =>
+        {
+            var album = await _metadata.GetAlbumAsync(provider, externalId)
+                ?? throw new InvalidOperationException("The starred external album is no longer available.");
+            await QueueResolvedAlbumAsync(album);
+        }, "album", externalId);
+
+    private async Task QueueResolvedAlbumAsync(Album album)
+    {
+        if (string.IsNullOrWhiteSpace(album.Artist) || string.IsNullOrWhiteSpace(album.Title))
+            throw new InvalidOperationException("Lidarr requires an album artist and title.");
+
+        var candidate = await _client.ResolveAlbumAsync(album.Artist, album.Title, album.Year);
+        var lazy = _albumJobs.GetOrAdd(candidate.ForeignAlbumId,
+            _ => new Lazy<Task>(() => SubmitAndReconcileAsync(candidate, album),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        try
+        {
+            await lazy.Value;
+        }
+        finally
+        {
+            _albumJobs.TryRemove(new KeyValuePair<string, Lazy<Task>>(candidate.ForeignAlbumId, lazy));
+        }
+    }
+
+    private async Task SubmitAndReconcileAsync(LidarrAlbumCandidate candidate, Album album)
+    {
+        var snapshot = _settings.CurrentValue;
+        var albumId = await _client.EnsureAlbumAndSearchAsync(candidate);
+        _logger.LogInformation("Lidarr accepted AlbumSearch for '{Artist} - {Album}' ({ForeignId}, local id {Id})",
+            album.Artist, album.Title, candidate.ForeignAlbumId, albumId);
+        _notifications.Notify(new NotificationEvent
+        {
+            Type = NotificationEventType.DownloadStarted,
+            Artist = album.Artist,
+            Title = album.Title,
+            Album = album.Title,
+            Source = "Lidarr",
+            CoverArtUrl = album.CoverArtUrl,
+            Detail = "Album search accepted",
+        });
+
+        try
+        {
+            await ReconcileImportsAsync(albumId, album, snapshot);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Lidarr import reconciliation failed for '{Artist} - {Album}'",
+                album.Artist, album.Title);
+            if (snapshot.CompletionMode == LidarrCompletionMode.Imported)
+            {
+                _notifications.Notify(new NotificationEvent
+                {
+                    Type = NotificationEventType.DownloadFailed,
+                    Artist = album.Artist,
+                    Title = album.Title,
+                    Album = album.Title,
+                    Source = "Lidarr",
+                    CoverArtUrl = album.CoverArtUrl,
+                    Detail = ex.Message,
+                });
+            }
+        }
+    }
+
+    private async Task ReconcileImportsAsync(int albumId, Album album, LidarrSettings settings)
+    {
+        var timeout = TimeSpan.FromSeconds(Math.Max(1, settings.ImportTimeoutSeconds));
+        var poll = TimeSpan.FromSeconds(Math.Clamp(settings.ImportTimeoutSeconds / 30, 1, 10));
+        var deadline = DateTime.UtcNow + timeout;
+        var imported = 0;
+        var expected = 0;
+        var visibleToOcto = 0;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var state = await _client.GetAlbumImportStateAsync(albumId);
+            var tracks = state.Tracks;
+            expected = state.TrackCount;
+            visibleToOcto = 0;
+            var visible = tracks
+                .Where(t => t.HasFile && !string.IsNullOrWhiteSpace(t.Path))
+                .GroupBy(t => t.Path!, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .ToList();
+            foreach (var track in visible)
+            {
+                var localPath = TranslateImportedPath(track.Path!, settings.RootFolderPath,
+                    _navIdentity.EffectiveDownloadPath(_configuration["Library:DownloadPath"] ?? "/music"));
+                if (!File.Exists(localPath)) continue;
+                visibleToOcto++;
+                if (!_recordedPaths.TryAdd(localPath, 0)) continue;
+                try
+                {
+                    await RecordImportAsync(album, track, localPath);
+                    imported++;
+                }
+                catch
+                {
+                    _recordedPaths.TryRemove(localPath, out _);
+                    throw;
+                }
+            }
+
+            if (state.IsComplete && visible.Count > 0 && visibleToOcto == visible.Count)
+            {
+                if (imported > 0) await _library.TriggerLibraryScanAsync(force: true);
+                if (settings.CompletionMode == LidarrCompletionMode.Imported && imported > 0)
+                {
+                    _notifications.Notify(new NotificationEvent
+                    {
+                        Type = NotificationEventType.AlbumCompleted,
+                        Artist = album.Artist,
+                        Title = album.Title,
+                        CoverArtUrl = album.CoverArtUrl,
+                        TrackCount = state.TrackCount,
+                        LosslessCount = visible.Count(t =>
+                            string.Equals(Path.GetExtension(t.Path), ".flac", StringComparison.OrdinalIgnoreCase)),
+                        FailedCount = 0,
+                    });
+                }
+                return;
+            }
+
+            await Task.Delay(poll);
+        }
+
+        if (imported > 0) await _library.TriggerLibraryScanAsync(force: true);
+        var detail = $"Lidarr import timed out after {(int)timeout.TotalMinutes} minute(s)"
+                     + (expected > 0 ? $" ({visibleToOcto}/{expected} files visible to Octo)" : "");
+        _logger.LogWarning("{Detail} for '{Artist} - {Album}'", detail, album.Artist, album.Title);
+        if (settings.CompletionMode == LidarrCompletionMode.Imported)
+        {
+            _notifications.Notify(new NotificationEvent
+            {
+                Type = NotificationEventType.DownloadFailed,
+                Artist = album.Artist,
+                Title = album.Title,
+                Album = album.Title,
+                Source = "Lidarr",
+                CoverArtUrl = album.CoverArtUrl,
+                Detail = detail,
+            });
+        }
+    }
+
+    private async Task RecordImportAsync(Album album, LidarrImportedTrack imported, string localPath)
+    {
+        var song = MatchSong(album, imported) ?? new Song
+        {
+            Artist = imported.Artist ?? album.Artist,
+            Title = imported.Title,
+            Album = album.Title,
+            Track = imported.TrackNumber,
+            Duration = imported.DurationSeconds,
+            CoverArtUrl = album.CoverArtUrl,
+            IsLocal = false,
+        };
+
+        if (!string.IsNullOrWhiteSpace(song.ExternalProvider) && !string.IsNullOrWhiteSpace(song.ExternalId))
+            await _library.RegisterDownloadedSongAsync(song, localPath);
+
+        var ext = Path.GetExtension(localPath).TrimStart('.').ToUpperInvariant();
+        long size = imported.SizeBytes;
+        if (size <= 0) try { size = new FileInfo(localPath).Length; } catch { /* best effort */ }
+        _history.Record(new DownloadHistoryEntry
+        {
+            Artist = song.Artist,
+            Title = song.Title,
+            Album = album.Title,
+            Path = localPath,
+            Format = string.IsNullOrEmpty(ext) ? "?" : ext,
+            Source = "Lidarr",
+            CoverArtUrl = song.CoverArtUrlLarge ?? song.CoverArtUrl ?? album.CoverArtUrl,
+            SizeBytes = size,
+            DownloadedAt = DateTime.UtcNow.ToString("o"),
+        });
+    }
+
+    internal static Song? MatchSong(Album album, LidarrImportedTrack track)
+    {
+        var normalized = LidarrClient.Normalize(track.Title);
+        var byTitle = album.Songs.Where(s => LidarrClient.Normalize(s.Title) == normalized).ToList();
+        if (byTitle.Count == 1) return byTitle[0];
+        if (track.TrackNumber is int number)
+        {
+            var byNumber = album.Songs.Where(s => s.Track == number).ToList();
+            if (byNumber.Count == 1) return byNumber[0];
+        }
+        return byTitle.FirstOrDefault();
+    }
+
+    internal static string TranslateImportedPath(string lidarrPath, string? lidarrRoot, string octoRoot)
+    {
+        if (string.IsNullOrWhiteSpace(lidarrRoot))
+            throw new InvalidOperationException("Lidarr root folder is not configured.");
+        var root = Path.GetFullPath(lidarrRoot);
+        var source = Path.GetFullPath(lidarrPath);
+        var relative = Path.GetRelativePath(root, source);
+        if (relative == ".." || relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            throw new InvalidOperationException($"Lidarr imported a path outside its configured root: {lidarrPath}");
+        var targetRoot = Path.GetFullPath(octoRoot);
+        var target = Path.GetFullPath(Path.Combine(targetRoot, relative));
+        if (Path.GetRelativePath(targetRoot, target).StartsWith("..", StringComparison.Ordinal))
+            throw new InvalidOperationException("Translated Lidarr path escaped Octo's library root.");
+        return target;
+    }
+
+    private async Task RunDetachedAsync(Func<Task> work, string kind, string externalId)
+    {
+        try { await work(); }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Lidarr {Kind} heart failed for {Id}", kind, externalId);
+            _notifications.Notify(new NotificationEvent
+            {
+                Type = NotificationEventType.DownloadFailed,
+                Source = "Lidarr",
+                Detail = ex.Message,
+            });
+        }
+    }
+}

--- a/octo/Services/Lidarr/LidarrHeartAcquisitionService.cs
+++ b/octo/Services/Lidarr/LidarrHeartAcquisitionService.cs
@@ -12,8 +12,10 @@ namespace Octo.Services.Lidarr;
 
 public interface ILidarrHeartAcquisitionService
 {
-    void QueueTrack(string provider, string externalId);
-    void QueueAlbum(string provider, string externalId);
+    Task<bool> TryAcquireTrackAsync(
+        string provider, string externalId, bool notifyFailure = true);
+    Task<bool> TryAcquireAlbumAsync(
+        string provider, string externalId, bool notifyFailure = true);
 }
 
 /// <summary>
@@ -61,8 +63,9 @@ public sealed class LidarrHeartAcquisitionService : ILidarrHeartAcquisitionServi
             if (!string.IsNullOrWhiteSpace(entry.Path)) _recordedPaths.TryAdd(entry.Path, 0);
     }
 
-    public void QueueTrack(string provider, string externalId) =>
-        _ = RunDetachedAsync(async () =>
+    public Task<bool> TryAcquireTrackAsync(
+        string provider, string externalId, bool notifyFailure = true) =>
+        TryAcquireAsync(async () =>
         {
             var song = await _metadata.GetSongAsync(provider, externalId)
                 ?? throw new InvalidOperationException("The starred external track is no longer available.");
@@ -84,15 +87,16 @@ public sealed class LidarrHeartAcquisitionService : ILidarrHeartAcquisitionServi
                 Songs = new List<Song> { song },
             };
             await QueueResolvedAlbumAsync(album);
-        }, "track", externalId);
+        }, "track", externalId, notifyFailure);
 
-    public void QueueAlbum(string provider, string externalId) =>
-        _ = RunDetachedAsync(async () =>
+    public Task<bool> TryAcquireAlbumAsync(
+        string provider, string externalId, bool notifyFailure = true) =>
+        TryAcquireAsync(async () =>
         {
             var album = await _metadata.GetAlbumAsync(provider, externalId)
                 ?? throw new InvalidOperationException("The starred external album is no longer available.");
             await QueueResolvedAlbumAsync(album);
-        }, "album", externalId);
+        }, "album", externalId, notifyFailure);
 
     private async Task QueueResolvedAlbumAsync(Album album)
     {
@@ -101,19 +105,21 @@ public sealed class LidarrHeartAcquisitionService : ILidarrHeartAcquisitionServi
 
         var candidate = await _client.ResolveAlbumAsync(album.Artist, album.Title, album.Year);
         var lazy = _albumJobs.GetOrAdd(candidate.ForeignAlbumId,
-            _ => new Lazy<Task>(() => SubmitAndReconcileAsync(candidate, album),
+            _ => new Lazy<Task>(() => SubmitAndStartReconciliationAsync(candidate, album),
                 LazyThreadSafetyMode.ExecutionAndPublication));
         try
         {
             await lazy.Value;
         }
-        finally
+        catch
         {
             _albumJobs.TryRemove(new KeyValuePair<string, Lazy<Task>>(candidate.ForeignAlbumId, lazy));
+            throw;
         }
     }
 
-    private async Task SubmitAndReconcileAsync(LidarrAlbumCandidate candidate, Album album)
+    private async Task SubmitAndStartReconciliationAsync(
+        LidarrAlbumCandidate candidate, Album album)
     {
         var snapshot = _settings.CurrentValue;
         var albumId = await _client.EnsureAlbumAndSearchAsync(candidate);
@@ -130,28 +136,35 @@ public sealed class LidarrHeartAcquisitionService : ILidarrHeartAcquisitionServi
             Detail = "Album search accepted",
         });
 
-        try
+        _ = Task.Run(async () =>
         {
-            await ReconcileImportsAsync(albumId, album, snapshot);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Lidarr import reconciliation failed for '{Artist} - {Album}'",
-                album.Artist, album.Title);
-            if (snapshot.CompletionMode == LidarrCompletionMode.Imported)
+            try
             {
-                _notifications.Notify(new NotificationEvent
-                {
-                    Type = NotificationEventType.DownloadFailed,
-                    Artist = album.Artist,
-                    Title = album.Title,
-                    Album = album.Title,
-                    Source = "Lidarr",
-                    CoverArtUrl = album.CoverArtUrl,
-                    Detail = ex.Message,
-                });
+                await ReconcileImportsAsync(albumId, album, snapshot);
             }
-        }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Lidarr import reconciliation failed for '{Artist} - {Album}'",
+                    album.Artist, album.Title);
+                if (snapshot.CompletionMode == LidarrCompletionMode.Imported)
+                {
+                    _notifications.Notify(new NotificationEvent
+                    {
+                        Type = NotificationEventType.DownloadFailed,
+                        Artist = album.Artist,
+                        Title = album.Title,
+                        Album = album.Title,
+                        Source = "Lidarr",
+                        CoverArtUrl = album.CoverArtUrl,
+                        Detail = ex.Message,
+                    });
+                }
+            }
+            finally
+            {
+                _albumJobs.TryRemove(candidate.ForeignAlbumId, out _);
+            }
+        });
     }
 
     private async Task ReconcileImportsAsync(int albumId, Album album, LidarrSettings settings)
@@ -297,18 +310,24 @@ public sealed class LidarrHeartAcquisitionService : ILidarrHeartAcquisitionServi
         return target;
     }
 
-    private async Task RunDetachedAsync(Func<Task> work, string kind, string externalId)
+    private async Task<bool> TryAcquireAsync(
+        Func<Task> work, string kind, string externalId, bool notifyFailure)
     {
-        try { await work(); }
+        try
+        {
+            await work();
+            return true;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Lidarr {Kind} heart failed for {Id}", kind, externalId);
-            _notifications.Notify(new NotificationEvent
+            if (notifyFailure) _notifications.Notify(new NotificationEvent
             {
                 Type = NotificationEventType.DownloadFailed,
                 Source = "Lidarr",
                 Detail = ex.Message,
             });
+            return false;
         }
     }
 }

--- a/octo/Services/Soulseek/SoulseekDownloadService.cs
+++ b/octo/Services/Soulseek/SoulseekDownloadService.cs
@@ -151,7 +151,9 @@ public class SoulseekDownloadService : BaseDownloadService
     // =========================================================================
     private const int MaxPeerAttempts = 5;
 
-    protected override async Task<string> DownloadTrackAsync(string trackId, Song song, bool suppressNotify, CancellationToken cancellationToken)
+    protected override async Task<string> DownloadTrackAsync(
+        string trackId, Song song, bool suppressNotify,
+        DownloadSource? sourceOverride, CancellationToken cancellationToken)
     {
         var routing = _idRegistry.Lookup(song.ExternalId ?? "") ?? SoulseekMetadataService.TryDecodeExternalId(song.ExternalId ?? "");
         if (routing is null || !routing.HasArtistTitle)
@@ -159,7 +161,7 @@ public class SoulseekDownloadService : BaseDownloadService
                 $"Cannot download '{song.Artist} - {song.Title}': missing artist/title in external id");
 
         // DownloadOnStar decides WHETHER to download; DownloadSource decides FROM WHERE.
-        switch (SubsonicSettings.DownloadSource)
+        switch (sourceOverride ?? SubsonicSettings.DownloadSource)
         {
             case DownloadSource.YouTube:
                 return await DownloadViaYouTubeAsync(routing, suppressNotify, announceStart: true, cancellationToken);

--- a/octo/appsettings.json
+++ b/octo/appsettings.json
@@ -5,6 +5,7 @@
     "DownloadMode": "Track",
     "DownloadOnStar": true,
     "DownloadAlbumOnStar": true,
+    "DownloadSource": "Soulseek",
     "WaitForLosslessOnPlay": false,
     "FolderStructure": "Flat",
     "UseLocalStaging": false,
@@ -24,6 +25,15 @@
     "MinFileSizeBytes": 5242880,
     "PreferredExtension": "flac",
     "DownloadTimeoutSeconds": 180
+  },
+  "Lidarr": {
+    "BaseUrl": "",
+    "ApiKey": "",
+    "RootFolderPath": "",
+    "QualityProfileId": 0,
+    "MetadataProfileId": 0,
+    "CompletionMode": "Accepted",
+    "ImportTimeoutSeconds": 1800
   },
   "YouTube": {
     "ShimUrl": "http://yt-dlp-shim:8080"

--- a/octo/wwwroot/admin/admin.css
+++ b/octo/wwwroot/admin/admin.css
@@ -941,6 +941,13 @@ section[data-pane].active { display: block; }
 .seg button:hover { color: var(--fg-soft); }
 .seg button.active { color: var(--fg); }
 
+@media (max-width: 760px) {
+  /* Four heart-source choices no longer fit comfortably in the segmented row.
+     Use the underlying native select on small screens for readable, keyboard-safe UI. */
+  .seg[data-seg-for="f-download-source"] { display: none; }
+  #f-download-source.seg-src { display: block !important; width: 100%; }
+}
+
 /* Save bar as a proper footer inside the slab card (rows have no padding of
    their own, so the injected .form-actions needs its own to line up). */
 .set-card .form-actions {

--- a/octo/wwwroot/admin/admin.css
+++ b/octo/wwwroot/admin/admin.css
@@ -341,6 +341,7 @@ section[data-pane].active { display: block; }
   line-height: 1.5;
 }
 .status-card.bad .status-card-body { color: var(--bad); }
+.status-card.warn .status-card-body { color: var(--warn); }
 .status-card-foot {
   font-size: 11px;
   color: var(--fg-faint);
@@ -359,6 +360,7 @@ section[data-pane].active { display: block; }
 }
 .status-dot.ok      { background: var(--good); box-shadow: 0 0 0 4px var(--good-glow); }
 .status-dot.bad     { background: var(--bad);  box-shadow: 0 0 0 4px var(--bad-glow); }
+.status-dot.warn    { background: var(--warn); box-shadow: 0 0 0 4px var(--warn-glow); }
 .status-dot.pending {
   background: var(--fg-faint);
   animation: pulse 1.4s ease-in-out infinite;
@@ -920,6 +922,84 @@ section[data-pane].active { display: block; }
 .switch input:checked ~ .sw-thumb { transform: translateX(18px); background: #0c0c0d; }
 .switch input:focus-visible ~ .sw-track { outline: 2px solid var(--accent-hover); outline-offset: 2px; }
 
+/* ── Ordered heart-source processing list ── */
+.source-priority-list {
+  border: 1px solid var(--border);
+  border-radius: var(--r-2);
+  overflow: hidden;
+  background: rgba(12, 12, 13, 0.34);
+}
+.source-priority-row {
+  min-height: 68px;
+  display: grid;
+  grid-template-columns: 44px 28px minmax(0, 1fr) auto 44px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px 8px 8px;
+  background: var(--bg-2);
+  transition: background var(--t-fast), opacity var(--t-fast);
+}
+.source-priority-row + .source-priority-row { border-top: 1px solid var(--border); }
+.source-priority-row.is-dragging { opacity: 0.48; background: var(--bg-4); }
+.source-priority-row.is-disabled .source-step,
+.source-priority-row.is-disabled .source-copy { opacity: 0.42; }
+.source-drag,
+.source-move button {
+  width: 44px;
+  height: 44px;
+  display: inline-grid;
+  place-items: center;
+  border: 0;
+  border-radius: var(--r-1);
+  color: var(--fg-mute);
+  background: transparent;
+}
+.source-drag { cursor: grab; touch-action: none; }
+.source-drag:active { cursor: grabbing; }
+.source-drag:hover,
+.source-move button:hover:not(:disabled) { color: var(--fg); background: var(--accent-soft); }
+.source-drag:focus-visible,
+.source-move button:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: -2px;
+}
+.source-drag svg,
+.source-move svg { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
+.source-step {
+  width: 24px;
+  height: 24px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--fg-soft);
+  font-size: 11px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+.source-copy { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.source-title { color: var(--fg); font-size: 13.5px; font-weight: 600; }
+.source-detail { color: var(--fg-soft); font-size: 12px; line-height: 1.35; }
+.source-move { display: flex; gap: 2px; }
+.source-move button:disabled { opacity: 0.24; cursor: default; }
+.source-enabled { height: 44px; }
+.source-enabled .sw-track { inset: 10px 0; }
+.source-enabled .sw-thumb { top: 13px; }
+
+@media (max-width: 620px) {
+  .source-priority-row {
+    grid-template-columns: 44px 28px minmax(0, 1fr) 44px;
+    gap: 8px;
+    padding-right: 10px;
+  }
+  .source-move { grid-column: 2 / 4; justify-content: flex-end; }
+  .source-enabled { grid-column: 4; grid-row: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .source-priority-row { transition: none; }
+}
+
 /* ── Segmented control (recessed track + sliding thumb) ── */
 .seg {
   position: relative; display: inline-flex; gap: 2px; padding: 3px; border-radius: 9px;
@@ -940,13 +1020,6 @@ section[data-pane].active { display: block; }
 }
 .seg button:hover { color: var(--fg-soft); }
 .seg button.active { color: var(--fg); }
-
-@media (max-width: 760px) {
-  /* Four heart-source choices no longer fit comfortably in the segmented row.
-     Use the underlying native select on small screens for readable, keyboard-safe UI. */
-  .seg[data-seg-for="f-download-source"] { display: none; }
-  #f-download-source.seg-src { display: block !important; width: 100%; }
-}
 
 /* Save bar as a proper footer inside the slab card (rows have no padding of
    their own, so the injected .form-actions needs its own to line up). */

--- a/octo/wwwroot/admin/admin.css
+++ b/octo/wwwroot/admin/admin.css
@@ -926,13 +926,15 @@ section[data-pane].active { display: block; }
 .source-priority-list {
   border: 1px solid var(--border);
   border-radius: var(--r-2);
-  overflow: hidden;
+  overflow: visible;
   background: rgba(12, 12, 13, 0.34);
 }
+.source-priority-row:first-child { border-radius: var(--r-2) var(--r-2) 0 0; }
+.source-priority-row:last-child { border-radius: 0 0 var(--r-2) var(--r-2); }
 .source-priority-row {
-  min-height: 68px;
+  min-height: 76px;
   display: grid;
-  grid-template-columns: 44px 28px minmax(0, 1fr) auto 44px;
+  grid-template-columns: 44px 28px minmax(180px, 1fr) auto;
   align-items: center;
   gap: 10px;
   padding: 8px 12px 8px 8px;
@@ -941,10 +943,21 @@ section[data-pane].active { display: block; }
 }
 .source-priority-row + .source-priority-row { border-top: 1px solid var(--border); }
 .source-priority-row.is-dragging { opacity: 0.48; background: var(--bg-4); }
+.source-drag-ghost {
+  position: fixed;
+  top: -10000px;
+  left: -10000px;
+  z-index: 9999;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-2);
+  opacity: 0.96;
+  box-shadow: var(--elev-3);
+  pointer-events: none;
+}
 .source-priority-row.is-disabled .source-step,
-.source-priority-row.is-disabled .source-copy { opacity: 0.42; }
-.source-drag,
-.source-move button {
+.source-priority-row.is-disabled .source-title,
+.source-priority-row.is-disabled .source-detail { opacity: 0.42; }
+.source-drag {
   width: 44px;
   height: 44px;
   display: inline-grid;
@@ -956,15 +969,12 @@ section[data-pane].active { display: block; }
 }
 .source-drag { cursor: grab; touch-action: none; }
 .source-drag:active { cursor: grabbing; }
-.source-drag:hover,
-.source-move button:hover:not(:disabled) { color: var(--fg); background: var(--accent-soft); }
-.source-drag:focus-visible,
-.source-move button:focus-visible {
+.source-drag:hover { color: var(--fg); background: var(--accent-soft); }
+.source-drag:focus-visible {
   outline: 2px solid var(--accent-hover);
   outline-offset: -2px;
 }
-.source-drag svg,
-.source-move svg { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
+.source-drag svg { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
 .source-step {
   width: 24px;
   height: 24px;
@@ -980,20 +990,72 @@ section[data-pane].active { display: block; }
 .source-copy { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .source-title { color: var(--fg); font-size: 13.5px; font-weight: 600; }
 .source-detail { color: var(--fg-soft); font-size: 12px; line-height: 1.35; }
-.source-move { display: flex; gap: 2px; }
-.source-move button:disabled { opacity: 0.24; cursor: default; }
-.source-enabled { height: 44px; }
-.source-enabled .sw-track { inset: 10px 0; }
-.source-enabled .sw-thumb { top: 13px; }
+.source-heart-controls { display: flex; align-items: center; gap: 20px; }
+.source-heart-choice {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--fg-soft);
+  font-size: 12px;
+  white-space: nowrap;
+}
+.source-heart-label { display: inline-flex; align-items: center; gap: 5px; }
+.source-info {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--accent-hover);
+  cursor: help;
+}
+.source-info svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-width: 1.4; stroke-linecap: round; }
+.source-info::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  z-index: 20;
+  right: -8px;
+  bottom: calc(100% + 7px);
+  width: 270px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-1);
+  background: var(--bg-4);
+  color: var(--fg);
+  box-shadow: var(--elev-2);
+  font-size: 11.5px;
+  line-height: 1.45;
+  white-space: normal;
+  opacity: 0;
+  transform: translateY(3px);
+  pointer-events: none;
+  transition: opacity var(--t-fast), transform var(--t-fast);
+}
+.source-info:hover::after,
+.source-info:focus-visible::after { opacity: 1; transform: translateY(0); }
+.source-info:focus-visible { outline: 2px solid var(--accent-hover); outline-offset: 1px; }
+.source-kind-switch { height: 44px; }
+.source-kind-switch .sw-track { inset: 10px 0; }
+.source-kind-switch .sw-thumb { top: 13px; }
 
-@media (max-width: 620px) {
+@media (max-width: 760px) {
   .source-priority-row {
-    grid-template-columns: 44px 28px minmax(0, 1fr) 44px;
+    grid-template-columns: 44px 28px minmax(0, 1fr);
     gap: 8px;
     padding-right: 10px;
   }
-  .source-move { grid-column: 2 / 4; justify-content: flex-end; }
-  .source-enabled { grid-column: 4; grid-row: 1; }
+  .source-heart-controls {
+    grid-column: 2 / 4;
+    justify-content: flex-end;
+    gap: 16px;
+  }
+}
+
+@media (max-width: 430px) {
+  .source-heart-controls { justify-content: space-between; gap: 8px; }
+  .source-heart-choice { flex-direction: column; align-items: flex-start; gap: 3px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/octo/wwwroot/admin/admin.css
+++ b/octo/wwwroot/admin/admin.css
@@ -1041,6 +1041,8 @@ section[data-pane].active { display: block; }
 .source-kind-switch .sw-thumb { top: 13px; }
 
 @media (max-width: 760px) {
+  .playback-source-row { flex-direction: column; align-items: stretch; }
+  .playback-source-row .set-ctrl { justify-content: flex-start; }
   .source-priority-row {
     grid-template-columns: 44px 28px minmax(0, 1fr);
     gap: 8px;

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -79,10 +79,12 @@ async function refreshStatus() {
 function setStatusCard(svc, probe) {
   const card = document.querySelector(`.status-card[data-svc="${svc}"]`);
   if (!card) return;
-  card.classList.toggle('bad', !probe.ok);
+  const state = probe.warning ? 'warn' : probe.ok ? 'ok' : 'bad';
+  card.classList.toggle('bad', state === 'bad');
+  card.classList.toggle('warn', state === 'warn');
   const dot = card.querySelector('.status-dot');
   const body = card.querySelector('.status-card-body');
-  if (dot)  dot.className  = `status-dot ${probe.ok ? 'ok' : 'bad'}`;
+  if (dot)  dot.className  = `status-dot ${state}`;
   if (body) body.textContent = probe.detail || (probe.ok ? 'online' : 'unreachable');
 }
 
@@ -109,9 +111,12 @@ async function loadSettings() {
     const [section, key] = el.name.split('.');
     const value = currentSettings?.[section]?.[key];
     if (value === undefined || value === null) return;
-    if (el.type === 'checkbox') el.checked = !!value;
+    if (el.dataset.json === 'true') el.value = JSON.stringify(value ?? []);
+    else if (el.type === 'checkbox') el.checked = !!value;
     else el.value = value;
   });
+
+  renderHeartSourceOrder(currentSettings?.Subsonic?.HeartDownloadSources);
 
   // Meta references
   const cfgPath = document.getElementById('meta-config-path');
@@ -151,6 +156,7 @@ function ensureSaveBar(form) {
   actions.className = 'form-actions';
   actions.innerHTML = `
     <button type="submit" class="btn btn-primary">Save</button>
+    ${form.id === 'lidarr-connection-form' ? '<button type="button" class="btn btn-ghost" id="lidarr-test-connection">Test connection</button>' : ''}
     <span class="saved-status"></span>
     <span class="restart-hint">
       <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -183,7 +189,10 @@ document.querySelectorAll('form[data-section]').forEach(form => {
       const [section, key] = el.name.split('.');
       patch[section] = patch[section] || {};
       let value;
-      if (el.type === 'checkbox') value = el.checked;
+      if (el.dataset.json === 'true') {
+        try { value = JSON.parse(el.value || '[]'); }
+        catch { value = []; }
+      } else if (el.type === 'checkbox') value = el.checked;
       else if (el.type === 'number' || el.dataset.number === 'true') {
         value = el.value === '' ? null : Number(el.value);
         if (Number.isNaN(value)) value = null;
@@ -228,6 +237,150 @@ document.querySelectorAll('form[data-section]').forEach(form => {
   });
 });
 
+// Heart acquisition is a short priority chain, not a workflow graph. Keep all
+// sources visible so disabling one never destroys the user's chosen order.
+const heartSourceMeta = {
+  Soulseek: { title: 'Soulseek', detail: 'Lossless FLAC from slskd peers' },
+  YouTube: { title: 'YouTube', detail: 'Lossy MP3 from the yt-dlp shim' },
+  Lidarr: { title: 'Lidarr', detail: 'Album-level handoff to your Lidarr server' },
+};
+let heartSourceSteps = [];
+
+function normalizeHeartSourceSteps(steps) {
+  const seen = new Set();
+  const normalized = [];
+  (Array.isArray(steps) ? steps : []).forEach(step => {
+    const source = step?.Source ?? step?.source;
+    if (!heartSourceMeta[source] || seen.has(source)) return;
+    seen.add(source);
+    normalized.push({ Source: source, Enabled: Boolean(step?.Enabled ?? step?.enabled) });
+  });
+  ['Soulseek', 'YouTube', 'Lidarr'].forEach(source => {
+    if (!seen.has(source)) normalized.push({ Source: source, Enabled: source === 'Soulseek' });
+  });
+  return normalized;
+}
+
+function renderHeartSourceOrder(steps = heartSourceSteps) {
+  const list = document.getElementById('heart-source-order');
+  if (!list) return;
+  heartSourceSteps = normalizeHeartSourceSteps(steps);
+  list.innerHTML = heartSourceSteps.map((step, index) => {
+    const meta = heartSourceMeta[step.Source];
+    return `
+      <div class="source-priority-row${step.Enabled ? '' : ' is-disabled'}"
+           data-source="${step.Source}" data-index="${index}">
+        <button type="button" class="source-drag" draggable="true"
+                aria-label="Drag ${meta.title} to reorder" title="Drag to reorder">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M5 3h1M10 3h1M5 8h1M10 8h1M5 13h1M10 13h1"/></svg>
+        </button>
+        <span class="source-step" aria-hidden="true">${index + 1}</span>
+        <span class="source-copy">
+          <span class="source-title">${meta.title}</span>
+          <span class="source-detail">${meta.detail}</span>
+        </span>
+        <span class="source-move">
+          <button type="button" data-move="up" aria-label="Move ${meta.title} up" ${index === 0 ? 'disabled' : ''}>
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="m4 10 4-4 4 4"/></svg>
+          </button>
+          <button type="button" data-move="down" aria-label="Move ${meta.title} down" ${index === heartSourceSteps.length - 1 ? 'disabled' : ''}>
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="m4 6 4 4 4-4"/></svg>
+          </button>
+        </span>
+        <label class="switch source-enabled">
+          <input type="checkbox" aria-label="Enable ${meta.title}" ${step.Enabled ? 'checked' : ''} />
+          <span class="sw-track"></span><span class="sw-thumb"></span>
+        </label>
+      </div>`;
+  }).join('');
+  syncHeartSourceInput();
+}
+
+function syncHeartSourceInput() {
+  const input = document.getElementById('f-heart-download-sources');
+  const help = document.getElementById('heart-source-order-help');
+  if (input) {
+    input.value = JSON.stringify(heartSourceSteps);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  if (help) help.textContent = heartSourceSteps.some(step => step.Enabled)
+    ? 'Drag a handle or use the arrow buttons to change priority. Disabled sources keep their position and are skipped.'
+    : 'No heart download sources are enabled. Hearts will not acquire files.';
+}
+
+function moveHeartSource(from, to) {
+  if (from === to || from < 0 || to < 0 ||
+      from >= heartSourceSteps.length || to >= heartSourceSteps.length) return;
+  const [step] = heartSourceSteps.splice(from, 1);
+  heartSourceSteps.splice(to, 0, step);
+  renderHeartSourceOrder();
+  document.querySelector(`.source-priority-row[data-index="${to}"] .source-drag`)?.focus();
+}
+
+const heartSourceList = document.getElementById('heart-source-order');
+heartSourceList?.addEventListener('click', event => {
+  const button = event.target.closest('[data-move]');
+  if (!button) return;
+  const row = button.closest('.source-priority-row');
+  const from = Number(row.dataset.index);
+  moveHeartSource(from, from + (button.dataset.move === 'up' ? -1 : 1));
+});
+heartSourceList?.addEventListener('change', event => {
+  if (!event.target.matches('.source-enabled input')) return;
+  const row = event.target.closest('.source-priority-row');
+  const source = row.dataset.source;
+  heartSourceSteps[Number(row.dataset.index)].Enabled = event.target.checked;
+  renderHeartSourceOrder();
+  document.querySelector(`.source-priority-row[data-source="${source}"] .source-enabled input`)?.focus();
+});
+heartSourceList?.addEventListener('dragstart', event => {
+  const handle = event.target.closest('.source-drag');
+  if (!handle) return;
+  const row = handle.closest('.source-priority-row');
+  event.dataTransfer.effectAllowed = 'move';
+  event.dataTransfer.setData('text/plain', row.dataset.index);
+  row.classList.add('is-dragging');
+});
+heartSourceList?.addEventListener('dragend', event => {
+  event.target.closest('.source-priority-row')?.classList.remove('is-dragging');
+});
+heartSourceList?.addEventListener('dragover', event => {
+  if (event.target.closest('.source-priority-row')) event.preventDefault();
+});
+heartSourceList?.addEventListener('drop', event => {
+  const row = event.target.closest('.source-priority-row');
+  if (!row) return;
+  event.preventDefault();
+  moveHeartSource(Number(event.dataTransfer.getData('text/plain')), Number(row.dataset.index));
+});
+
+document.getElementById('lidarr-test-connection')?.addEventListener('click', async (event) => {
+  const button = event.currentTarget;
+  const form = document.getElementById('lidarr-connection-form');
+  const status = form?.querySelector('.saved-status');
+  const baseUrl = document.getElementById('f-lidarr-url')?.value ?? '';
+  const apiKey = document.getElementById('f-lidarr-key')?.value ?? '';
+  button.disabled = true;
+  if (status) status.textContent = 'Testing…';
+  try {
+    const r = await fetch('/api/admin/lidarr/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseUrl, apiKey }),
+    });
+    const result = await r.json();
+    if (!r.ok) throw new Error(result.error || `HTTP ${r.status}`);
+    populateLidarrOptions(result.options || {});
+    if (status) status.textContent = result.message || 'Connected to Lidarr.';
+    toast(result.message || 'Connected to Lidarr.', 'ok');
+  } catch (err) {
+    if (status) status.textContent = `Test failed: ${err.message}`;
+    toast(`Lidarr test failed: ${err.message}`, 'error');
+  } finally {
+    button.disabled = false;
+  }
+});
+
 function isFieldDirty(el) {
   if (!currentSettings || !el.name?.includes('.')) return false;
   const [section, key] = el.name.split('.');
@@ -244,14 +397,12 @@ function isFieldDirty(el) {
 // Lidarr owns these choices. Keep them disabled until a saved connection can
 // supply real values; this avoids persisting a made-up profile id.
 async function loadLidarrOptions() {
-  const button = document.getElementById('lidarr-load-options');
   const status = document.getElementById('lidarr-options-status');
   const root = document.getElementById('f-lidarr-root');
   const quality = document.getElementById('f-lidarr-quality');
   const metadata = document.getElementById('f-lidarr-metadata');
   if (!root || !quality || !metadata) return;
 
-  if (button) button.disabled = true;
   if (status) status.textContent = 'Loading choices…';
   [root, quality, metadata].forEach(el => { el.disabled = true; });
   try {
@@ -259,34 +410,41 @@ async function loadLidarrOptions() {
     const data = await r.json();
     if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
 
-    const selectedRoot = currentSettings?.Lidarr?.RootFolderPath ?? '';
-    const selectedQuality = String(currentSettings?.Lidarr?.QualityProfileId ?? 0);
-    const selectedMetadata = String(currentSettings?.Lidarr?.MetadataProfileId ?? 0);
-    root.innerHTML = '<option value="">Choose a root folder</option>' +
-      (data.rootFolders || []).map(x => `<option value="${esc(x.path)}">${esc(x.path)}</option>`).join('');
-    quality.innerHTML = '<option value="0">Choose a quality profile</option>' +
-      (data.qualityProfiles || []).map(x => `<option value="${x.id}">${esc(x.name)}</option>`).join('');
-    metadata.innerHTML = '<option value="0">Choose a metadata profile</option>' +
-      (data.metadataProfiles || []).map(x => `<option value="${x.id}">${esc(x.name)}</option>`).join('');
-    root.value = selectedRoot;
-    quality.value = selectedQuality;
-    metadata.value = selectedMetadata;
-    [root, quality, metadata].forEach(el => { el.disabled = false; });
-    const empty = [];
-    if (!(data.rootFolders || []).length) empty.push('root folders');
-    if (!(data.qualityProfiles || []).length) empty.push('quality profiles');
-    if (!(data.metadataProfiles || []).length) empty.push('metadata profiles');
-    if (status) status.textContent = empty.length
-      ? `Connected, but Lidarr returned no ${empty.join(', ')}.`
-      : 'Connected. Choices loaded from Lidarr.';
+    populateLidarrOptions(data);
   } catch (err) {
     if (status) status.textContent = `Could not load choices: ${err.message}`;
-  } finally {
-    if (button) button.disabled = false;
   }
 }
 
-document.getElementById('lidarr-load-options')?.addEventListener('click', loadLidarrOptions);
+function populateLidarrOptions(data) {
+  const status = document.getElementById('lidarr-options-status');
+  const root = document.getElementById('f-lidarr-root');
+  const quality = document.getElementById('f-lidarr-quality');
+  const metadata = document.getElementById('f-lidarr-metadata');
+  if (!root || !quality || !metadata) return;
+  const selectedRoot = root.value || currentSettings?.Lidarr?.RootFolderPath || '';
+  const selectedQuality = quality.value !== '0'
+    ? quality.value : String(currentSettings?.Lidarr?.QualityProfileId ?? 0);
+  const selectedMetadata = metadata.value !== '0'
+    ? metadata.value : String(currentSettings?.Lidarr?.MetadataProfileId ?? 0);
+  root.innerHTML = '<option value="">Choose a root folder</option>' +
+    (data.rootFolders || []).map(x => `<option value="${esc(x.path)}">${esc(x.path)}</option>`).join('');
+  quality.innerHTML = '<option value="0">Choose a quality profile</option>' +
+    (data.qualityProfiles || []).map(x => `<option value="${x.id}">${esc(x.name)}</option>`).join('');
+  metadata.innerHTML = '<option value="0">Choose a metadata profile</option>' +
+    (data.metadataProfiles || []).map(x => `<option value="${x.id}">${esc(x.name)}</option>`).join('');
+  root.value = selectedRoot;
+  quality.value = selectedQuality;
+  metadata.value = selectedMetadata;
+  [root, quality, metadata].forEach(el => { el.disabled = false; });
+  const empty = [];
+  if (!(data.rootFolders || []).length) empty.push('root folders');
+  if (!(data.qualityProfiles || []).length) empty.push('quality profiles');
+  if (!(data.metadataProfiles || []).length) empty.push('metadata profiles');
+  if (status) status.textContent = empty.length
+    ? `Connected, but Lidarr returned no ${empty.join(', ')}.`
+    : 'Connected. Choices loaded from Lidarr.';
+}
 
 // ────────────────────────────────────────────────────────────────
 // Raw config editor

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -116,6 +116,8 @@ async function loadSettings() {
     else el.value = value;
   });
 
+  syncPlaybackSourceControl();
+  updateStreamSettings();
   renderHeartSourceOrder(currentSettings?.Subsonic?.HeartDownloadSources);
 
   // Meta references
@@ -319,6 +321,33 @@ function renderHeartSourceOrder(steps = heartSourceSteps) {
   }).join('');
   syncHeartSourceInput();
 }
+
+function updateStreamSettings() {
+  const waitForLossless = document.getElementById('f-wait-for-lossless-on-play')?.checked;
+  const activeSource = waitForLossless ? 'Lossless' : 'YouTube';
+  document.querySelectorAll('[data-stream-source]').forEach(section => {
+    section.hidden = section.dataset.streamSource !== activeSource;
+  });
+}
+
+function syncPlaybackSourceControl() {
+  const control = document.getElementById('f-playback-source');
+  const wait = document.getElementById('f-wait-for-lossless-on-play');
+  if (!control || !wait) return;
+  control.value = wait.checked ? 'Lossless' : 'YouTube';
+}
+
+document.getElementById('f-playback-source')?.addEventListener('change', event => {
+  const wait = document.getElementById('f-wait-for-lossless-on-play');
+  if (!wait) return;
+  wait.checked = event.target.value === 'Lossless';
+  wait.dispatchEvent(new Event('input', { bubbles: true }));
+  updateStreamSettings();
+});
+
+document.querySelectorAll('[data-open-tab]').forEach(button => {
+  button.addEventListener('click', () => activateTab(button.dataset.openTab));
+});
 
 function syncHeartSourceInput() {
   const input = document.getElementById('f-heart-download-sources');

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -132,6 +132,9 @@ async function loadSettings() {
   updateDiscoveryBanner();
   buildSegments();
   syncSegments(false);
+  if (currentSettings?.Lidarr?.BaseUrl && currentSettings?.Lidarr?.ApiKey) {
+    loadLidarrOptions();
+  }
 
   // Initial dirty-check pass: all forms start clean.
   document.querySelectorAll('form[data-section]').forEach(form => {
@@ -176,11 +179,12 @@ document.querySelectorAll('form[data-section]').forEach(form => {
 
     form.querySelectorAll('[name]').forEach(el => {
       if (!el.name?.includes('.')) return;
+      if (el.disabled) return;
       const [section, key] = el.name.split('.');
       patch[section] = patch[section] || {};
       let value;
       if (el.type === 'checkbox') value = el.checked;
-      else if (el.type === 'number') {
+      else if (el.type === 'number' || el.dataset.number === 'true') {
         value = el.value === '' ? null : Number(el.value);
         if (Number.isNaN(value)) value = null;
       } else value = el.value;
@@ -205,7 +209,11 @@ document.querySelectorAll('form[data-section]').forEach(form => {
       const result = await r.json();
       if (!r.ok) throw new Error(result.error || `HTTP ${r.status}`);
 
+      // The JSON configuration provider reloads asynchronously after the atomic
+      // write. Give it one watcher tick before testing a newly saved connection.
+      if (form.id === 'lidarr-connection-form') await new Promise(resolve => setTimeout(resolve, 600));
       currentSettings = await (await fetch('/api/admin/settings')).json();
+      if (form.id === 'lidarr-connection-form') await loadLidarrOptions();
       status.textContent = `Saved · ${new Date().toLocaleTimeString()}`;
       form.querySelector('.form-actions')?.classList.remove('dirty');
       toast(needsRestart
@@ -232,6 +240,53 @@ function isFieldDirty(el) {
       (live === null || live === undefined || live === '')) return false;
   return saved != live;
 }
+
+// Lidarr owns these choices. Keep them disabled until a saved connection can
+// supply real values; this avoids persisting a made-up profile id.
+async function loadLidarrOptions() {
+  const button = document.getElementById('lidarr-load-options');
+  const status = document.getElementById('lidarr-options-status');
+  const root = document.getElementById('f-lidarr-root');
+  const quality = document.getElementById('f-lidarr-quality');
+  const metadata = document.getElementById('f-lidarr-metadata');
+  if (!root || !quality || !metadata) return;
+
+  if (button) button.disabled = true;
+  if (status) status.textContent = 'Loading choices…';
+  [root, quality, metadata].forEach(el => { el.disabled = true; });
+  try {
+    const r = await fetch('/api/admin/lidarr/options', { cache: 'no-store' });
+    const data = await r.json();
+    if (!r.ok) throw new Error(data.error || `HTTP ${r.status}`);
+
+    const selectedRoot = currentSettings?.Lidarr?.RootFolderPath ?? '';
+    const selectedQuality = String(currentSettings?.Lidarr?.QualityProfileId ?? 0);
+    const selectedMetadata = String(currentSettings?.Lidarr?.MetadataProfileId ?? 0);
+    root.innerHTML = '<option value="">Choose a root folder</option>' +
+      (data.rootFolders || []).map(x => `<option value="${esc(x.path)}">${esc(x.path)}</option>`).join('');
+    quality.innerHTML = '<option value="0">Choose a quality profile</option>' +
+      (data.qualityProfiles || []).map(x => `<option value="${x.id}">${esc(x.name)}</option>`).join('');
+    metadata.innerHTML = '<option value="0">Choose a metadata profile</option>' +
+      (data.metadataProfiles || []).map(x => `<option value="${x.id}">${esc(x.name)}</option>`).join('');
+    root.value = selectedRoot;
+    quality.value = selectedQuality;
+    metadata.value = selectedMetadata;
+    [root, quality, metadata].forEach(el => { el.disabled = false; });
+    const empty = [];
+    if (!(data.rootFolders || []).length) empty.push('root folders');
+    if (!(data.qualityProfiles || []).length) empty.push('quality profiles');
+    if (!(data.metadataProfiles || []).length) empty.push('metadata profiles');
+    if (status) status.textContent = empty.length
+      ? `Connected, but Lidarr returned no ${empty.join(', ')}.`
+      : 'Connected. Choices loaded from Lidarr.';
+  } catch (err) {
+    if (status) status.textContent = `Could not load choices: ${err.message}`;
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+document.getElementById('lidarr-load-options')?.addEventListener('click', loadLidarrOptions);
 
 // ────────────────────────────────────────────────────────────────
 // Raw config editor

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -242,9 +242,12 @@ document.querySelectorAll('form[data-section]').forEach(form => {
 const heartSourceMeta = {
   Soulseek: { title: 'Soulseek', detail: 'Lossless FLAC from slskd peers' },
   YouTube: { title: 'YouTube', detail: 'Lossy MP3 from the yt-dlp shim' },
-  Lidarr: { title: 'Lidarr', detail: 'Album-level handoff to your Lidarr server' },
+  Lidarr: { title: 'Lidarr', detail: 'Album automation through your Lidarr server' },
 };
 let heartSourceSteps = [];
+let draggedHeartSourceRow = null;
+let draggedHeartSourcePointer = null;
+let heartSourceDragGhost = null;
 
 function normalizeHeartSourceSteps(steps) {
   const seen = new Set();
@@ -253,10 +256,19 @@ function normalizeHeartSourceSteps(steps) {
     const source = step?.Source ?? step?.source;
     if (!heartSourceMeta[source] || seen.has(source)) return;
     seen.add(source);
-    normalized.push({ Source: source, Enabled: Boolean(step?.Enabled ?? step?.enabled) });
+    const legacyEnabled = step?.Enabled ?? step?.enabled ?? false;
+    normalized.push({
+      Source: source,
+      SongEnabled: Boolean(step?.SongEnabled ?? step?.songEnabled ?? legacyEnabled),
+      AlbumEnabled: Boolean(step?.AlbumEnabled ?? step?.albumEnabled ?? legacyEnabled),
+    });
   });
   ['Soulseek', 'YouTube', 'Lidarr'].forEach(source => {
-    if (!seen.has(source)) normalized.push({ Source: source, Enabled: source === 'Soulseek' });
+    if (!seen.has(source)) normalized.push({
+      Source: source,
+      SongEnabled: source === 'Soulseek',
+      AlbumEnabled: source === 'Soulseek',
+    });
   });
   return normalized;
 }
@@ -268,10 +280,11 @@ function renderHeartSourceOrder(steps = heartSourceSteps) {
   list.innerHTML = heartSourceSteps.map((step, index) => {
     const meta = heartSourceMeta[step.Source];
     return `
-      <div class="source-priority-row${step.Enabled ? '' : ' is-disabled'}"
+      <div class="source-priority-row${step.SongEnabled || step.AlbumEnabled ? '' : ' is-disabled'}"
            data-source="${step.Source}" data-index="${index}">
         <button type="button" class="source-drag" draggable="true"
-                aria-label="Drag ${meta.title} to reorder" title="Drag to reorder">
+                aria-label="Drag ${meta.title} to reorder. Use arrow keys to move it."
+                title="Drag to reorder; arrow keys also work">
           <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M5 3h1M10 3h1M5 8h1M10 8h1M5 13h1M10 13h1"/></svg>
         </button>
         <span class="source-step" aria-hidden="true">${index + 1}</span>
@@ -279,18 +292,29 @@ function renderHeartSourceOrder(steps = heartSourceSteps) {
           <span class="source-title">${meta.title}</span>
           <span class="source-detail">${meta.detail}</span>
         </span>
-        <span class="source-move">
-          <button type="button" data-move="up" aria-label="Move ${meta.title} up" ${index === 0 ? 'disabled' : ''}>
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="m4 10 4-4 4 4"/></svg>
-          </button>
-          <button type="button" data-move="down" aria-label="Move ${meta.title} down" ${index === heartSourceSteps.length - 1 ? 'disabled' : ''}>
-            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="m4 6 4 4 4-4"/></svg>
-          </button>
+        <span class="source-heart-controls" role="group" aria-label="${meta.title} heart types">
+          <span class="source-heart-choice">
+            <span class="source-heart-label">Song hearts
+              ${step.Source === 'Lidarr' ? `
+                <span class="source-info" tabindex="0" role="img"
+                      aria-label="A song heart asks Lidarr to acquire the entire album. Enable this if you want Lidarr to handle single-song requests anyway."
+                      data-tooltip="A song heart asks Lidarr to acquire the entire album. Enable this if you want Lidarr to handle single-song requests anyway.">
+                  <svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 4.8v.1"/></svg>
+                </span>` : ''}
+            </span>
+            <label class="switch source-kind-switch">
+              <input type="checkbox" data-heart-kind="SongEnabled" aria-label="Use ${meta.title} for song hearts" ${step.SongEnabled ? 'checked' : ''} />
+              <span class="sw-track"></span><span class="sw-thumb"></span>
+            </label>
+          </span>
+          <span class="source-heart-choice">
+            <span class="source-heart-label">Album hearts</span>
+            <label class="switch source-kind-switch">
+              <input type="checkbox" data-heart-kind="AlbumEnabled" aria-label="Use ${meta.title} for album hearts" ${step.AlbumEnabled ? 'checked' : ''} />
+              <span class="sw-track"></span><span class="sw-thumb"></span>
+            </label>
+          </span>
         </span>
-        <label class="switch source-enabled">
-          <input type="checkbox" aria-label="Enable ${meta.title}" ${step.Enabled ? 'checked' : ''} />
-          <span class="sw-track"></span><span class="sw-thumb"></span>
-        </label>
       </div>`;
   }).join('');
   syncHeartSourceInput();
@@ -303,8 +327,8 @@ function syncHeartSourceInput() {
     input.value = JSON.stringify(heartSourceSteps);
     input.dispatchEvent(new Event('input', { bubbles: true }));
   }
-  if (help) help.textContent = heartSourceSteps.some(step => step.Enabled)
-    ? 'Drag a handle or use the arrow buttons to change priority. Disabled sources keep their position and are skipped.'
+  if (help) help.textContent = heartSourceSteps.some(step => step.SongEnabled || step.AlbumEnabled)
+    ? 'Drag a row by its handle to change priority. With the handle focused, use the arrow keys to move it.'
     : 'No heart download sources are enabled. Hearts will not acquire files.';
 }
 
@@ -318,41 +342,106 @@ function moveHeartSource(from, to) {
 }
 
 const heartSourceList = document.getElementById('heart-source-order');
-heartSourceList?.addEventListener('click', event => {
-  const button = event.target.closest('[data-move]');
-  if (!button) return;
-  const row = button.closest('.source-priority-row');
-  const from = Number(row.dataset.index);
-  moveHeartSource(from, from + (button.dataset.move === 'up' ? -1 : 1));
-});
 heartSourceList?.addEventListener('change', event => {
-  if (!event.target.matches('.source-enabled input')) return;
+  if (!event.target.matches('[data-heart-kind]')) return;
   const row = event.target.closest('.source-priority-row');
-  const source = row.dataset.source;
-  heartSourceSteps[Number(row.dataset.index)].Enabled = event.target.checked;
-  renderHeartSourceOrder();
-  document.querySelector(`.source-priority-row[data-source="${source}"] .source-enabled input`)?.focus();
+  heartSourceSteps[Number(row.dataset.index)][event.target.dataset.heartKind] = event.target.checked;
+  const step = heartSourceSteps[Number(row.dataset.index)];
+  row.classList.toggle('is-disabled', !step.SongEnabled && !step.AlbumEnabled);
+  syncHeartSourceInput();
+});
+heartSourceList?.addEventListener('keydown', event => {
+  const handle = event.target.closest('.source-drag');
+  if (!handle || !['ArrowUp', 'ArrowDown'].includes(event.key)) return;
+  event.preventDefault();
+  const from = Number(handle.closest('.source-priority-row').dataset.index);
+  moveHeartSource(from, from + (event.key === 'ArrowUp' ? -1 : 1));
 });
 heartSourceList?.addEventListener('dragstart', event => {
   const handle = event.target.closest('.source-drag');
   if (!handle) return;
   const row = handle.closest('.source-priority-row');
   event.dataTransfer.effectAllowed = 'move';
-  event.dataTransfer.setData('text/plain', row.dataset.index);
+  event.dataTransfer.setData('text/plain', row.dataset.source);
+  const bounds = row.getBoundingClientRect();
+  heartSourceDragGhost = row.cloneNode(true);
+  heartSourceDragGhost.classList.add('source-drag-ghost');
+  heartSourceDragGhost.setAttribute('aria-hidden', 'true');
+  heartSourceDragGhost.style.width = `${bounds.width}px`;
+  document.body.appendChild(heartSourceDragGhost);
+  event.dataTransfer.setDragImage(
+    heartSourceDragGhost,
+    Math.max(0, Math.min(bounds.width, event.clientX - bounds.left)),
+    Math.max(0, Math.min(bounds.height, event.clientY - bounds.top)));
+  draggedHeartSourceRow = row;
   row.classList.add('is-dragging');
 });
 heartSourceList?.addEventListener('dragend', event => {
   event.target.closest('.source-priority-row')?.classList.remove('is-dragging');
+  syncHeartSourceOrderFromDom();
+  draggedHeartSourceRow = null;
+  heartSourceDragGhost?.remove();
+  heartSourceDragGhost = null;
 });
 heartSourceList?.addEventListener('dragover', event => {
-  if (event.target.closest('.source-priority-row')) event.preventDefault();
+  const target = event.target.closest('.source-priority-row');
+  if (!target || !draggedHeartSourceRow || target === draggedHeartSourceRow) return;
+  event.preventDefault();
+  previewHeartSourceRowMove(target, event.clientY);
 });
 heartSourceList?.addEventListener('drop', event => {
-  const row = event.target.closest('.source-priority-row');
-  if (!row) return;
   event.preventDefault();
-  moveHeartSource(Number(event.dataTransfer.getData('text/plain')), Number(row.dataset.index));
 });
+heartSourceList?.addEventListener('pointerdown', event => {
+  const handle = event.target.closest('.source-drag');
+  if (!handle || event.pointerType === 'mouse') return;
+  event.preventDefault();
+  draggedHeartSourcePointer = event.pointerId;
+  draggedHeartSourceRow = handle.closest('.source-priority-row');
+  draggedHeartSourceRow.classList.add('is-dragging');
+  handle.setPointerCapture(event.pointerId);
+});
+heartSourceList?.addEventListener('pointermove', event => {
+  if (event.pointerId !== draggedHeartSourcePointer || !draggedHeartSourceRow) return;
+  const target = document.elementFromPoint(event.clientX, event.clientY)
+    ?.closest('.source-priority-row');
+  if (target) previewHeartSourceRowMove(target, event.clientY);
+});
+heartSourceList?.addEventListener('pointerup', finishHeartSourcePointerDrag);
+heartSourceList?.addEventListener('pointercancel', finishHeartSourcePointerDrag);
+
+function finishHeartSourcePointerDrag(event) {
+  if (event.pointerId !== draggedHeartSourcePointer) return;
+  draggedHeartSourceRow?.classList.remove('is-dragging');
+  syncHeartSourceOrderFromDom();
+  draggedHeartSourceRow = null;
+  draggedHeartSourcePointer = null;
+}
+
+function previewHeartSourceRowMove(target, clientY) {
+  if (!heartSourceList || !draggedHeartSourceRow || target === draggedHeartSourceRow) return;
+  const afterTarget = clientY > target.getBoundingClientRect().top + target.offsetHeight / 2;
+  heartSourceList.insertBefore(draggedHeartSourceRow, afterTarget ? target.nextSibling : target);
+  refreshHeartSourceRowNumbers();
+}
+
+function refreshHeartSourceRowNumbers() {
+  heartSourceList?.querySelectorAll('.source-priority-row').forEach((row, index) => {
+    row.dataset.index = index;
+    const number = row.querySelector('.source-step');
+    if (number) number.textContent = String(index + 1);
+  });
+}
+
+function syncHeartSourceOrderFromDom() {
+  if (!heartSourceList) return;
+  const bySource = new Map(heartSourceSteps.map(step => [step.Source, step]));
+  heartSourceSteps = [...heartSourceList.querySelectorAll('.source-priority-row')]
+    .map(row => bySource.get(row.dataset.source))
+    .filter(Boolean);
+  refreshHeartSourceRowNumbers();
+  syncHeartSourceInput();
+}
 
 document.getElementById('lidarr-test-connection')?.addEventListener('click', async (event) => {
   const button = event.currentTarget;

--- a/octo/wwwroot/admin/admin.js
+++ b/octo/wwwroot/admin/admin.js
@@ -327,9 +327,13 @@ function syncHeartSourceInput() {
     input.value = JSON.stringify(heartSourceSteps);
     input.dispatchEvent(new Event('input', { bubbles: true }));
   }
-  if (help) help.textContent = heartSourceSteps.some(step => step.SongEnabled || step.AlbumEnabled)
-    ? 'Drag a row by its handle to change priority. With the handle focused, use the arrow keys to move it.'
-    : 'No heart download sources are enabled. Hearts will not acquire files.';
+  if (help) {
+    const noneEnabled = !heartSourceSteps.some(step => step.SongEnabled || step.AlbumEnabled);
+    help.hidden = !noneEnabled;
+    help.textContent = noneEnabled
+      ? 'No heart download sources are enabled. Hearts will not acquire files.'
+      : '';
+  }
 }
 
 function moveHeartSource(from, to) {

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -348,11 +348,11 @@
             <div class="set-row stack">
               <div class="set-info">
                 <div class="set-info-t">Download source</div>
-                <div class="set-info-d">Soulseek gives lossless FLAC but depends on a peer having the file. YouTube always resolves but is lossy MP3, fetched through the yt-dlp shim. "Soulseek, then YouTube" tries FLAC first and falls back to MP3 only when no peer delivers. Same setting as <code>DOWNLOAD_SOURCE</code> in <code>.env</code> (<code>Soulseek</code> / <code>YouTube</code> / <code>SoulseekThenYouTube</code>); set it in either place, this one wins.</div>
+                <div class="set-info-d">Soulseek gives lossless FLAC when a peer has the file. YouTube saves a lossy MP3, and "Soulseek, then YouTube" falls back to it when needed. Lidarr applies only to hearts and fetches the track's full album; permanent playback and playlist downloads remain direct. Same setting as <code>DOWNLOAD_SOURCE</code> in <code>.env</code>; set it in either place, this one wins.</div>
               </div>
               <div class="set-ctrl">
                 <div class="seg" data-seg-for="f-download-source"><span class="seg-thumb"></span></div>
-                <select id="f-download-source" name="Subsonic.DownloadSource" class="seg-src" data-restart="true" hidden>
+                <select id="f-download-source" name="Subsonic.DownloadSource" class="seg-src" hidden>
                   <option value="Soulseek">Soulseek</option>
                   <option value="YouTube">YouTube</option>
                   <option value="SoulseekThenYouTube">Soulseek → YouTube</option>

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -345,19 +345,17 @@
         <div class="set-section">
           <div class="set-head"><h3 class="set-title">Source</h3></div>
           <form data-section="downloads" class="set-card">
-            <div class="set-row stack">
+            <div class="set-row stack source-priority-setting">
               <div class="set-info">
-                <div class="set-info-t">Download source</div>
-                <div class="set-info-d">Soulseek gives lossless FLAC when a peer has the file. YouTube saves a lossy MP3, and "Soulseek, then YouTube" falls back to it when needed. Lidarr applies only to hearts and fetches the track's full album; permanent playback and playlist downloads remain direct. Same setting as <code>DOWNLOAD_SOURCE</code> in <code>.env</code>; set it in either place, this one wins.</div>
+                <div class="set-info-t" id="heart-source-order-label">Heart download priority</div>
+                <div class="set-info-d">Octo tries enabled sources from top to bottom and stops at the first success. Lidarr fetches the track's full album. Permanent playback and playlist downloads keep their existing direct behavior.</div>
               </div>
-              <div class="set-ctrl">
-                <div class="seg" data-seg-for="f-download-source"><span class="seg-thumb"></span></div>
-                <select id="f-download-source" name="Subsonic.DownloadSource" class="seg-src" hidden>
-                  <option value="Soulseek">Soulseek</option>
-                  <option value="YouTube">YouTube</option>
-                  <option value="SoulseekThenYouTube">Soulseek → YouTube</option>
-                  <option value="Lidarr">Lidarr</option>
-                </select>
+              <div class="source-priority-list" id="heart-source-order"
+                   aria-labelledby="heart-source-order-label" aria-describedby="heart-source-order-help"></div>
+              <input type="hidden" id="f-heart-download-sources"
+                     name="Subsonic.HeartDownloadSources" data-json="true" />
+              <div class="set-info-d" id="heart-source-order-help" role="status" aria-live="polite">
+                Drag a handle or use the arrow buttons to change priority. Disabled sources keep their position and are skipped.
               </div>
             </div>
             <div class="set-row">
@@ -711,7 +709,7 @@
             <div class="set-row stack">
               <div class="set-info">
                 <label class="set-info-t" for="f-lidarr-root">Root folder</label>
-                <div class="set-info-d">Save the connection first, then load choices from Lidarr. The same files must be mounted into Octo's Navidrome library root.</div>
+                <div class="set-info-d">Test or save the connection to load choices from Lidarr. The same files must be mounted into Octo's Navidrome library root.</div>
               </div>
               <select class="set-input" id="f-lidarr-root" name="Lidarr.RootFolderPath" disabled><option value="">Connect to Lidarr first</option></select>
             </div>
@@ -744,7 +742,6 @@
               <input class="set-input" id="f-lidarr-timeout" name="Lidarr.ImportTimeoutSeconds" type="number" min="60" step="60" />
             </div>
             <div class="set-row stack">
-              <button type="button" class="btn btn-ghost" id="lidarr-load-options">Load choices from Lidarr</button>
               <div class="set-info-d" id="lidarr-options-status" role="status" aria-live="polite"></div>
             </div>
           </form>

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -55,7 +55,7 @@
             <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
               <path d="M8 2.5v7M5 7l3 3 3-3M3.5 13h9"/>
             </svg>
-            <span>Downloads</span>
+            <span>Streams &amp; downloads</span>
           </button>
           <button class="sidebar-nav-item" data-tab="subsonic">
             <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -86,12 +86,6 @@
               <path d="M3 3.5h10v9H3z"/><path d="M5.5 6h5M5.5 8.5h5M5.5 11h3"/>
             </svg>
             <span>Lidarr</span>
-          </button>
-          <button class="sidebar-nav-item" data-tab="youtube">
-            <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
-              <rect x="2" y="3.5" width="12" height="9" rx="1.5"/><path d="m6.5 6.5 3 1.5-3 1.5z" fill="currentColor"/>
-            </svg>
-            <span>YouTube</span>
           </button>
         </div>
 
@@ -303,27 +297,6 @@
             </div>
             <div class="set-row">
               <div class="set-info">
-                <div class="set-info-t">Storage mode</div>
-                <div class="set-info-d">Stream previews and download on star, keep every played track, or cache temporarily.</div>
-              </div>
-              <div class="set-ctrl">
-                <div class="seg" data-seg-for="f-storage-mode"><span class="seg-thumb"></span></div>
-                <select id="f-storage-mode" name="Subsonic.StorageMode" class="seg-src" hidden>
-                  <option value="Stream">Stream</option>
-                  <option value="Permanent">Permanent</option>
-                  <option value="Cache">Cache</option>
-                </select>
-              </div>
-            </div>
-            <div class="set-row stack">
-              <div class="set-info">
-                <div class="set-info-t">Cache duration (hours)</div>
-                <div class="set-info-d">How long Cache-mode files live before auto-cleanup.</div>
-              </div>
-              <input class="set-input" id="f-cache-hours" name="Subsonic.CacheDurationHours" type="number" min="1" />
-            </div>
-            <div class="set-row">
-              <div class="set-info">
                 <div class="set-info-t">Use local staging</div>
                 <div class="set-info-d">Required when the download path is a cloud/FUSE mount (rclone, pCloud).</div>
               </div>
@@ -333,22 +306,64 @@
         </div>
       </section>
 
-      <!-- ─── DOWNLOADS ──────────────────────────────────────── -->
+      <!-- ─── STREAMS & DOWNLOADS ────────────────────────────── -->
       <section data-pane="downloads">
         <header class="page-header">
           <div>
-            <h1>Downloads</h1>
-            <p>Where a starred song's permanent copy comes from, and when Octo fetches it.</p>
+            <h1>Streams &amp; downloads</h1>
+            <p>Choose how missing tracks play and where hearts acquire permanent copies.</p>
           </div>
         </header>
 
         <div class="set-section">
-          <div class="set-head"><h3 class="set-title">Source</h3></div>
+          <div class="set-head"><h3 class="set-title">Stream source</h3></div>
+          <form data-section="playback-source" class="set-card">
+            <div class="set-row playback-source-row">
+              <div class="set-info">
+                <div class="set-info-t">When a track is missing</div>
+                <div class="set-info-d">YouTube starts immediately and is the default. Soulseek download waits for a lossless copy before playback begins.</div>
+              </div>
+              <div class="set-ctrl">
+                <div class="seg" data-seg-for="f-playback-source"><span class="seg-thumb"></span></div>
+                <select id="f-playback-source" class="seg-src" hidden aria-label="Primary missing-track playback source">
+                  <option value="YouTube">YouTube stream</option>
+                  <option value="Lossless">Soulseek download</option>
+                </select>
+              </div>
+              <input type="checkbox" id="f-wait-for-lossless-on-play" name="Subsonic.WaitForLosslessOnPlay" data-restart="true" hidden />
+            </div>
+            <div class="set-row stack" data-stream-source="YouTube">
+              <div class="set-info">
+                <div class="set-info-t">YouTube shim URL</div>
+                <div class="set-info-d">The yt-dlp sidecar that resolves and streams missing tracks. The default works inside the Docker network.</div>
+              </div>
+              <input class="set-input" id="f-yt-url" name="YouTube.ShimUrl" data-restart="true" placeholder="http://yt-dlp-shim:8080" />
+            </div>
+            <div class="set-row stack" data-stream-source="Lossless" hidden>
+              <div class="set-info">
+                <div class="set-info-t">Soulseek connection</div>
+                <div class="set-info-d">Octo downloads the lossless copy through slskd before returning audio. Connection credentials, search limits, and transfer timeouts stay on the existing Soulseek page.</div>
+              </div>
+              <div>
+                <button type="button" class="btn btn-ghost" data-open-tab="soulseek">Open Soulseek settings</button>
+              </div>
+            </div>
+            <div class="set-row" data-stream-source="Lossless" hidden>
+              <div class="set-info">
+                <div class="set-info-t">Lossless wait timeout <span class="set-opt">seconds</span></div>
+                <div class="set-info-d">Only with lossless waiting enabled. 0 waits indefinitely; a positive value falls back to the YouTube preview after this many seconds while acquisition continues.</div>
+              </div>
+              <input class="set-input" id="f-lossless-wait-timeout" name="Subsonic.LosslessWaitTimeoutSeconds" type="number" min="0" />
+            </div>
+          </form>
+        </div>
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Heart acquisition</h3></div>
           <form data-section="downloads" class="set-card">
             <div class="set-row stack source-priority-setting">
               <div class="set-info">
                 <div class="set-info-t" id="heart-source-order-label">Heart download priority</div>
-                <div class="set-info-d">Choose which sources handle song and album hearts. Octo tries each enabled source from top to bottom and stops at the first success. Permanent playback and playlist downloads keep their existing direct behavior.</div>
+                <div class="set-info-d">Choose which sources handle song and album hearts. Octo tries each enabled source from top to bottom and stops at the first success. Only Soulseek is enabled by default.</div>
               </div>
               <div class="source-priority-list" id="heart-source-order"
                    aria-labelledby="heart-source-order-label" aria-describedby="heart-source-order-help"></div>
@@ -356,20 +371,6 @@
                      name="Subsonic.HeartDownloadSources" data-json="true" />
               <div class="set-info-d" id="heart-source-order-help"
                    role="status" aria-live="polite" hidden></div>
-            </div>
-            <div class="set-row">
-              <div class="set-info">
-                <div class="set-info-t">Wait for lossless on first play</div>
-                <div class="set-info-d">Permanent mode only. Off, a track plays straight away and the lossless copy turns up as its own library track once the scan finds it. On, the first play waits for the lossless file, which can take minutes and which most players give up on.</div>
-              </div>
-              <label class="switch"><input type="checkbox" id="f-wait-for-lossless-on-play" name="Subsonic.WaitForLosslessOnPlay" data-restart="true" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
-            </div>
-            <div class="set-row">
-              <div class="set-info">
-                <div class="set-info-t">Lossless wait timeout <span class="set-opt">seconds</span></div>
-                <div class="set-info-d">Only with the wait on. 0 waits as long as the fetch needs. Above 0, playback falls back to the streaming preview after this many seconds while the download finishes in the background; some players refuse the preview on a track advertised lossless.</div>
-              </div>
-              <input class="set-input" id="f-lossless-wait-timeout" name="Subsonic.LosslessWaitTimeoutSeconds" type="number" min="0" />
             </div>
           </form>
         </div>
@@ -414,19 +415,6 @@
         <div class="set-section">
           <div class="set-head"><h3 class="set-title">Behavior</h3></div>
           <form data-section="subsonic-behavior" class="set-card">
-            <div class="set-row">
-              <div class="set-info">
-                <div class="set-info-t">Download mode</div>
-                <div class="set-info-d">Fetch only the played song, or pull the whole album in the background.</div>
-              </div>
-              <div class="set-ctrl">
-                <div class="seg" data-seg-for="f-download-mode"><span class="seg-thumb"></span></div>
-                <select id="f-download-mode" name="Subsonic.DownloadMode" class="seg-src" hidden>
-                  <option value="Track">Track</option>
-                  <option value="Album">Album</option>
-                </select>
-              </div>
-            </div>
             <div class="set-row">
               <div class="set-info">
                 <div class="set-info-t">Explicit content</div>
@@ -730,34 +718,6 @@
               <div class="set-info-d" id="lidarr-options-status" role="status" aria-live="polite"></div>
             </div>
           </form>
-        </div>
-      </section>
-
-      <!-- ─── YOUTUBE ────────────────────────────────────────── -->
-      <section data-pane="youtube">
-        <header class="page-header">
-          <div>
-            <h1>YouTube preview</h1>
-            <p>Sidecar service that resolves YouTube audio for instant streaming.</p>
-          </div>
-        </header>
-
-        <div class="set-section">
-          <div class="set-head"><h3 class="set-title">Shim</h3></div>
-          <form data-section="youtube" class="set-card">
-            <div class="set-row stack">
-              <div class="set-info">
-                <div class="set-info-t">Shim URL</div>
-                <div class="set-info-d">The yt-dlp sidecar. Default works inside the docker network.</div>
-              </div>
-              <input class="set-input" id="f-yt-url" name="YouTube.ShimUrl" data-restart="true" placeholder="http://yt-dlp-shim:8080" />
-            </div>
-          </form>
-        </div>
-
-        <div class="info-card">
-          <h3 class="info-card-title">How it works</h3>
-          <p>The shim is its own container running yt-dlp behind a tiny Flask wrapper. Process isolation keeps yt-dlp's quirks — and YouTube's frequent extractor breakage — from affecting Octo. Concurrent yt-dlp slots and cache size are configured via env vars on the <code>yt-dlp-shim</code> service in <code>docker-compose.yml</code>.</p>
         </div>
       </section>
 

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -81,6 +81,12 @@
             </svg>
             <span>Soulseek</span>
           </button>
+          <button class="sidebar-nav-item" data-tab="lidarr">
+            <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M3 3.5h10v9H3z"/><path d="M5.5 6h5M5.5 8.5h5M5.5 11h3"/>
+            </svg>
+            <span>Lidarr</span>
+          </button>
           <button class="sidebar-nav-item" data-tab="youtube">
             <svg class="icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
               <rect x="2" y="3.5" width="12" height="9" rx="1.5"/><path d="m6.5 6.5 3 1.5-3 1.5z" fill="currentColor"/>
@@ -182,6 +188,14 @@
             </div>
             <div class="status-card-body">probing…</div>
             <div class="status-card-foot">slskd · downloads on star</div>
+          </article>
+          <article class="status-card" data-svc="lidarr">
+            <div class="status-card-head">
+              <span class="status-dot pending"></span>
+              <span class="status-card-title">Lidarr</span>
+            </div>
+            <div class="status-card-body">probing…</div>
+            <div class="status-card-foot">optional album acquisition</div>
           </article>
           <article class="status-card" data-svc="ytDlpShim">
             <div class="status-card-head">
@@ -334,14 +348,15 @@
             <div class="set-row stack">
               <div class="set-info">
                 <div class="set-info-t">Download source</div>
-                <div class="set-info-d">Soulseek gives lossless FLAC but depends on a peer having the file. YouTube always resolves but is lossy MP3. "Soulseek, then YouTube" tries FLAC first and falls back to MP3 only when no peer delivers.</div>
+                <div class="set-info-d">Soulseek and YouTube keep their existing behavior. Lidarr applies to hearts only, always fetching the track's full album; permanent playback and playlist downloads remain direct.</div>
               </div>
               <div class="set-ctrl">
                 <div class="seg" data-seg-for="f-download-source"><span class="seg-thumb"></span></div>
-                <select id="f-download-source" name="Subsonic.DownloadSource" class="seg-src" hidden>
+                <select id="f-download-source" name="Subsonic.DownloadSource" class="seg-src" data-restart="true" hidden>
                   <option value="Soulseek">Soulseek</option>
                   <option value="YouTube">YouTube</option>
                   <option value="SoulseekThenYouTube">Soulseek → YouTube</option>
+                  <option value="Lidarr">Lidarr</option>
                 </select>
               </div>
             </div>
@@ -656,6 +671,86 @@
         </div>
       </section>
 
+      <!-- ─── LIDARR ─────────────────────────────────────────── -->
+      <section data-pane="lidarr">
+        <header class="page-header">
+          <div>
+            <h1>Lidarr</h1>
+            <p>Use an existing Lidarr server for track and album hearts. Lidarr must already have working indexers and a download client.</p>
+          </div>
+        </header>
+
+        <div class="info-card">
+          <h3 class="info-card-title">Album-level acquisition</h3>
+          <p>Lidarr cannot search for one track. Hearting a single external song resolves its release and imports the full album. Octo never deletes, renames, or retags Lidarr-managed files.</p>
+        </div>
+
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Connection</h3></div>
+          <form data-section="lidarr-connection" class="set-card" id="lidarr-connection-form">
+            <div class="set-row stack">
+              <div class="set-info">
+                <label class="set-info-t" for="f-lidarr-url">Base URL</label>
+                <div class="set-info-d">Reachable from the Octo container, for example <code>http://host.docker.internal:8686</code>.</div>
+              </div>
+              <input class="set-input" id="f-lidarr-url" name="Lidarr.BaseUrl" type="url" placeholder="http://lidarr:8686" autocomplete="url" />
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <label class="set-info-t" for="f-lidarr-key">API key</label>
+                <div class="set-info-d">Found in Lidarr under Settings → General → Security.</div>
+              </div>
+              <input class="set-input" id="f-lidarr-key" name="Lidarr.ApiKey" type="password" autocomplete="off" />
+            </div>
+          </form>
+        </div>
+
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Album defaults</h3></div>
+          <form data-section="lidarr-defaults" class="set-card" id="lidarr-defaults-form">
+            <div class="set-row stack">
+              <div class="set-info">
+                <label class="set-info-t" for="f-lidarr-root">Root folder</label>
+                <div class="set-info-d">Save the connection first, then load choices from Lidarr. The same files must be mounted into Octo's Navidrome library root.</div>
+              </div>
+              <select class="set-input" id="f-lidarr-root" name="Lidarr.RootFolderPath" disabled><option value="">Connect to Lidarr first</option></select>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <label class="set-info-t" for="f-lidarr-quality">Quality profile</label>
+              </div>
+              <select class="set-input" id="f-lidarr-quality" name="Lidarr.QualityProfileId" data-number="true" disabled><option value="0">Connect to Lidarr first</option></select>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <label class="set-info-t" for="f-lidarr-metadata">Metadata profile</label>
+              </div>
+              <select class="set-input" id="f-lidarr-metadata" name="Lidarr.MetadataProfileId" data-number="true" disabled><option value="0">Connect to Lidarr first</option></select>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <label class="set-info-t" for="f-lidarr-completion">Completion notifications</label>
+                <div class="set-info-d">Accepted stops at a successful Lidarr handoff. Imported reports completion or failure only after files appear or the timeout expires. Neither option blocks later hearts.</div>
+              </div>
+              <select class="set-input" id="f-lidarr-completion" name="Lidarr.CompletionMode">
+                <option value="Accepted">Continue on acceptance</option>
+                <option value="Imported">Wait for import notifications</option>
+              </select>
+            </div>
+            <div class="set-row stack">
+              <div class="set-info">
+                <label class="set-info-t" for="f-lidarr-timeout">Import timeout <span class="set-opt">seconds</span></label>
+              </div>
+              <input class="set-input" id="f-lidarr-timeout" name="Lidarr.ImportTimeoutSeconds" type="number" min="60" step="60" />
+            </div>
+            <div class="set-row stack">
+              <button type="button" class="btn btn-ghost" id="lidarr-load-options">Load choices from Lidarr</button>
+              <div class="set-info-d" id="lidarr-options-status" role="status" aria-live="polite"></div>
+            </div>
+          </form>
+        </div>
+      </section>
+
       <!-- ─── YOUTUBE ────────────────────────────────────────── -->
       <section data-pane="youtube">
         <header class="page-header">
@@ -704,7 +799,7 @@
             <label for="raw-editor">JSON content</label>
             <textarea id="raw-editor" spellcheck="false" autocapitalize="off" autocomplete="off" autocorrect="off" placeholder="{}"></textarea>
             <div class="field-help">
-              Top-level keys: <code>Subsonic</code>, <code>Library</code>, <code>Soulseek</code>, <code>YouTube</code>, <code>LastFm</code>.
+              Top-level keys: <code>Subsonic</code>, <code>Library</code>, <code>Soulseek</code>, <code>Lidarr</code>, <code>YouTube</code>, <code>LastFm</code>.
               Anything you set here overrides the corresponding env var until removed.
             </div>
           </div>
@@ -757,7 +852,7 @@
         </header>
 
         <div class="info-card">
-          <p>Octo is a Subsonic API proxy that augments your existing Navidrome library with discovery and on-demand downloading. Search includes external recommendations alongside your local songs; "Radio" on any song fans out via Last.fm and previews via YouTube; star a song you don't own and Octo grabs it via Soulseek.</p>
+          <p>Octo is a Subsonic API proxy that augments your existing Navidrome library with discovery and on-demand downloading. Search includes external recommendations alongside your local songs; "Radio" on any song fans out via Last.fm and previews via YouTube; star music you don't own and Octo acquires it through Soulseek or your existing Lidarr server.</p>
         </div>
 
         <div class="info-card">

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -354,9 +354,8 @@
                    aria-labelledby="heart-source-order-label" aria-describedby="heart-source-order-help"></div>
               <input type="hidden" id="f-heart-download-sources"
                      name="Subsonic.HeartDownloadSources" data-json="true" />
-              <div class="set-info-d" id="heart-source-order-help" role="status" aria-live="polite">
-                Drag a row by its handle to change priority. With the handle focused, use the arrow keys to move it.
-              </div>
+              <div class="set-info-d" id="heart-source-order-help"
+                   role="status" aria-live="polite" hidden></div>
             </div>
             <div class="set-row">
               <div class="set-info">

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -348,29 +348,15 @@
             <div class="set-row stack source-priority-setting">
               <div class="set-info">
                 <div class="set-info-t" id="heart-source-order-label">Heart download priority</div>
-                <div class="set-info-d">Octo tries enabled sources from top to bottom and stops at the first success. Lidarr fetches the track's full album. Permanent playback and playlist downloads keep their existing direct behavior.</div>
+                <div class="set-info-d">Choose which sources handle song and album hearts. Octo tries each enabled source from top to bottom and stops at the first success. Permanent playback and playlist downloads keep their existing direct behavior.</div>
               </div>
               <div class="source-priority-list" id="heart-source-order"
                    aria-labelledby="heart-source-order-label" aria-describedby="heart-source-order-help"></div>
               <input type="hidden" id="f-heart-download-sources"
                      name="Subsonic.HeartDownloadSources" data-json="true" />
               <div class="set-info-d" id="heart-source-order-help" role="status" aria-live="polite">
-                Drag a handle or use the arrow buttons to change priority. Disabled sources keep their position and are skipped.
+                Drag a row by its handle to change priority. With the handle focused, use the arrow keys to move it.
               </div>
-            </div>
-            <div class="set-row">
-              <div class="set-info">
-                <div class="set-info-t">Download a song when starred</div>
-                <div class="set-info-d">Works in every storage mode.</div>
-              </div>
-              <label class="switch"><input type="checkbox" id="f-download-on-star" name="Subsonic.DownloadOnStar" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
-            </div>
-            <div class="set-row">
-              <div class="set-info">
-                <div class="set-info-t">Download an album when starred</div>
-                <div class="set-info-d">Star a whole album to fetch every track. Downloads run one at a time, so a full album takes a while.</div>
-              </div>
-              <label class="switch"><input type="checkbox" id="f-download-album-on-star" name="Subsonic.DownloadAlbumOnStar" /><span class="sw-track"></span><span class="sw-thumb"></span></label>
             </div>
             <div class="set-row">
               <div class="set-info">

--- a/scripts/preview-admin.sh
+++ b/scripts/preview-admin.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container_name=octo-ui-preview
+image_name=octo:ui-preview
+
+if [[ "${1:-}" == stop ]]; then
+  docker stop "$container_name" >/dev/null 2>&1 || true
+  echo "Stopped $container_name."
+  exit 0
+fi
+
+preview_port="${1:-5277}"
+preview_url="http://localhost:${preview_port}/admin/index.html"
+
+if docker container inspect "$container_name" >/dev/null 2>&1; then
+  docker rm -f "$container_name" >/dev/null
+fi
+
+echo "Building the current working tree as $image_name..."
+docker build --load -t "$image_name" .
+
+docker run -d --rm \
+  --name "$container_name" \
+  -p "${preview_port}:8080" \
+  --tmpfs /app/config \
+  --tmpfs /music \
+  -e Subsonic__Url=http://127.0.0.1:1 \
+  -e Subsonic__AutoDetectDownloadPath=false \
+  -e Soulseek__BaseUrl=http://127.0.0.1:1 \
+  -e Library__DownloadPath=/music \
+  "$image_name" >/dev/null
+
+for _ in {1..60}; do
+  if curl -fsS "$preview_url" >/dev/null 2>&1; then
+    echo "Preview ready: $preview_url"
+    echo "Stop it with: ./scripts/preview-admin.sh stop"
+    if [[ "${NO_OPEN:-0}" != 1 ]]; then
+      if command -v open >/dev/null 2>&1; then open "$preview_url"
+      elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$preview_url"
+      fi
+    fi
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Preview failed to start. Inspect it with: docker logs $container_name" >&2
+exit 1


### PR DESCRIPTION
Feel free to break this up or reject it, I have it working on my end but i thought others might enjoy it.

The TLDR is that it allows for the use of Lidarr for both individual and track downloads ( tracks preferred ). This is a better batching strategy. It also clarifys visually the difference in streaming and downloading, and introduces a new ui component to manage that.



## AI Summary

This PR adds Lidarr as a first-class download option and introduces an ordered fallback system for heart-triggered downloads.

Existing local playback through Navidrome remains unchanged. When an external track is not available locally, Octo streams it from YouTube by default. Users can still opt into waiting for a lossless Soulseek download before playback.

## Changes

- Added support for an existing Lidarr server.
- Added Lidarr connection testing and automatic loading of root folders and profiles.
- Added an ordered heart-download list for Soulseek, YouTube, and Lidarr.
- Added separate song and album-heart toggles for each source.
- Heart downloads try enabled sources in priority order and stop after the first successful handoff.
- Lidarr song requests acquire the complete album because Lidarr operates at the album level.
- Lidarr album requests are deduplicated by MusicBrainz release-group ID.
- Added Accepted and Imported Lidarr completion modes.
- Added background import reconciliation, history updates, path translation, and Navidrome rescanning.
- Combined playback-stream and heart-download settings into the Streams & downloads page.
- Kept Last.fm, playlist downloads, permanent playback behavior, and the existing Soulseek service intact.
- Added Compose, installer, environment-example, and README configuration for Lidarr.
- Restored the standard upstream GitHub Actions workflow after local testing.

## Defaults

- Missing external tracks stream from YouTube.
- Waiting for a lossless Soulseek copy before playback is available but disabled by default.
- Soulseek remains the first heart-download source.
- YouTube remains the second heart-download source.
- Lidarr is last and disabled until configured.
- Existing installations retain compatible legacy configuration behavior.

## Lidarr requirements

Octo connects to an existing Lidarr installation. Lidarr must already have working indexers and a download client.

Lidarr and Octo/Navidrome must have access to the same music library. Their container paths may differ as long as the configured root paths point to the same underlying files.

Octo does not rename, retag, move, or delete Lidarr-managed files.

## Validation

- Complete .NET test suite: 268 passed
- yt-dlp shim test suite: 17 passed
- Admin JavaScript syntax validation passed
- Docker image and local admin preview build passed