### PR TITLE
Add ENABLE_SEARCH_DISCOVERY to make search3/search2's Deezer/Last.fm fan-out optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,10 @@ USE_LOCAL_STAGING=false
 EXPLICIT_FILTER=All
 CACHE_DURATION_HOURS=1
 ENABLE_EXTERNAL_PLAYLISTS=false
+# Off, search3/search2 returns only local library matches: no wait on Deezer/Last.fm,
+# and every result plays straight from Navidrome instead of resolving through the
+# YouTube shim. Radio and Last.fm's own discovery stations are unaffected either way.
+ENABLE_SEARCH_DISCOVERY=true
 
 # Where downloaded FLACs land on the HOST. This directory is bind-mounted as
 # /music into the octo, yt-dlp-shim, and slskd containers, so downloaded files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       Subsonic__ExplicitFilter: ${EXPLICIT_FILTER:-All}
       Subsonic__CacheDurationHours: ${CACHE_DURATION_HOURS:-1}
       Subsonic__EnableExternalPlaylists: ${ENABLE_EXTERNAL_PLAYLISTS:-false}
+      Subsonic__EnableSearchDiscovery: ${ENABLE_SEARCH_DISCOVERY:-true}
 
       # Where downloaded FLACs land (bind-mount below)
       Library__DownloadPath: /music

--- a/octo.Tests/SearchBudgetTests.cs
+++ b/octo.Tests/SearchBudgetTests.cs
@@ -106,4 +106,27 @@ public class SearchBudgetTests
         Assert.Equal(int.MaxValue / 4, local);
         Assert.Equal(SearchBudget.ExternalCeiling, external);
     }
+
+    [Theory]
+    // discoveryEnabled: false sends the whole request to local and drops external to
+    // zero regardless of size, so the call site's Last.fm/Deezer fan-out never fires.
+    [InlineData(0, 0)]
+    [InlineData(5, 5)]
+    [InlineData(20, 20)]
+    [InlineData(1000, 1000)]
+    public void Compute_DiscoveryDisabled_ReturnsAllSlotsLocal(int requested, int expectedLocal)
+    {
+        var (local, external) = SearchBudget.Compute(requested, discoveryEnabled: false);
+
+        Assert.Equal(expectedLocal, local);
+        Assert.Equal(0, external);
+    }
+
+    [Fact]
+    public void Compute_DiscoveryDefaultsToEnabled()
+    {
+        // The three-arg and two-arg forms must agree, so a caller upgraded to pass the
+        // flag explicitly can't silently change behaviour by getting the default wrong.
+        Assert.Equal(SearchBudget.Compute(20), SearchBudget.Compute(20, discoveryEnabled: true));
+    }
 }

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -831,7 +831,8 @@ public class SubsonicController : ControllerBase
         // local floor used to be a flat 20, which is also the spec default for
         // songCount, so the most common search in the wild left nothing for
         // discovery at all (#14).
-        var (localSongTarget, externalTarget) = SearchBudget.Compute(requestedSongs);
+        var (localSongTarget, externalTarget) =
+            SearchBudget.Compute(requestedSongs, _subsonicSettings.EnableSearchDiscovery);
 
         // A client that asked for a handful of songs is searching as the user types. The
         // song side already costs nothing there (the budget leaves no room for discovery),
@@ -843,7 +844,7 @@ public class SubsonicController : ControllerBase
         // Album discovery runs concurrently with the song fan-out below so it costs no
         // serial latency. It needs no Last.fm key (Deezer's catalog is keyless), so albums
         // still appear for a user who has not set one up.
-        var albumTask = requestedAlbums > 0 && !isTypeAheadProbe
+        var albumTask = requestedAlbums > 0 && !isTypeAheadProbe && _subsonicSettings.EnableSearchDiscovery
             ? _metadataService.SearchAlbumsAsync(cleanQuery, Math.Min(requestedAlbums, 20))
             : Task.FromResult(new List<Album>());
 

--- a/octo/Models/Settings/SubsonicSettings.cs
+++ b/octo/Models/Settings/SubsonicSettings.cs
@@ -197,6 +197,19 @@ public class SubsonicSettings
     /// Playlists appear as "albums" in search results with genre "Playlist"
     /// </summary>
     public bool EnableExternalPlaylists { get; set; } = true;
+
+    /// <summary>
+    /// Include Last.fm/Deezer discovery songs and albums in search3/search2 results
+    /// (default: true).
+    /// Environment variable: ENABLE_SEARCH_DISCOVERY
+    ///
+    /// Off, search returns only local library matches: every result plays straight from
+    /// Navidrome instead of resolving through the YouTube shim on first tap, and a search
+    /// no longer waits on Deezer/Last.fm at all. This only changes what search3/search2
+    /// hands back; radio (getSimilarSongs2) and the Last.fm personalized/discovery
+    /// stations are unaffected either way.
+    /// </summary>
+    public bool EnableSearchDiscovery { get; set; } = true;
     
     /// <summary>
     /// Directory name for storing playlist .m3u files (default: "playlists")

--- a/octo/Services/Subsonic/SearchBudget.cs
+++ b/octo/Services/Subsonic/SearchBudget.cs
@@ -43,12 +43,22 @@ public static class SearchBudget
     /// The client's songCount. Negative values are treated as zero; the previous
     /// expression sanitised those only by accident, through its flat floor.
     /// </param>
+    /// <param name="discoveryEnabled">
+    /// <see cref="Models.Settings.SubsonicSettings.EnableSearchDiscovery"/>. False sends the
+    /// whole request to the local target and skips discovery entirely, which is what lets
+    /// the call site skip its Last.fm/Deezer fan-out too instead of just discarding it.
+    /// </param>
     /// <returns>
     /// Local and external targets. Their sum never exceeds <paramref name="requestedSongs"/>.
     /// </returns>
-    public static (int Local, int External) Compute(int requestedSongs)
+    public static (int Local, int External) Compute(int requestedSongs, bool discoveryEnabled = true)
     {
         var requested = Math.Max(0, requestedSongs);
+
+        if (!discoveryEnabled)
+        {
+            return (requested, 0);
+        }
 
         // Locals still scale with big requests through the quarter rule, which is what
         // keeps behaviour identical for the large counts radio-style clients send. The

--- a/octo/appsettings.json
+++ b/octo/appsettings.json
@@ -12,7 +12,8 @@
     "ExplicitFilter": "All",
     "CacheDurationHours": 1,
     "EnableExternalPlaylists": false,
-    "PlaylistsDirectory": "playlists"
+    "PlaylistsDirectory": "playlists",
+    "EnableSearchDiscovery": true
   },
   "Library": {
     "DownloadPath": "/music"


### PR DESCRIPTION
## What

Adds `Subsonic.EnableSearchDiscovery` (env var `ENABLE_SEARCH_DISCOVERY`, default `true`, unchanged behavior). Off, `search3`/`search2` returns only local library matches: no Deezer/Last.fm fan-out, and every result plays straight from Navidrome instead of resolving through the YouTube shim on first tap.

## Why

Search always spends real time fanning out to Deezer and Last.fm for discovery songs and albums, even when the query already fully matches owned local content, with no existing way to turn that off. Measured against a real Navidrome, same query, same container, config, and Last.fm key, before/after:

| Query | Discovery on | Discovery off |
|---|---|---|
| An artist already fully owned locally | 482ms, 4 results | 116ms, same 4 results |
| A real song not in the library | 1.14s, 20 results (padded with discovery) | 81ms, 0 results (no padding) |

Discovery is a deliberate, valuable feature (#15), this just makes it optional for anyone who wants Subsonic search to stay a plain library lookup, e.g. running Octo mainly for its download/heart pipeline while pointing a Subsonic client at it for everyday listening.

## How

`SearchBudget.Compute` takes a `discoveryEnabled` parameter (default `true`, so the two existing call sites keep compiling and behaving unchanged) and returns the whole requested count as the local target with zero external when `false`. `Search3()` passes `_subsonicSettings.EnableSearchDiscovery` in, and gates the album-search task on the same flag, this already short-circuits both the song and album fan-out that `externalTarget > 0` and the album ternary already guard, no other call site touched. Wired through `appsettings.json`, `docker-compose.yml`, `.env.example`, matching how `EnableExternalPlaylists` is wired.

Radio (`getSimilarSongs2`) and the Last.fm personalized/discovery stations are a separate code path and untouched either way.

## Testing

- New `SearchBudgetTests` cases for `discoveryEnabled: false` across the existing size range, plus one pinning that the two-arg and three-arg forms agree by default.
- Full suite: 375 passed (372 existing + 3 new). 3 pre-existing failures reproduced identically on a fresh unmodified `main` clone in the same container (2 need `ffmpeg`, absent from the bare `dotnet/sdk` test image, 1 is a flaky image-byte comparison), so nothing here caused them.
- Built the real image from this repo's own `Dockerfile` and ran it standalone against a live Navidrome (not mocked), config included so the real Last.fm key applied, for the before/after numbers above.

