### PR TITLE
Stop the 5-minute host-factory default from flaking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
 
       - name: Test
         run: dotnet test --configuration Release --no-build --verbosity normal
+        env:
+          # The WebApplicationFactory tests boot the real Program, and on this
+          # runner that first host build has ranged from 1m32s to over 5m
+          # across runs of the same commit's code (2m08s on the PR run, timeout
+          # on the merge run, 1m32s on the release run). The resolver kills the
+          # build at 5m by default, which turned that variance into a flaky
+          # red on main. Locally the same build takes about a second, so this
+          # only widens the CI cliff; a genuine hang still fails the job.
+          DOTNET_HOST_FACTORY_RESOLVER_DEFAULT_TIMEOUT_IN_SECONDS: "600"
 
   # The shim is Python and its image is only ever built on the deploy host, so
   # before this job a syntax error in app.py passed CI and was discovered when


### PR DESCRIPTION
## What

Raises `DOTNET_HOST_FACTORY_RESOLVER_DEFAULT_TIMEOUT_IN_SECONDS` to 600 on the CI test step.

## Why

The merge-to-main CI run for #23 failed (run [32673844236](https://github.com/winters27/octo/actions/runs/32673844236)) on `ExternalPlaybackTests.ExternalPlaybackUsesYouTubeRegardlessOfLegacyStorageMode` with `Timed out waiting for the entry point to build the IHost after 00:05:00`. The commit was healthy: the same code passed on the PR run and on the 2026.08.23 release run.

The cause is variance, not a hang. #23 added the repo's first `WebApplicationFactory` tests, which boot the real `Program`, and on the 2-core runner that first host build has measured 2m08s (PR run), over 5m (merge run, killed by the default timeout), and 1m32s (release run) for identical code. Locally it takes about a second (full suite 268/268 in 5s on the release commit). The resolver's 5-minute default sits inside that CI variance band, so main will keep going red on good commits until the cliff moves.

Test-step env only: nothing changes locally, and a genuinely hung host build still fails the job.