### PR TITLE
Force-configurable metadata language for Deezer and Last.fm requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,12 @@ LASTFM_ENABLE_RADIO=true
 LASTFM_RADIO_TRACK_COUNT=50
 LASTFM_RADIO_CACHE_HOURS=24
 
+# ===== METADATA LANGUAGE =====
+# Language for genre and other text fetched from metadata providers and
+# written into file tags (Accept-Language code, e.g. en, de, fr).
+# Empty = provider decides from the server's IP.
+METADATA_LANGUAGE=en
+
 # ===== NOTIFICATIONS (ntfy / Discord webhook) — both optional =====
 # Push a message when Octo fetches (or fails to fetch) music. A transport is
 # enabled simply by its URL being set; both empty = notifications off.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,9 @@ services:
       LastFm__RadioTrackCount: ${LASTFM_RADIO_TRACK_COUNT:-50}
       LastFm__RadioCacheDurationHours: ${LASTFM_RADIO_CACHE_HOURS:-24}
 
+      # ----- Metadata language (genre tags etc. from Deezer / Last.fm) -----
+      Metadata__Language: ${METADATA_LANGUAGE:-en}
+
       # ----- Notifications (ntfy / Discord webhook) — both optional -----
       Notifications__NtfyUrl: ${NTFY_URL:-}
       Notifications__NtfyToken: ${NTFY_TOKEN:-}

--- a/octo.Tests/AcceptLanguageHeaderTests.cs
+++ b/octo.Tests/AcceptLanguageHeaderTests.cs
@@ -1,0 +1,72 @@
+using Octo.Models.Settings;
+using Octo.Services.Metadata;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The header this applies is what keeps Deezer from localizing genre names to
+/// the server's IP country (issue #24), so the interesting cases are the ones
+/// where a user-typed value is messy: blank, padded, garbage, or a whole
+/// browser-style list pasted in.
+/// </summary>
+public class AcceptLanguageHeaderTests
+{
+    private static HttpClient Applied(string language)
+    {
+        var client = new HttpClient();
+        AcceptLanguageHeader.Apply(client, new MetadataSettings { Language = language });
+        return client;
+    }
+
+    [Fact]
+    public void SetsTheHeaderForASimpleCode()
+    {
+        var client = Applied("en");
+
+        Assert.Contains(client.DefaultRequestHeaders.AcceptLanguage, v => v.Value == "en");
+    }
+
+    [Fact]
+    public void TrimsWhitespace()
+    {
+        var client = Applied("  de  ");
+
+        Assert.Contains(client.DefaultRequestHeaders.AcceptLanguage, v => v.Value == "de");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyValueLeavesTheHeaderUnset(string language)
+    {
+        Assert.Empty(Applied(language).DefaultRequestHeaders.AcceptLanguage);
+    }
+
+    [Fact]
+    public void GarbageValueLeavesTheHeaderUnset()
+    {
+        // A value the header parser rejects must degrade to provider-default
+        // behavior, never break client construction.
+        Assert.Empty(Applied("???").DefaultRequestHeaders.AcceptLanguage);
+    }
+
+    [Fact]
+    public void AcceptsABrowserStyleList()
+    {
+        var client = Applied("en-US,en;q=0.9");
+
+        Assert.Contains(client.DefaultRequestHeaders.AcceptLanguage, v => v.Value == "en-US");
+        Assert.Contains(client.DefaultRequestHeaders.AcceptLanguage, v => v.Value == "en");
+    }
+
+    [Fact]
+    public void ReapplyingReplacesInsteadOfStacking()
+    {
+        var client = new HttpClient();
+        AcceptLanguageHeader.Apply(client, new MetadataSettings { Language = "de" });
+        AcceptLanguageHeader.Apply(client, new MetadataSettings { Language = "en" });
+
+        var value = Assert.Single(client.DefaultRequestHeaders.AcceptLanguage);
+        Assert.Equal("en", value.Value);
+    }
+}

--- a/octo.Tests/DeezerMetadataServiceTests.cs
+++ b/octo.Tests/DeezerMetadataServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
+using Octo.Models.Settings;
 using Octo.Services.Metadata;
 using System.Net;
 
@@ -10,7 +11,8 @@ public class DeezerMetadataServiceTests
 {
     /// <summary>Builds a service whose HTTP layer answers from a url-substring to body map.
     /// Any url with no match returns 404, which exercises the best-effort paths.</summary>
-    private static DeezerMetadataService BuildService(Dictionary<string, string> routes)
+    private static DeezerMetadataService BuildService(Dictionary<string, string> routes,
+        string language = "en", List<HttpRequestMessage>? capture = null)
     {
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()
@@ -19,6 +21,7 @@ public class DeezerMetadataServiceTests
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
             {
+                capture?.Add(req);
                 var url = req.RequestUri!.ToString();
                 foreach (var (needle, body) in routes)
                 {
@@ -35,7 +38,9 @@ public class DeezerMetadataServiceTests
         factory.Setup(f => f.CreateClient(It.IsAny<string>()))
             .Returns(() => new HttpClient(handler.Object));
 
-        return new DeezerMetadataService(factory.Object, new Mock<ILogger<DeezerMetadataService>>().Object);
+        return new DeezerMetadataService(factory.Object,
+            TestOptions.Monitor(new MetadataSettings { Language = language }),
+            new Mock<ILogger<DeezerMetadataService>>().Object);
     }
 
     /// <summary>Deezer reports throttling as HTTP 200 with this body, which is the whole
@@ -86,7 +91,9 @@ public class DeezerMetadataServiceTests
             .Returns(() => new HttpClient(handler.Object));
 
         callCount = needle => { lock (gate) { return counts.TryGetValue(needle, out var n) ? n : 0; } };
-        return new DeezerMetadataService(factory.Object, new Mock<ILogger<DeezerMetadataService>>().Object);
+        return new DeezerMetadataService(factory.Object,
+            TestOptions.Monitor(new MetadataSettings()),
+            new Mock<ILogger<DeezerMetadataService>>().Object);
     }
 
     private const string AlbumDetailJson =
@@ -382,6 +389,34 @@ public class DeezerMetadataServiceTests
 
         Assert.NotNull(await svc.GetAlbumDetailAsync("999"));
         Assert.Equal(2, calls("/album/999"));
+    }
+
+    // ---- Metadata language (issue #24) ---------------------------------------
+    // Deezer localizes genre names to the caller's IP country, so the request
+    // must pin the language or a non-English host writes localized genre tags.
+
+    [Fact]
+    public async Task Requests_CarryConfiguredAcceptLanguage()
+    {
+        var seen = new List<HttpRequestMessage>();
+        var svc = BuildService(new(), language: "en", capture: seen);
+
+        await svc.GetAlbumDetailAsync("1");
+
+        Assert.NotEmpty(seen);
+        Assert.All(seen, r => Assert.Contains(r.Headers.AcceptLanguage, v => v.Value == "en"));
+    }
+
+    [Fact]
+    public async Task Requests_OmitAcceptLanguage_WhenLanguageEmpty()
+    {
+        var seen = new List<HttpRequestMessage>();
+        var svc = BuildService(new(), language: "", capture: seen);
+
+        await svc.GetAlbumDetailAsync("1");
+
+        Assert.NotEmpty(seen);
+        Assert.All(seen, r => Assert.Empty(r.Headers.AcceptLanguage));
     }
 
     /// <summary>A throttled track search must not be cached as "this track has no metadata".</summary>

--- a/octo.Tests/LastFmServiceTests.cs
+++ b/octo.Tests/LastFmServiceTests.cs
@@ -13,9 +13,10 @@ namespace Octo.Tests;
 /// </summary>
 public class LastFmServiceTests
 {
-    private static LastFmService With(string apiKey, bool enableRadio) =>
+    private static LastFmService With(string apiKey, bool enableRadio, string language = "en") =>
         new(new HttpClient(),
             Options.Create(new LastFmSettings { ApiKey = apiKey, EnableRadio = enableRadio }),
+            Options.Create(new MetadataSettings { Language = language }),
             new Mock<ILogger<LastFmService>>().Object);
 
     [Theory]
@@ -46,5 +47,17 @@ public class LastFmServiceTests
 
         Assert.True(svc.HasApiKey);
         Assert.False(svc.IsRadioEnabled);
+    }
+
+    [Fact]
+    public void Construction_AppliesMetadataLanguageToTheClient()
+    {
+        var client = new HttpClient();
+        _ = new LastFmService(client,
+            Options.Create(new LastFmSettings { ApiKey = "abc123" }),
+            Options.Create(new MetadataSettings { Language = "en" }),
+            new Mock<ILogger<LastFmService>>().Object);
+
+        Assert.Contains(client.DefaultRequestHeaders.AcceptLanguage, v => v.Value == "en");
     }
 }

--- a/octo.Tests/SoulseekMetadataServiceTests.cs
+++ b/octo.Tests/SoulseekMetadataServiceTests.cs
@@ -39,7 +39,9 @@ public class SoulseekMetadataServiceTests
 
         var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
         var youtube = new YouTubeResolver(factory.Object, config, new Mock<ILogger<YouTubeResolver>>().Object);
-        var deezer = new DeezerMetadataService(factory.Object, new Mock<ILogger<DeezerMetadataService>>().Object);
+        var deezer = new DeezerMetadataService(factory.Object,
+            TestOptions.Monitor(new Octo.Models.Settings.MetadataSettings()),
+            new Mock<ILogger<DeezerMetadataService>>().Object);
 
         return new SoulseekMetadataService(
             youtube, _registry, deezer, new Mock<ILogger<SoulseekMetadataService>>().Object);

--- a/octo/Controllers/AdminController.cs
+++ b/octo/Controllers/AdminController.cs
@@ -32,6 +32,7 @@ public class AdminController : ControllerBase
     private readonly IOptionsMonitor<LidarrSettings> _lidarrOpts;
     private readonly IOptionsMonitor<LastFmSettings> _lastFmOpts;
     private readonly IOptionsMonitor<NotificationSettings> _notificationOpts;
+    private readonly IOptionsMonitor<MetadataSettings> _metadataOpts;
     private readonly Octo.Services.Notifications.NotificationService _notifications;
     private readonly IConfiguration _config;
     private readonly SoulseekClient _slskd;
@@ -55,6 +56,7 @@ public class AdminController : ControllerBase
         IOptionsMonitor<LidarrSettings> lidarrOpts,
         IOptionsMonitor<LastFmSettings> lastFmOpts,
         IOptionsMonitor<NotificationSettings> notificationOpts,
+        IOptionsMonitor<MetadataSettings> metadataOpts,
         Octo.Services.Notifications.NotificationService notifications,
         IConfiguration config,
         SoulseekClient slskd,
@@ -79,6 +81,7 @@ public class AdminController : ControllerBase
         _lidarrOpts = lidarrOpts;
         _lastFmOpts = lastFmOpts;
         _notificationOpts = notificationOpts;
+        _metadataOpts = metadataOpts;
         _notifications = notifications;
         _config = config;
         _slskd = slskd;
@@ -367,6 +370,10 @@ public class AdminController : ControllerBase
                 ["RadioTrackCount"] = lastfm.RadioTrackCount,
                 ["RadioCacheDurationHours"] = lastfm.RadioCacheDurationHours,
             },
+            ["Metadata"] = new Dictionary<string, object>
+            {
+                ["Language"] = _metadataOpts.CurrentValue.Language ?? "",
+            },
             ["Notifications"] = new Dictionary<string, object>
             {
                 ["NtfyUrl"] = notif.NtfyUrl ?? "",
@@ -519,6 +526,10 @@ public class AdminController : ControllerBase
                 ["RadioTrackCount"] = lastfm.RadioTrackCount,
                 ["RadioCacheDurationHours"] = lastfm.RadioCacheDurationHours,
             },
+            ["Metadata"] = new JsonObject
+            {
+                ["Language"] = _metadataOpts.CurrentValue.Language ?? "",
+            },
             ["Notifications"] = new JsonObject
             {
                 ["NtfyUrl"] = notif.NtfyUrl ?? "",
@@ -614,6 +625,7 @@ public class AdminController : ControllerBase
             "YouTube:ShimUrl",
             "LastFm:ApiKey", "LastFm:EnableRadio", "LastFm:RadioTrackCount",
             "LastFm:RadioCacheDurationHours",
+            "Metadata:Language",
             "Notifications:NtfyUrl", "Notifications:NtfyToken",
             "Notifications:DiscordWebhookUrl",
             "Notifications:NotifyDownloadStarted", "Notifications:NotifyDownloadCompleted",

--- a/octo/Models/Settings/MetadataSettings.cs
+++ b/octo/Models/Settings/MetadataSettings.cs
@@ -1,0 +1,13 @@
+namespace Octo.Models.Settings;
+
+public class MetadataSettings
+{
+    /// <summary>
+    /// Language code sent as Accept-Language to the external metadata APIs
+    /// (Deezer, Last.fm). Deezer localizes album genre names by caller IP
+    /// unless told otherwise, so a server hosted in a non-English country
+    /// writes localized genre tags into downloaded files. Empty lets the
+    /// provider decide from the server's IP.
+    /// </summary>
+    public string Language { get; set; } = "en";
+}

--- a/octo/Program.cs
+++ b/octo/Program.cs
@@ -47,6 +47,8 @@ builder.Services.Configure<LastFmSettings>(
     builder.Configuration.GetSection("LastFm"));
 builder.Services.Configure<NotificationSettings>(
     builder.Configuration.GetSection("Notifications"));
+builder.Services.Configure<MetadataSettings>(
+    builder.Configuration.GetSection("Metadata"));
 
 builder.Services.AddSingleton<ILocalLibraryService, LocalLibraryService>();
 

--- a/octo/Services/CoverArt/DeezerCoverArtLookup.cs
+++ b/octo/Services/CoverArt/DeezerCoverArtLookup.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
 using Octo.Services.Soulseek;
 
 namespace Octo.Services.CoverArt;
@@ -23,12 +25,14 @@ public class DeezerCoverArtLookup : ICoverArtSource
 
     public string Name => "deezer";
 
-    public DeezerCoverArtLookup(IHttpClientFactory httpClientFactory, ILogger<DeezerCoverArtLookup> logger)
+    public DeezerCoverArtLookup(IHttpClientFactory httpClientFactory,
+        IOptions<MetadataSettings> metadataSettings, ILogger<DeezerCoverArtLookup> logger)
     {
         // Named so API calls go through the shared Deezer rate limiter. This same client
         // also fetches the image bytes from the CDN, which the handler leaves unmetered.
         _http = httpClientFactory.CreateClient(Octo.Services.Metadata.DeezerRateLimiter.ClientName);
         _http.Timeout = TimeSpan.FromSeconds(8);
+        Octo.Services.Metadata.AcceptLanguageHeader.Apply(_http, metadataSettings.Value);
         _logger = logger;
     }
 

--- a/octo/Services/CoverArt/LastFmCoverArtLookup.cs
+++ b/octo/Services/CoverArt/LastFmCoverArtLookup.cs
@@ -26,10 +26,12 @@ public class LastFmCoverArtLookup : ICoverArtSource
 
     private const string BaseUrl = "https://ws.audioscrobbler.com/2.0/";
 
-    public LastFmCoverArtLookup(IHttpClientFactory httpClientFactory, IOptions<LastFmSettings> settings, ILogger<LastFmCoverArtLookup> logger)
+    public LastFmCoverArtLookup(IHttpClientFactory httpClientFactory, IOptions<LastFmSettings> settings,
+        IOptions<MetadataSettings> metadataSettings, ILogger<LastFmCoverArtLookup> logger)
     {
         _http = httpClientFactory.CreateClient();
         _http.Timeout = TimeSpan.FromSeconds(8);
+        Octo.Services.Metadata.AcceptLanguageHeader.Apply(_http, metadataSettings.Value);
         _settings = settings.Value;
         _logger = logger;
     }

--- a/octo/Services/LastFm/LastFmService.cs
+++ b/octo/Services/LastFm/LastFmService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Octo.Models.Settings;
+using Octo.Services.Metadata;
 
 namespace Octo.Services.LastFm;
 
@@ -21,9 +22,11 @@ public class LastFmService
     public LastFmService(
         HttpClient httpClient,
         IOptions<LastFmSettings> settings,
+        IOptions<MetadataSettings> metadataSettings,
         ILogger<LastFmService> logger)
     {
         _httpClient = httpClient;
+        AcceptLanguageHeader.Apply(_httpClient, metadataSettings.Value);
         _settings = settings.Value;
         _logger = logger;
     }

--- a/octo/Services/Metadata/AcceptLanguageHeader.cs
+++ b/octo/Services/Metadata/AcceptLanguageHeader.cs
@@ -1,0 +1,26 @@
+using Octo.Models.Settings;
+
+namespace Octo.Services.Metadata;
+
+/// <summary>
+/// Applies the configured metadata language as an Accept-Language header.
+/// An invalid configured value must never break client construction, so a
+/// value the header parser rejects is simply not sent.
+/// </summary>
+public static class AcceptLanguageHeader
+{
+    public static void Apply(HttpClient client, MetadataSettings settings)
+    {
+        client.DefaultRequestHeaders.AcceptLanguage.Clear();
+        var configured = settings.Language;
+        if (string.IsNullOrWhiteSpace(configured)) return;
+        // Tolerate a pasted browser-style list ("en-US,en;q=0.9"): add each
+        // segment on its own so one bad segment cannot take out the rest.
+        foreach (var part in configured.Split(','))
+        {
+            var lang = part.Trim();
+            if (lang.Length > 0)
+                client.DefaultRequestHeaders.AcceptLanguage.TryParseAdd(lang);
+        }
+    }
+}

--- a/octo/Services/Metadata/DeezerMetadataService.cs
+++ b/octo/Services/Metadata/DeezerMetadataService.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Octo.Models.Settings;
 
 namespace Octo.Services.Metadata;
 
@@ -77,6 +79,7 @@ public class DeezerMetadataService : IDisposable
     private static readonly TimeSpan PartialTtl = TimeSpan.FromMinutes(10);
 
     private readonly IHttpClientFactory _httpFactory;
+    private readonly IOptionsMonitor<MetadataSettings> _metadataOptions;
     private readonly ILogger<DeezerMetadataService> _logger;
 
     // Owned rather than injected from DI: metadata records are tens of bytes and
@@ -116,9 +119,12 @@ public class DeezerMetadataService : IDisposable
 
     public void Dispose() => _cache.Dispose();
 
-    public DeezerMetadataService(IHttpClientFactory httpFactory, ILogger<DeezerMetadataService> logger)
+    public DeezerMetadataService(IHttpClientFactory httpFactory,
+        IOptionsMonitor<MetadataSettings> metadataOptions,
+        ILogger<DeezerMetadataService> logger)
     {
         _httpFactory = httpFactory;
+        _metadataOptions = metadataOptions;
         _logger = logger;
     }
 
@@ -128,6 +134,10 @@ public class DeezerMetadataService : IDisposable
         // client here would silently bypass Deezer's budget.
         var c = _httpFactory.CreateClient(DeezerRateLimiter.ClientName);
         c.Timeout = TimeSpan.FromSeconds(8);
+        // Genre names in album payloads localize to the caller's IP country
+        // unless this header pins them. Applied per creation, so a settings
+        // change reaches the next lookup without a restart.
+        AcceptLanguageHeader.Apply(c, _metadataOptions.CurrentValue);
         return c;
     }
 

--- a/octo/appsettings.json
+++ b/octo/appsettings.json
@@ -44,6 +44,9 @@
     "RadioTrackCount": 50,
     "RadioCacheDurationHours": 24
   },
+  "Metadata": {
+    "Language": "en"
+  },
   "Notifications": {
     "NtfyUrl": "",
     "NtfyToken": "",

--- a/octo/wwwroot/admin/index.html
+++ b/octo/wwwroot/admin/index.html
@@ -374,6 +374,19 @@
             </div>
           </form>
         </div>
+
+        <div class="set-section">
+          <div class="set-head"><h3 class="set-title">Metadata</h3></div>
+          <form data-section="metadata" class="set-card">
+            <div class="set-row stack">
+              <div class="set-info">
+                <div class="set-info-t">Tag language</div>
+                <div class="set-info-d">Language for genre and other text fetched from metadata providers (Deezer, Last.fm) and written into a download's tags. Without it, providers pick a language from the server's IP address. Two-letter code like <code>en</code>, <code>de</code>, <code>fr</code>; empty lets the provider decide. New lookups use it right away; results cached in the last 12 hours keep their old language until they expire.</div>
+              </div>
+              <input class="set-input" id="f-metadata-language" name="Metadata.Language" placeholder="en" maxlength="16" />
+            </div>
+          </form>
+        </div>
       </section>
 
       <!-- ─── SUBSONIC ───────────────────────────────────────── -->
@@ -741,7 +754,7 @@
             <label for="raw-editor">JSON content</label>
             <textarea id="raw-editor" spellcheck="false" autocapitalize="off" autocomplete="off" autocorrect="off" placeholder="{}"></textarea>
             <div class="field-help">
-              Top-level keys: <code>Subsonic</code>, <code>Library</code>, <code>Soulseek</code>, <code>Lidarr</code>, <code>YouTube</code>, <code>LastFm</code>.
+              Top-level keys: <code>Subsonic</code>, <code>Library</code>, <code>Soulseek</code>, <code>Lidarr</code>, <code>YouTube</code>, <code>LastFm</code>, <code>Metadata</code>.
               Anything you set here overrides the corresponding env var until removed.
             </div>
           </div>


### PR DESCRIPTION
## What

Adds a `Metadata:Language` setting (default `en`) sent as an `Accept-Language` header on every Deezer and Last.fm API request, so tag text is deterministic instead of depending on the server's hosting country.

Closes #24.

## Why

#24 reports localized genre tags and asks to force `lang=en` on Last.fm requests. Root-causing it showed the genre Octo writes into file tags does not come from Last.fm at all: it comes from Deezer's album endpoint (`album.genres.data[0].name`), which localizes genre names by caller IP. Verified live against `api.deezer.com/album/302127`: no header returns `Electro`, `Accept-Language: ja` returns `エレクトロ`, `ru` returns `Электронная музыка`. The header pins it. The same header is also sent to Last.fm so the whole metadata surface follows one setting.

(Anyone re-verifying: test with `ja` or `ru`, not `fr`/`de` — genre 106 is spelled `Electro` in en, fr, and de alike.)

## How

- `MetadataSettings` (`Metadata:Language`, default `en`; empty = provider decides by IP) + `AcceptLanguageHeader.Apply`, which tolerates padded values and browser-style lists and silently drops values the header parser rejects.
- Applied per client creation in `DeezerMetadataService.Client()` via `IOptionsMonitor`, so an admin change reaches the next lookup without a restart; applied at construction in `DeezerCoverArtLookup`, `LastFmService`, and `LastFmCoverArtLookup`.
- Surfaced in the admin UI (Downloads tab, new Metadata card), `GET/POST /api/admin/settings`, raw config, config sources, `appsettings.json`, and `METADATA_LANGUAGE` in compose/.env.

## Notes for upgraders

Servers in non-English countries previously got localized tags by IP accident; new downloads now tag in English unless `Metadata:Language` is set to their language. Existing files keep their tags. Deezer lookups cached in the last 12 hours keep their old language until they expire.

## Testing

- New `AcceptLanguageHeaderTests` plus header assertions on captured Deezer requests and the Last.fm client; full suite 257 green.
- Live round-trip on a local run: saving `de` through the settings API reached `GET /api/admin/settings`, raw config, and config sources within 2 seconds, no restart.