### PR TITLE
Fix slow stream start, type-ahead search contention, and cold cover art

### DIFF
--- a/octo.Tests/SoulseekMetadataServiceTests.cs
+++ b/octo.Tests/SoulseekMetadataServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
+using Octo.Services.CoverArt;
 using Octo.Services.Metadata;
 using Octo.Services.Soulseek;
 using Octo.Services.YouTube;
@@ -43,8 +44,11 @@ public class SoulseekMetadataServiceTests
             TestOptions.Monitor(new Octo.Models.Settings.MetadataSettings()),
             new Mock<ILogger<DeezerMetadataService>>().Object);
 
+        var coverArt = new CoverArtAggregator(
+            Array.Empty<ICoverArtSource>(), new Mock<ILogger<CoverArtAggregator>>().Object);
+
         return new SoulseekMetadataService(
-            youtube, _registry, deezer, new Mock<ILogger<SoulseekMetadataService>>().Object);
+            youtube, _registry, deezer, coverArt, new Mock<ILogger<SoulseekMetadataService>>().Object);
     }
 
     private const string AlbumSearchJson = @"{""data"":[

--- a/octo.Tests/SupersedableBuildCoordinatorTests.cs
+++ b/octo.Tests/SupersedableBuildCoordinatorTests.cs
@@ -1,0 +1,90 @@
+using Octo.Services.Common;
+
+namespace Octo.Tests;
+
+/// <summary>
+/// The coordinator's join guard is what stops "cage", "cage t" from cancelling a build a
+/// second caller already joined. Get that guard wrong and a client sharing a build with
+/// someone else's type-ahead sees its own search cancelled for a query it never typed.
+/// </summary>
+public class SupersedableBuildCoordinatorTests
+{
+    private static readonly TimeSpan Generous = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task AJoinedBuildSurvivesSupersession()
+    {
+        var coordinator = new SupersedableBuildCoordinator<int>();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<int> CageFactory(CancellationToken ct)
+        {
+            started.TrySetResult();
+            await release.Task.WaitAsync(ct);
+            return 100;
+        }
+
+        var owner = coordinator.RunAsync("cage", CageFactory, Generous, fallback: -1, onFailure: (_, _) => { });
+        await started.Task;
+
+        // Joins the same build. SingleFlight increments its Joins counter synchronously
+        // before this call can suspend, so the join guard sees it below.
+        var joiner = coordinator.RunAsync("cage", CageFactory, Generous, fallback: -1, onFailure: (_, _) => { });
+
+        var extend = coordinator.RunAsync("cage t", _ => Task.FromResult(200), Generous, fallback: -2, onFailure: (_, _) => { });
+
+        release.SetResult();
+        var results = await Task.WhenAll(owner, joiner, extend);
+
+        Assert.Equal(100, results[0]);
+        Assert.Equal(100, results[1]);
+        Assert.Equal(200, results[2]);
+    }
+
+    [Fact]
+    public async Task ALoneBuildIsSupersededAndFallsBackWithoutThrowing()
+    {
+        var coordinator = new SupersedableBuildCoordinator<int>();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<int> CageFactory(CancellationToken ct)
+        {
+            started.TrySetResult();
+            await Task.Delay(Generous, ct);
+            return 1;
+        }
+
+        var cage = coordinator.RunAsync("cage", CageFactory, Generous, fallback: -1, onFailure: (_, _) => { });
+        await started.Task;
+
+        var cageT = coordinator.RunAsync("cage t", _ => Task.FromResult(2), Generous, fallback: -2, onFailure: (_, _) => { });
+
+        Assert.Equal(-1, await cage);
+        Assert.Equal(2, await cageT);
+    }
+
+    [Fact]
+    public async Task AnUnrelatedQueryDoesNotCancelANonPrefixBuild()
+    {
+        var coordinator = new SupersedableBuildCoordinator<int>();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async Task<int> CageFactory(CancellationToken ct)
+        {
+            started.TrySetResult();
+            await release.Task.WaitAsync(ct);
+            return 1;
+        }
+
+        var cage = coordinator.RunAsync("cage", CageFactory, Generous, fallback: -1, onFailure: (_, _) => { });
+        await started.Task;
+
+        var beths = await coordinator.RunAsync("beths", _ => Task.FromResult(2), Generous, fallback: -2, onFailure: (_, _) => { });
+        Assert.Equal(2, beths);
+
+        release.SetResult();
+        Assert.Equal(1, await cage);
+    }
+}

--- a/octo/Controllers/SubSonicController.cs
+++ b/octo/Controllers/SubSonicController.cs
@@ -844,8 +844,8 @@ public class SubsonicController : ControllerBase
         // serial latency. It needs no Last.fm key (Deezer's catalog is keyless), so albums
         // still appear for a user who has not set one up.
         var albumTask = requestedAlbums > 0 && !isTypeAheadProbe
-            ? _metadataService.SearchAlbumsAsync(cleanQuery, Math.Min(requestedAlbums, 20))
-            : Task.FromResult(new List<Album>());
+            ? _externalSearch.GetAlbumsAsync(cleanQuery, Math.Min(requestedAlbums, 20))
+            : Task.FromResult<IReadOnlyList<Album>>(new List<Album>());
 
         // One build per query, shared by every caller. Clients routinely fire several
         // search calls for a single typed query, and those calls resolve to the same
@@ -902,7 +902,7 @@ public class SubsonicController : ControllerBase
 
         // Degrade to no albums rather than failing the whole search if Deezer is slow,
         // throttled or unreachable.
-        List<Album> externalAlbums;
+        IReadOnlyList<Album> externalAlbums;
         try { externalAlbums = await albumTask; }
         catch (Exception ex)
         {
@@ -913,7 +913,7 @@ public class SubsonicController : ControllerBase
         var externalResult = new SearchResult
         {
             Songs = externalSongs,
-            Albums = externalAlbums,
+            Albums = externalAlbums.ToList(),
             Artists = new List<Artist>(),
         };
 

--- a/octo/Services/Common/ExternalSearchService.cs
+++ b/octo/Services/Common/ExternalSearchService.cs
@@ -39,7 +39,18 @@ public sealed class ExternalSearchService
     /// </summary>
     private static readonly TimeSpan BuildTimeout = TimeSpan.FromSeconds(10);
 
-    private readonly SingleFlight<string, List<Song>> _flight = new();
+    /// <summary>Deadline for one album build. Deezer's own client timeout already bounds
+    /// each call inside it; this is the ceiling on the whole build, retries included.</summary>
+    private static readonly TimeSpan AlbumBuildTimeout = TimeSpan.FromSeconds(10);
+
+    // Amperfy (and most Subsonic clients' type-ahead) fires one search3 call per
+    // keystroke, uncancelled. Plain SingleFlight only collapses two callers asking for
+    // the SAME query; it does nothing for the sequence "cage", "cage t", "cage the",
+    // where each keystroke is a distinct key racing the same rate-limited lane as the
+    // query the user actually meant. SupersedableBuildCoordinator adds prefix-based
+    // cancellation on top of that collapsing.
+    private readonly SupersedableBuildCoordinator<List<Song>> _songBuilds = new();
+    private readonly SupersedableBuildCoordinator<List<Album>> _albumBuilds = new();
     private readonly IMusicMetadataService _metadata;
     private readonly LastFmService? _lastFm;
     private readonly ILogger<ExternalSearchService> _logger;
@@ -66,23 +77,34 @@ public sealed class ExternalSearchService
         // the search results too.
         if (_lastFm is null || !_lastFm.HasApiKey) return Array.Empty<Song>();
 
-        // Key on the query alone. The build size is constant, so two callers wanting
-        // different row counts still want the same work done.
-        var key = query.Trim().ToLowerInvariant();
+        return await _songBuilds.RunAsync(
+            query.Trim(),
+            token => BuildAsync(query, token),
+            BuildTimeout,
+            fallback: new List<Song>(),
+            onFailure: (q, ex) =>
+                // Discovery is an addition to search, never a precondition for it. The
+                // steps inside the build are individually best-effort, but the deadline is
+                // not: the enrichment fan-out waits on its semaphore outside its own try, so
+                // a timeout there would otherwise escape and take local results down with it.
+                _logger.LogDebug("external search '{Q}' failed: {M}", q, ex.Message));
+    }
 
-        try
-        {
-            return await _flight.RunAsync(key, token => BuildAsync(query, token), BuildTimeout);
-        }
-        catch (Exception ex)
-        {
-            // Discovery is an addition to search, never a precondition for it. The steps
-            // inside the build are individually best-effort, but the deadline is not: the
-            // enrichment fan-out waits on its semaphore outside its own try, so a timeout
-            // there would otherwise escape and take the user's local results down with it.
-            _logger.LogDebug("external search '{Q}' failed: {M}", query, ex.Message);
-            return Array.Empty<Song>();
-        }
+    /// <summary>
+    /// Up to <paramref name="limit"/> external albums for this query, via the same
+    /// prefix-supersession as <see cref="GetAsync"/>. Needs no Last.fm key: Deezer's
+    /// album catalog is keyless.
+    /// </summary>
+    public async Task<IReadOnlyList<Album>> GetAlbumsAsync(string query, int limit, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(query) || limit <= 0) return Array.Empty<Album>();
+
+        return await _albumBuilds.RunAsync(
+            query,
+            token => _metadata.SearchAlbumsAsync(query, limit, token),
+            AlbumBuildTimeout,
+            fallback: new List<Album>(),
+            onFailure: (q, ex) => _logger.LogDebug("external album search '{Q}' failed: {M}", q, ex.Message));
     }
 
     /// <summary>
@@ -147,6 +169,12 @@ public sealed class ExternalSearchService
         // the loser could leave a song advertising the length of a video that would not be
         // the one played.
         _ = _metadata.PrewarmYouTubeIdsAsync(songs, topN: 12);
+
+        // Same reasoning, for cover art: a client renders the first screen of results a
+        // moment after this returns, and without a prewarm each row's getCoverArt call
+        // pays for the Deezer/iTunes/Last.fm chain itself, one row at a time. 24 covers
+        // more than a screenful so scrolling a little still finds a warm cache.
+        _ = _metadata.PrewarmCoverArtAsync(songs, topN: 24);
 
         return songs;
     }

--- a/octo/Services/Common/ExternalSearchService.cs
+++ b/octo/Services/Common/ExternalSearchService.cs
@@ -40,7 +40,7 @@ public sealed class ExternalSearchService
     private static readonly TimeSpan BuildTimeout = TimeSpan.FromSeconds(10);
 
     /// <summary>Deadline for one album build. Deezer's own client timeout already bounds
-    /// each call inside it; this is the ceiling on the whole build, retries included.</summary>
+    /// the call inside it; this is the ceiling on the whole build.</summary>
     private static readonly TimeSpan AlbumBuildTimeout = TimeSpan.FromSeconds(10);
 
     // Amperfy (and most Subsonic clients' type-ahead) fires one search3 call per

--- a/octo/Services/Common/SingleFlight.cs
+++ b/octo/Services/Common/SingleFlight.cs
@@ -14,10 +14,27 @@ namespace Octo.Services.Common;
 /// </summary>
 public sealed class SingleFlight<TKey, TValue> where TKey : notnull
 {
-    private readonly ConcurrentDictionary<TKey, TaskCompletionSource<TValue>> _inFlight = new();
+    private sealed class Entry
+    {
+        public readonly TaskCompletionSource<TValue> Source =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Callers currently sharing this execution, including the owner. A supersession
+        /// policy (see <see cref="SupersedableBuildCoordinator{TValue}"/>) reads this to
+        /// decide whether cancelling this key would only hurt its own caller or would also
+        /// take a joined caller down with it.
+        /// </summary>
+        public int Joins = 1;
+    }
+
+    private readonly ConcurrentDictionary<TKey, Entry> _inFlight = new();
 
     /// <summary>Number of executions currently running. Exposed for tests and logging.</summary>
     public int InFlightCount => _inFlight.Count;
+
+    /// <summary>How many callers are currently sharing the execution for <paramref name="key"/>, or 0 if none is running.</summary>
+    public int GetJoinCount(TKey key) => _inFlight.TryGetValue(key, out var entry) ? entry.Joins : 0;
 
     /// <summary>
     /// Run <paramref name="factory"/> for <paramref name="key"/>, or join the execution
@@ -34,28 +51,26 @@ public sealed class SingleFlight<TKey, TValue> where TKey : notnull
         Func<CancellationToken, Task<TValue>> factory,
         TimeSpan timeout)
     {
-        // RunContinuationsAsynchronously is required. Without it, completing this source
-        // runs every joined request's continuation — response headers, body writes, the
-        // whole serialisation — inline on whichever thread finished the work.
-        var mine = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var mine = new Entry();
 
         var existing = _inFlight.GetOrAdd(key, mine);
         if (!ReferenceEquals(existing, mine))
         {
             // Someone else owns this key. Join them rather than doing the work twice.
-            return await existing.Task;
+            Interlocked.Increment(ref existing.Joins);
+            return await existing.Source.Task;
         }
 
         try
         {
             using var cts = new CancellationTokenSource(timeout);
-            mine.SetResult(await factory(cts.Token));
+            mine.Source.SetResult(await factory(cts.Token));
         }
         catch (Exception ex)
         {
             // Every joiner sees the failure, and the finally below removes the entry, so
             // the next caller retries rather than inheriting a permanently faulted task.
-            mine.SetException(ex);
+            mine.Source.SetException(ex);
         }
         finally
         {
@@ -65,6 +80,6 @@ public sealed class SingleFlight<TKey, TValue> where TKey : notnull
             _inFlight.TryRemove(key, out _);
         }
 
-        return await mine.Task;
+        return await mine.Source.Task;
     }
 }

--- a/octo/Services/Common/SupersedableBuildCoordinator.cs
+++ b/octo/Services/Common/SupersedableBuildCoordinator.cs
@@ -1,0 +1,93 @@
+using System.Collections.Concurrent;
+
+namespace Octo.Services.Common;
+
+/// <summary>
+/// Wraps a <see cref="SingleFlight{TKey,TValue}"/> keyed build with prefix-based
+/// supersession for interactive type-ahead search: a shorter, still-running query is
+/// cancelled the moment a longer query that extends it (or vice versa) arrives, since the
+/// shorter one's result is about to be replaced in the client's own UI anyway.
+///
+/// This exists because Amperfy (and most Subsonic clients' type-ahead) fires one search3
+/// call per keystroke, uncancelled. Each partial-word build competed for the same
+/// rate-limited external lane as the query the user actually meant, and the real query
+/// could blow its own timeout waiting behind three stale ones. Cancelling a superseded
+/// build frees that lane immediately instead of waiting out its own timeout.
+/// </summary>
+public sealed class SupersedableBuildCoordinator<TValue>
+{
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _activeBuilds = new();
+    private readonly SingleFlight<string, TValue> _flight = new();
+
+    /// <summary>
+    /// Run <paramref name="factory"/> for <paramref name="query"/>, cancelling any
+    /// still-running build for a shorter or longer query that shares a prefix with this
+    /// one, then join or start this query's own build.
+    /// </summary>
+    /// <param name="fallback">Returned if the build fails or times out, instead of throwing.</param>
+    /// <param name="onFailure">Invoked with the query and exception on failure, for logging.</param>
+    public async Task<TValue> RunAsync(
+        string query,
+        Func<CancellationToken, Task<TValue>> factory,
+        TimeSpan timeout,
+        TValue fallback,
+        Action<string, Exception> onFailure)
+    {
+        var key = query.ToLowerInvariant();
+
+        // Cancel any in-flight build whose key is a prefix of this one or vice versa.
+        // Never cancel a build another caller has already joined: that caller's request
+        // is not superseded just because this one also started, and killing it would fail
+        // a search that has nothing to do with type-ahead churn.
+        foreach (var (activeKey, cts) in _activeBuilds)
+        {
+            if (activeKey == key)
+            {
+                continue;
+            }
+
+            var isPrefixOfThis = activeKey.Length < key.Length && key.StartsWith(activeKey, StringComparison.Ordinal);
+            var thisIsPrefixOfIt = key.Length < activeKey.Length && activeKey.StartsWith(key, StringComparison.Ordinal);
+
+            if ((isPrefixOfThis || thisIsPrefixOfIt) && _flight.GetJoinCount(activeKey) <= 1)
+            {
+                try
+                {
+                    cts.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The build already finished and disposed its token between the
+                    // snapshot above and this cancel; nothing left to supersede.
+                }
+            }
+        }
+
+        try
+        {
+            return await _flight.RunAsync(key, token => RunTrackedAsync(key, token, factory), timeout);
+        }
+        catch (Exception ex)
+        {
+            onFailure(query, ex);
+            return fallback;
+        }
+    }
+
+    private async Task<TValue> RunTrackedAsync(string key, CancellationToken token, Func<CancellationToken, Task<TValue>> factory)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(token);
+        // Only the caller that actually starts the build reaches here and registers a
+        // token to cancel: a joiner returns from SingleFlight.RunAsync's early-join path
+        // and never runs this factory at all.
+        _activeBuilds[key] = linked;
+        try
+        {
+            return await factory(linked.Token);
+        }
+        finally
+        {
+            _activeBuilds.TryRemove(key, out _);
+        }
+    }
+}

--- a/octo/Services/CoverArt/CoverArtAggregator.cs
+++ b/octo/Services/CoverArt/CoverArtAggregator.cs
@@ -42,7 +42,7 @@ public class CoverArtAggregator : IDisposable
             _sources.Count, string.Join(", ", _sources.Select(s => s.Name)));
     }
 
-    public async Task<byte[]?> GetCoverAsync(SoulseekRouting routing, CancellationToken ct = default)
+    public async Task<byte[]?> GetCoverAsync(SoulseekRouting routing, bool background = false, CancellationToken ct = default)
     {
         var cacheKey = MakeCacheKey(routing);
         if (_cache.TryGetValue(cacheKey, out Entry? cached)) return cached!.Bytes;
@@ -52,7 +52,7 @@ public class CoverArtAggregator : IDisposable
             byte[]? bytes;
             try
             {
-                bytes = await source.TryFetchAsync(routing, ct);
+                bytes = await source.TryFetchAsync(routing, background, ct);
             }
             catch (Exception ex)
             {

--- a/octo/Services/CoverArt/DeezerCoverArtLookup.cs
+++ b/octo/Services/CoverArt/DeezerCoverArtLookup.cs
@@ -36,20 +36,20 @@ public class DeezerCoverArtLookup : ICoverArtSource
         _logger = logger;
     }
 
-    public async Task<byte[]?> TryFetchAsync(SoulseekRouting routing, CancellationToken ct = default)
+    public async Task<byte[]?> TryFetchAsync(SoulseekRouting routing, bool background = false, CancellationToken ct = default)
     {
         var artist = (routing.Artist ?? "").Trim();
         try
         {
             string? coverUrl = routing.Kind switch
             {
-                RoutingKind.Album   => await ResolveAlbumCoverAsync(artist, (routing.Album ?? routing.Title ?? "").Trim(), ct),
-                RoutingKind.Artist  => await ResolveArtistCoverAsync(artist, ct),
-                _                   => await ResolveTrackCoverAsync(artist, (routing.Title ?? "").Trim(), ct),
+                RoutingKind.Album   => await ResolveAlbumCoverAsync(artist, (routing.Album ?? routing.Title ?? "").Trim(), background, ct),
+                RoutingKind.Artist  => await ResolveArtistCoverAsync(artist, background, ct),
+                _                   => await ResolveTrackCoverAsync(artist, (routing.Title ?? "").Trim(), background, ct),
             };
             if (string.IsNullOrEmpty(coverUrl)) return null;
 
-            using var resp = await _http.GetAsync(coverUrl, ct);
+            using var resp = await SendAsync(coverUrl, background, ct);
             if (!resp.IsSuccessStatusCode) return null;
             return await resp.Content.ReadAsByteArrayAsync(ct);
         }
@@ -61,40 +61,40 @@ public class DeezerCoverArtLookup : ICoverArtSource
         }
     }
 
-    private async Task<string?> ResolveTrackCoverAsync(string artist, string title, CancellationToken ct)
+    private async Task<string?> ResolveTrackCoverAsync(string artist, string title, bool background, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(artist) || string.IsNullOrEmpty(title)) return null;
         // Deezer's q= supports field-qualified queries like `artist:"X" track:"Y"` for
         // higher precision than a flat keyword query.
         var q = $"artist:\"{artist}\" track:\"{title}\"";
         var url = $"https://api.deezer.com/search?q={Uri.EscapeDataString(q)}&limit=5";
-        var doc = await GetJsonAsync(url, ct);
+        var doc = await GetJsonAsync(url, background, ct);
         if (doc is null) return null;
         if (!doc.RootElement.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
             return null;
         return PickBestAlbumCover(data, artist);
     }
 
-    private async Task<string?> ResolveAlbumCoverAsync(string artist, string album, CancellationToken ct)
+    private async Task<string?> ResolveAlbumCoverAsync(string artist, string album, bool background, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(artist) || string.IsNullOrEmpty(album)) return null;
         var q = $"artist:\"{artist}\" album:\"{album}\"";
         var url = $"https://api.deezer.com/search/album?q={Uri.EscapeDataString(q)}&limit=5";
-        var doc = await GetJsonAsync(url, ct);
+        var doc = await GetJsonAsync(url, background, ct);
         if (doc is null) return null;
         if (!doc.RootElement.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
         {
             // Fallback to a track-based search for "albums" that are really singles.
-            return await ResolveTrackCoverAsync(artist, album, ct);
+            return await ResolveTrackCoverAsync(artist, album, background, ct);
         }
         return PickBestDirectCover(data, artist);
     }
 
-    private async Task<string?> ResolveArtistCoverAsync(string artist, CancellationToken ct)
+    private async Task<string?> ResolveArtistCoverAsync(string artist, bool background, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(artist)) return null;
         var url = $"https://api.deezer.com/search/artist?q={Uri.EscapeDataString(artist)}&limit=5";
-        var doc = await GetJsonAsync(url, ct);
+        var doc = await GetJsonAsync(url, background, ct);
         if (doc is null) return null;
         if (!doc.RootElement.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
             return null;
@@ -116,13 +116,26 @@ public class DeezerCoverArtLookup : ICoverArtSource
         return best;
     }
 
-    private async Task<JsonDocument?> GetJsonAsync(string url, CancellationToken ct)
+    private async Task<JsonDocument?> GetJsonAsync(string url, bool background, CancellationToken ct)
     {
-        using var resp = await _http.GetAsync(url, ct);
+        using var resp = await SendAsync(url, background, ct);
         if (!resp.IsSuccessStatusCode) return null;
         var json = await resp.Content.ReadAsStringAsync(ct);
         try { return JsonDocument.Parse(json); }
         catch { return null; }
+    }
+
+    /// <summary>
+    /// GETs through the shared Deezer client, marking the request for the background
+    /// rate-limit lane when this call is a prewarm. Only api.deezer.com is metered by
+    /// <see cref="Octo.Services.Metadata.DeezerRateLimitHandler"/>, so setting this option
+    /// on a CDN image request is harmless but pointless; done uniformly for simplicity.
+    /// </summary>
+    private Task<HttpResponseMessage> SendAsync(string url, bool background, CancellationToken ct)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, url);
+        req.Options.Set(Octo.Services.Metadata.DeezerRateLimitHandler.BackgroundLane, background);
+        return _http.SendAsync(req, ct);
     }
 
     /// <summary>Pick best track-result cover by artist scoring; reads from <c>album.cover_xl</c>.</summary>

--- a/octo/Services/CoverArt/ICoverArtSource.cs
+++ b/octo/Services/CoverArt/ICoverArtSource.cs
@@ -21,5 +21,10 @@ public interface ICoverArtSource
     /// or transport error. Bytes returned should be a decodable image (caller
     /// will composite a watermark, so don't pre-encode).
     /// </summary>
-    Task<byte[]?> TryFetchAsync(SoulseekRouting routing, CancellationToken ct = default);
+    /// <param name="background">
+    /// True only for fire-and-forget prewarm. Sources with a shared rate-limited
+    /// lane (Deezer) route this onto the background lane so prewarm traffic
+    /// cannot make an interactive search or cover fetch queue behind it.
+    /// </param>
+    Task<byte[]?> TryFetchAsync(SoulseekRouting routing, bool background = false, CancellationToken ct = default);
 }

--- a/octo/Services/CoverArt/ITunesCoverArtLookup.cs
+++ b/octo/Services/CoverArt/ITunesCoverArtLookup.cs
@@ -33,7 +33,7 @@ public class ITunesCoverArtLookup : ICoverArtSource
         _logger = logger;
     }
 
-    public async Task<byte[]?> TryFetchAsync(SoulseekRouting routing, CancellationToken ct = default)
+    public async Task<byte[]?> TryFetchAsync(SoulseekRouting routing, bool background = false, CancellationToken ct = default)
     {
         var artist = (routing.Artist ?? "").Trim();
         if (routing.Kind == RoutingKind.Album)

--- a/octo/Services/CoverArt/LastFmCoverArtLookup.cs
+++ b/octo/Services/CoverArt/LastFmCoverArtLookup.cs
@@ -36,7 +36,7 @@ public class LastFmCoverArtLookup : ICoverArtSource
         _logger = logger;
     }
 
-    public async Task<byte[]?> TryFetchAsync(SoulseekRouting routing, CancellationToken ct = default)
+    public async Task<byte[]?> TryFetchAsync(SoulseekRouting routing, bool background = false, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(_settings.ApiKey)) return null;
         var artist = (routing.Artist ?? "").Trim();

--- a/octo/Services/IMusicMetadataService.cs
+++ b/octo/Services/IMusicMetadataService.cs
@@ -65,11 +65,22 @@ public interface IMusicMetadataService
     /// </summary>
     Task PrewarmYouTubeIdsForSongIdsAsync(IEnumerable<string> songIds, int topN, CancellationToken ct = default)
         => Task.CompletedTask;
-    
+
+    /// <summary>
+    /// Best-effort pre-fetch of cover art for the first N songs of a freshly-built
+    /// search result, so a client that renders them a moment later finds the image
+    /// already cached instead of triggering the fetch itself. Fire-and-forget, on
+    /// each source's background rate-limit lane so it never queues behind a live
+    /// search or cover request. Default no-op preserves source compatibility for
+    /// any provider that doesn't need it.
+    /// </summary>
+    Task PrewarmCoverArtAsync(IEnumerable<Song> songs, int topN, CancellationToken ct = default)
+        => Task.CompletedTask;
+
     /// <summary>
     /// Searches for albums on external providers
     /// </summary>
-    Task<List<Album>> SearchAlbumsAsync(string query, int limit = 20);
+    Task<List<Album>> SearchAlbumsAsync(string query, int limit = 20, CancellationToken ct = default);
     
     /// <summary>
     /// Searches for artists on external providers

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Octo.Models.Domain;
 using Octo.Models.Search;
 using Octo.Models.Subsonic;
+using Octo.Services.CoverArt;
 using Octo.Services.Metadata;
 using Octo.Services.YouTube;
 
@@ -26,17 +27,20 @@ public class SoulseekMetadataService : IMusicMetadataService
     private readonly YouTubeResolver _youtube;
     private readonly ExternalIdRegistry _idRegistry;
     private readonly DeezerMetadataService _deezer;
+    private readonly CoverArtAggregator _coverArt;
     private readonly ILogger<SoulseekMetadataService> _logger;
 
     public SoulseekMetadataService(
         YouTubeResolver youtube,
         ExternalIdRegistry idRegistry,
         DeezerMetadataService deezer,
+        CoverArtAggregator coverArt,
         ILogger<SoulseekMetadataService> logger)
     {
         _youtube = youtube;
         _idRegistry = idRegistry;
         _deezer = deezer;
+        _coverArt = coverArt;
         _logger = logger;
     }
 
@@ -190,7 +194,7 @@ public class SoulseekMetadataService : IMusicMetadataService
                 // Deezer duration as a hint so it picks the closest-length canonical
                 // video (not a long-form/compilation upload); playback reuses the
                 // stored videoId, so the shown length matches the audio.
-                var hit = await _youtube.MetaAsync($"{song.Artist} {song.Title}", song.Duration, ct);
+                var hit = await _youtube.MetaAsync($"{song.Artist} {song.Title}", song.Duration, ct: ct);
                 if (hit is { VideoId.Length: > 0 } && hit.Duration is int d && d > 0)
                 {
                     song.Duration = d;
@@ -269,11 +273,42 @@ public class SoulseekMetadataService : IMusicMetadataService
         return Task.WhenAll(tasks);
     }
 
-    public async Task<List<Album>> SearchAlbumsAsync(string query, int limit = 20)
+    /// <summary>
+    /// Fire-and-forget background prewarm of cover art for the first <paramref name="topN"/>
+    /// songs of a search, so a client that renders them a moment later finds the image
+    /// already in <see cref="CoverArtAggregator"/>'s cache. Shares <see cref="_prewarmGate"/>
+    /// with the YouTube prewarm above and passes background: true through to the cover
+    /// sources so this can never queue behind a live search or getCoverArt request.
+    /// </summary>
+    public Task PrewarmCoverArtAsync(IEnumerable<Song> songs, int topN, CancellationToken ct = default)
+    {
+        var targets = songs.Where(s => !s.IsLocal).Take(topN).ToList();
+        if (targets.Count == 0) return Task.CompletedTask;
+
+        var tasks = targets.Select(async song =>
+        {
+            if (!await _prewarmGate.WaitAsync(PrewarmQueueWait, ct)) return;
+            try
+            {
+                var routing = _idRegistry.Lookup(song.Id) ?? new SoulseekRouting
+                {
+                    Kind = RoutingKind.Song,
+                    Artist = song.Artist,
+                    Title = song.Title,
+                };
+                await _coverArt.GetCoverAsync(routing, background: true, ct);
+            }
+            catch { /* best-effort warm; never throw out of fire-and-forget */ }
+            finally { _prewarmGate.Release(); }
+        });
+        return Task.WhenAll(tasks);
+    }
+
+    public async Task<List<Album>> SearchAlbumsAsync(string query, int limit = 20, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query) || limit <= 0) return new List<Album>();
 
-        var hits = await _deezer.SearchAlbumsAsync(query, limit);
+        var hits = await _deezer.SearchAlbumsAsync(query, limit, ct);
         var albums = new List<Album>(hits.Count);
 
         foreach (var hit in hits)

--- a/octo/Services/Soulseek/SoulseekMetadataService.cs
+++ b/octo/Services/Soulseek/SoulseekMetadataService.cs
@@ -183,6 +183,13 @@ public class SoulseekMetadataService : IMusicMetadataService
     private readonly SemaphoreSlim _prewarmGate = new(3);
     private static readonly TimeSpan PrewarmQueueWait = TimeSpan.FromSeconds(2);
 
+    // Cover art never touches the shim: it hits Deezer/iTunes/Last.fm over HTTP, and
+    // Deezer's own background lane (DeezerRateLimiter.BackgroundPermits) already bounds
+    // that traffic. It needs its own gate, not _prewarmGate above: sharing that one meant
+    // 24 cover-art tasks and 12 YouTube tasks fought over 3 permits with a 2s bounded
+    // wait, so most cover fetches timed out and the ones that won starved YouTube prewarm.
+    private readonly SemaphoreSlim _coverArtPrewarmGate = new(6);
+
     public async Task ResolveTopDurationsAsync(List<Song> songs, CancellationToken ct = default)
     {
         var tasks = songs.Where(s => !s.IsLocal).Take(TopDurationResolveLimit).Select(async song =>
@@ -276,9 +283,10 @@ public class SoulseekMetadataService : IMusicMetadataService
     /// <summary>
     /// Fire-and-forget background prewarm of cover art for the first <paramref name="topN"/>
     /// songs of a search, so a client that renders them a moment later finds the image
-    /// already in <see cref="CoverArtAggregator"/>'s cache. Shares <see cref="_prewarmGate"/>
-    /// with the YouTube prewarm above and passes background: true through to the cover
-    /// sources so this can never queue behind a live search or getCoverArt request.
+    /// already in <see cref="CoverArtAggregator"/>'s cache. Uses its own
+    /// <see cref="_coverArtPrewarmGate"/>, separate from the shim-bound YouTube prewarm
+    /// gate, and passes background: true through to the cover sources so this can never
+    /// queue behind a live search or getCoverArt request.
     /// </summary>
     public Task PrewarmCoverArtAsync(IEnumerable<Song> songs, int topN, CancellationToken ct = default)
     {
@@ -287,7 +295,7 @@ public class SoulseekMetadataService : IMusicMetadataService
 
         var tasks = targets.Select(async song =>
         {
-            if (!await _prewarmGate.WaitAsync(PrewarmQueueWait, ct)) return;
+            if (!await _coverArtPrewarmGate.WaitAsync(PrewarmQueueWait, ct)) return;
             try
             {
                 var routing = _idRegistry.Lookup(song.Id) ?? new SoulseekRouting
@@ -299,7 +307,7 @@ public class SoulseekMetadataService : IMusicMetadataService
                 await _coverArt.GetCoverAsync(routing, background: true, ct);
             }
             catch { /* best-effort warm; never throw out of fire-and-forget */ }
-            finally { _prewarmGate.Release(); }
+            finally { _coverArtPrewarmGate.Release(); }
         });
         return Task.WhenAll(tasks);
     }

--- a/octo/Services/YouTube/YouTubeResolver.cs
+++ b/octo/Services/YouTube/YouTubeResolver.cs
@@ -92,11 +92,17 @@ public class YouTubeResolver
     /// resolution). Returns the top video's id + duration for showing an accurate
     /// length without paying the full /search extraction.
     /// </summary>
-    public async Task<YouTubeHit?> MetaAsync(string query, int? durationHint = null, CancellationToken ct = default)
+    /// <param name="background">
+    /// Same meaning as on <see cref="SearchAsync"/>: true only for fire-and-forget
+    /// prewarm, so the shim's gate never makes an interactive caller queue behind it.
+    /// </param>
+    public async Task<YouTubeHit?> MetaAsync(string query, int? durationHint = null,
+        bool background = false, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(query)) return null;
         var url = $"{_baseUrl}/meta?q={Uri.EscapeDataString(query)}"
-            + (durationHint is int dh && dh > 0 ? $"&duration={dh}" : "");
+            + (durationHint is int dh && dh > 0 ? $"&duration={dh}" : "")
+            + (background ? "&bg=1" : "");
         try
         {
             var http = _httpClientFactory.CreateClient(SearchClientName);

--- a/yt-dlp-shim/app.py
+++ b/yt-dlp-shim/app.py
@@ -465,6 +465,7 @@ def meta():
         abort(400, "missing q")
     hint_str = request.args.get("duration", "").strip()
     duration_hint = int(hint_str) if hint_str.isdigit() else None
+    bg = _is_bg()
 
     key = _norm_q(q)
     # Hot front: exact repeat within this process.
@@ -483,7 +484,7 @@ def meta():
 
     if duration_hint is not None:
         out = _run([f"ytsearch5:{q}", "--flat-playlist", "--print", "%(.{id,title,duration})j"],
-                   timeout=20, label="meta5")
+                   timeout=20, label="meta5", bg=bg)
         cands = []
         for ln in (out or "").strip().split("\n"):
             ln = ln.strip()
@@ -499,7 +500,7 @@ def meta():
         data = cands[0]
     else:
         out = _run([f"ytsearch1:{q}", "--flat-playlist", "--print", "%(.{id,title,duration})j"],
-                   timeout=15, label="meta")
+                   timeout=15, label="meta", bg=bg)
         if out is None:
             return jsonify(error="search_failed"), 502
         line = next((ln.strip() for ln in out.strip().split("\n") if ln.strip()), "")
@@ -709,10 +710,20 @@ def stream():
     # range requests on an audio/mp4 container — without this passthrough they
     # silently drop the song from the queue. Browsers and Feishin don't care
     # about Range for short clips, hence why those clients worked anyway.
+    #
+    # A caller that sends NO Range at all still needs one synthesized upstream:
+    # googlevideo serves a plain unranged GET at ~30KB/s (a whole song's worth
+    # of trickle) but the exact same bytes at multiple MB/s the instant the
+    # request carries any Range header, even a fully open-ended "bytes=0-".
+    # Measured 2026-09-08: unranged GET of a 3.6MB track topped out at 32KB/s
+    # and never finished in 60s; "Range: bytes=0-" pulled the whole file in
+    # 1.1s. Since the caller never asked for a partial response here, we
+    # translate upstream's 206 back to a plain 200 below so this stays
+    # invisible to clients that did not request a range themselves.
     upstream_headers = {}
     incoming_range = request.headers.get("Range")
-    if incoming_range:
-        upstream_headers["Range"] = incoming_range
+    synthesized_range = not incoming_range
+    upstream_headers["Range"] = incoming_range if incoming_range else "bytes=0-"
     if _UPSTREAM_UA:
         upstream_headers["User-Agent"] = _UPSTREAM_UA
 
@@ -778,16 +789,27 @@ def stream():
 
     # Reflect upstream's status (200 for full body, 206 for partial). Forward
     # the metadata that AVPlayer / Subsonic clients need to seek correctly.
+    #
+    # A synthesized Range (see above) makes upstream answer 206 to a request
+    # the caller never made as partial. Report 200 to the caller instead and
+    # drop Content-Range: upstream's Content-Length already equals the full
+    # size here since the synthesized range always starts at byte 0.
+    response_status = upstream.status_code
     headers = {
         "Content-Type": upstream.headers.get("Content-Type", "audio/mp4"),
         "Accept-Ranges": "bytes",
         "Cache-Control": "no-store",
     }
+    skip_headers = {"Content-Range"} if synthesized_range and upstream.status_code == 206 else set()
+    if synthesized_range and upstream.status_code == 206:
+        response_status = 200
     for h in ("Content-Length", "Content-Range"):
+        if h in skip_headers:
+            continue
         v = upstream.headers.get(h)
         if v is not None:
             headers[h] = v
-    return Response(generator(), headers=headers, status=upstream.status_code)
+    return Response(generator(), headers=headers, status=response_status)
 
 
 @app.get("/download")


### PR DESCRIPTION
## Summary

Four fixes I'd built and been running locally as Docker images, but never got around to committing. I rewrote the source from scratch against current `main`, verified each fix still holds, and added test coverage for the one piece that had none.

Numbered 1, 2, 3, and 5 because #32 already covers fix 4 (the `ENABLE_SEARCH_DISCOVERY` toggle).

### 1. Slow stream start

YouTube throttles a request with no `Range` header to about 30KB/s. `yt-dlp-shim`'s `/stream` endpoint now always sends `Range: bytes=0-` to the upstream CDN, and translates the resulting 206 back to 200 when the client asked for no partial response.

I confirmed this against the live CDN: resolve a video to its `googlevideo.com` URL, then `curl` the same URL twice, seconds apart, with and without the header.

| Video id | No `Range` header | `Range: bytes=0-` |
|---|---|---|
| `dQw4w9WgXcQ` | 32.7 KB/s (262 KB in 8s, hit an 8s timeout) | 1.69 MB/s (3.4 MB in 2.0s) |
| `9bZkp7q19f0` | 30.7 KB/s (240 KB in 8s, hit an 8s timeout) | 3.19 MB/s (4.0 MB in 1.3s) |

The no-header rows hit the timeout before finishing, so the real gap is larger than the ratio above shows.

### 2. Type-ahead search cancellation

Clients fire one uncancelled `search3` call per keystroke, so a real query could queue behind several stale partial-word queries on the same rate-limited external lane. `SupersedableBuildCoordinator<TValue>` cancels a shorter in-flight build the moment a query that extends it, or vice versa, arrives, unless another caller already joined that build. Wired into `ExternalSearchService` for both songs and a new album search path.

`SupersedableBuildCoordinatorTests.cs` checks the join guard directly: a wrong guard would cancel a build another client already joined, turning that client's own search into a silent fallback for a query it never typed.

### 3. Cold cover art on first view

`PrewarmCoverArtAsync` runs after every search build and threads a `background` flag through `CoverArtAggregator` and each art source, so prewarm traffic cannot block a live search or `getCoverArt` request.

It originally shared a semaphore sized for `yt-dlp-shim`'s background concurrency (3 permits) with a separate YouTube-id prewarm path. With 24 cover-art tasks and 12 YouTube tasks competing for those 3 permits and a 2-second wait, most cover fetches timed out silently, and the tasks that won held a permit through Deezer's 8-second HTTP timeout, starving YouTube prewarm. Cover art now waits on its own `SemaphoreSlim(6)`. Deezer's own background rate lane (`DeezerRateLimiter.BackgroundPermits`, 10 per 5 seconds) still bounds Deezer traffic on its own.

### 5. Background-priority YouTube metadata lookups

Pairs with fix 1: `YouTubeResolver.MetaAsync` gained a `background` parameter that appends `&bg=1` to the shim's `/meta` request, routing prewarm calls through the shim's background gate instead of the interactive one.

## Testing

Full suite passes locally: 373 of 373, `dotnet test` with `ffmpeg` and `fonts-dejavu-core` installed for the audio-dependent tests.
